### PR TITLE
ci(claude-review): draft-skip guard + paths-ignore + concurrency (token-budget cuts)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -12,11 +12,16 @@ on:
 
 jobs:
   claude-review:
-    # Review runs on every PR event and every human comment/review on a PR,
-    # regardless of branch name or trigger phrase. Bot comments are skipped
-    # so Claude doesn't react to Vercel/Supabase/dependabot/itself.
+    # Review runs on every non-draft PR event (opened / synchronize / reopened /
+    # ready_for_review) plus every human comment/review on a PR, regardless of
+    # branch name or trigger phrase. Drafts are skipped explicitly — push as
+    # many commits as you want while in draft, the action won't fire. Flipping
+    # draft → ready triggers `ready_for_review`, which runs a fresh review; any
+    # further commits then trigger `synchronize`, which also runs because the
+    # PR is no longer a draft. Bot comments are skipped so Claude doesn't react
+    # to Vercel/Supabase/dependabot/itself.
     if: |
-      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.comment.user.type != 'Bot') ||
       (github.event_name == 'pull_request_review_comment' && github.event.comment.user.type != 'Bot') ||
       (github.event_name == 'pull_request_review' && github.event.review.user.type != 'Bot')

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,12 +3,30 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    # Skip reviews entirely for PRs that only touch generated / lockfile / index
+    # artefacts. Review tokens are budget — don't spend them parsing a ~500 KB
+    # pagefind index or a pnpm-lock refresh. If a PR mixes these paths with
+    # reviewable code, the workflow still fires normally; this filter only
+    # catches PRs whose diff is *exclusively* ignored paths.
+    paths-ignore:
+      - "registry.json"
+      - "pnpm-lock.yaml"
+      - "public/_pagefind/**"
   issue_comment:
     types: [created]
   pull_request_review_comment:
     types: [created]
   pull_request_review:
     types: [submitted]
+
+# One in-flight review per PR. A new commit on the same PR cancels the
+# previous review run, so a burst of three fixups in 90 seconds costs one
+# review, not three. Falls back to `issue.number` for comment/review events
+# (same PR number, different event payload shape) and to `github.ref` as a
+# last resort for any non-PR trigger that gets added in the future.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Summary

Three small, safe edits to `.github/workflows/claude-review.yml` so the Claude code-review action behaves sanely, skips work it shouldn't do, and stops burning rate-limit tokens. No model change (Opus stays — the deeper reasoning is worth keeping for security scanning); no prompt change.

## The three changes

### 1 — Add `ready_for_review` to trigger + explicit draft-skip guard

Flipping a PR from draft → ready now fires a review on the transition itself, no dummy commit needed. And the draft-skip decision is now in *our* `if:` guard instead of hidden inside the action — previously the action's internal skip completed the check green with no review posted, making it look like the action had silently failed.

### 2 — `paths-ignore` for generated / lock files

PRs whose diff is *exclusively* one of these never fire the review:

```yaml
paths-ignore:
  - "registry.json"
  - "pnpm-lock.yaml"
  - "public/_pagefind/**"
```

Mixed PRs (reviewable code + one of these paths) fire normally — this filter only catches diffs that are 100% generated/lockfile noise. Common case it catches: dependabot lockfile bumps.

### 3 — `concurrency:` with `cancel-in-progress`

One in-flight review per PR. A new commit cancels the previous review run. Three fixup pushes in 90 seconds used to cost three overlapping reviews; now they cost one.

```yaml
concurrency:
  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
  cancel-in-progress: true
```

Falls back cleanly across pull_request / issue_comment / review events.

## Net behavior (draft-skip × paths-ignore × concurrency)

| Event | Draft PR | Ready PR | PR with only generated-file diff |
|---|---|---|---|
| `opened` | skipped | runs | skipped (paths-ignore) |
| push commit (`synchronize`) | skipped | runs; cancels prior | skipped |
| `ready_for_review` | — | runs | skipped |
| `reopened` | skipped | runs | skipped |
| human `issue_comment` | runs | runs | runs (comments bypass paths) |
| bot comment | skipped | skipped | skipped |

## Why this lives in its own PR into main

`anthropics/claude-code-action@v1` enforces that the review workflow file on the PR branch matches byte-for-byte the version on the repository's default branch — a security control that prevents a PR from modifying its own review workflow to exfiltrate secrets or skip review. So *any* change to this file has to land on main first; it can't take effect from a feature branch.

Discovered the hard way while trying to apply change #1 on PR #52, where the action kept failing with *"The workflow file must exist and have identical content to the version on the repository's default branch."*

Keeping all three changes tiny and on one PR so review is one diff, one merge.

## Context: the 429 on PR #52

PR #52's claude-review hit `API Error: Request rejected (429) · This request would exceed your organization's rate limit of 30,000 input tokens per minute`. Changes #2 and #3 together should reduce review token volume by ~40–60% in typical feature-branch flow — enough headroom that most days never touch the ceiling. If rate limits keep biting after this lands, the next lever is upgrading the Anthropic tier or routing through Bedrock/Vertex for a separate quota pool.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm audit` — no known vulnerabilities
- [ ] `lint / actionlint` CI check — verifies YAML validity
- [ ] After merge, verify on PR #52:
  - Flipping draft → ready triggers a review
  - A burst of commits produces one review, not N
  - A PR that only touches `registry.json` skips the review

https://claude.ai/code/session_01YPT39eiRaqW9RR9FVZcyhn