### PR TITLE
feat(registry): dogfood nyuchi-harness + wire NyuchiHeader into the layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,16 +165,24 @@ design-portal/
 │   ├── design/, docs/, foundations/, observability/, patterns/, registry/   # MDX doc routes
 ├── components/
 │   ├── docs/                         # DB-driven docs renderers (DEPRECATED — see §15.18)
-│   ├── landing/                      # Landing sections (header, hero, footer, install-steps,
-│   │                                 #   ai-native-section, copy-command, explore-section,
-│   │                                 #   component-catalog, component-showcase)
+│   ├── landing/                      # Portal-specific compositions over registry components
+│   │                                 #   (header.tsx configures NyuchiHeader, footer.tsx
+│   │                                 #   composes primitives + portal chrome; hero, install-
+│   │                                 #   steps, ai-native, build-with, explore, resilient-
+│   │                                 #   by-design, architecture-canvas / explorer)
 │   ├── layout/                       # mineral-strip.tsx, nyuchi-logo.tsx
+│   ├── mukoko/                       # Vendored registry:ui brand components
+│   │                                 #   (mukoko-header, mukoko-footer, mukoko-theme-provider,
+│   │                                 #   mukoko-skeleton-set, mukoko-error-set,
+│   │                                 #   mukoko-verified-badge) — registry paths kept as-is
+│   │                                 #   for pnpm registry:sync parity, see §8.6 note
 │   ├── patterns/                     # Pattern demos (architecture, observability,
 │   │                                 #   error-boundary, lazy-loading, component-pattern, code-block)
 │   ├── playground/                   # Interactive component gallery + API tester
 │   ├── ui/                           # ~35 portal primitives (the only registry items committed
 │   │                                 #   to disk; the other ~510 live only in Supabase
-│   │                                 #   and are served via /api/v1/ui)
+│   │                                 #   and are served via /api/v1/ui) — plus user-menu.tsx
+│   │                                 #   (vendored from nyuchi-user-menu)
 │   ├── error-boundary.tsx, lazy-section.tsx, section-error-boundary.tsx
 │   ├── theme-provider.tsx, theme-toggle.tsx
 │   └── example.tsx
@@ -183,10 +191,19 @@ design-portal/
 │   └── use-memory-pressure.ts        # Memory pressure observer
 ├── lib/
 │   ├── utils.ts                      # cn() utility (clsx + tailwind-merge)
+│   ├── icons.ts                      # Re-export shim for @/lib/icons (lucide-react passthrough)
 │   ├── observability.ts              # Structured logging with [mukoko] prefix
 │   ├── metrics.ts                    # MCP/API usage tracking
 │   ├── mcp-server.ts                 # MCP server factory (served at /mcp)
-│   └── db/                           # Supabase data access — SOURCE OF TRUTH
+│   ├── harness/                      # Vendored: NyuchiHarness + useNyuchiHarness hook
+│   │                                 #   (observability + motion + a11y + health wiring)
+│   ├── resilience/                   # Vendored: section error boundary + retry fetch + fallback
+│   ├── tokens/                       # Vendored: L1 design tokens + multi-platform generators
+│   ├── motion/                       # Vendored: motion presets + reduced-motion detection
+│   ├── a11y/                         # Vendored: focus-trap, live-region, skip-nav
+│   ├── circuit-breaker.ts, retry.ts, timeout.ts, fallback-chain.ts,
+│   ├── bulkhead.ts, rate-limiter.ts, chaos.ts    # Resilience primitives (vendored)
+│   └── db/                           # Supabase data access — SOURCE OF TRUTH for components
 │       ├── client.ts                 # Browser-side cache (localStorage)
 │       ├── index.ts                  # Server-side query functions
 │       └── types.ts                  # ComponentRow, ComponentDocRow, etc.
@@ -567,7 +584,20 @@ GET https://design.nyuchi.com/api/v1/skills/{name}    # raw MDX
 
 Skills are source-of-truthed in the existing `ai_instructions` Supabase table (or a new `skills` table if the versioning / audit needs differ) and served via a new `/api/v1/skills/*` endpoint that the CLI consumes. Claude Code plugin support requires a top-level `plugin.json` manifest in the skills repo.
 
-### 8.7 registry.json Schema Reference
+### 8.7 Vendored registry stack — path + naming drift
+
+The portal dogfoods its own registry. The 33-item transitive closure of `nyuchi-header` / `nyuchi-footer` / `nyuchi-user-menu` is vendored into this repo — the harness, resilience, tokens, motion, a11y, theme-provider, skeleton/error sets, verified-badge, and the seven resilience primitives (circuit-breaker, retry, timeout, fallback-chain, bulkhead, rate-limiter, chaos).
+
+**Two divergences between the registry's declared paths and the portal's reality**:
+
+1. **`components/mukoko/*` paths, `nyuchi-*` item names.** The registry is mid-rename (CLAUDE.md §11 already reflects the `nyuchi-*` names, but the registry's `files[].path` still points at `components/mukoko/mukoko-header.tsx`, etc.). Vendored files keep the `components/mukoko/*` path so that future `pnpm registry:sync` sees them as unchanged and doesn't try to overwrite with reshaped paths. When the registry itself completes the rename to `components/nyuchi/*`, run `pnpm registry:sync` + rename locally in a single commit.
+2. **Brand component imports use `@/components/brand/*` paths** that don't exist in this repo. The portal keeps `nyuchi-logo.tsx` and `mineral-strip.tsx` under `@/components/layout/` instead. Vendored files are patched on install to target the portal's real paths. Next `pnpm registry:sync` will re-patch automatically via the sync script (issue to be filed against the registry to align paths).
+
+**Upstream-bug tracking.** The vendor pass fixed 11 genuine bugs in the registry source code (template-literal escape artefacts, broken exports, missing prop definitions, type mismatches). They are listed in the commit message of the vendor commit and mirrored in a tracking GitHub issue. Re-running `pnpm registry:sync` before the upstream issues close will reintroduce the bugs — the sync script may need a patch-set overlay until the registry is clean.
+
+**Footer composition note.** `components/landing/footer.tsx` is deliberately NOT a one-line wrapper over `NyuchiFooter`. The portal footer has four portal-specific features NyuchiFooter doesn't currently expose: (1) the ecosystem brand grid (mukoko-consumer + nyuchi-enterprise columns), (2) a socials row (GitHub x2, X/Twitter), (3) an inline `ThemeToggle`, (4) a version line. The portal footer is a composition of primitives (`Separator`, `NyuchiLogo`, `ThemeToggle`) — not a hand-rolled variation of `NyuchiFooter`. Extending `NyuchiFooter` upstream with `ecosystem` / `socials` / `actions` / `version` props so the portal can fully dogfood it is a tracked follow-up.
+
+### 8.8 registry.json Schema Reference
 
 ```json
 {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { getPageMap } from "nextra/page-map"
 import "nextra-theme-docs/style.css"
 import "./globals.css"
 import { MineralStrip } from "@/components/layout/mineral-strip"
+import { SidebarProvider } from "@/components/ui/sidebar"
 import { Header } from "@/components/landing/header"
 import { Footer as CustomFooter } from "@/components/landing/footer"
 
@@ -175,16 +176,25 @@ export default async function RootLayout({
             sticky header (z-50) naturally covers it — the strip appears
             only outside the header band. */}
         <MineralStrip className="fixed inset-y-0 left-0 z-40 h-screen rounded-none" />
-        <div className="pl-1">
-          <Layout
-            navbar={navbar}
-            pageMap={await getPageMap()}
-            docsRepositoryBase="https://github.com/nyuchitech/design-portal/tree/main"
-            footer={footer}
-          >
-            {children}
-          </Layout>
-        </div>
+        {/* SidebarProvider wraps the whole app so `NyuchiHeader`'s built-in
+            SidebarTrigger has the context it needs. The actual `<Sidebar>`
+            content lands in the follow-up dashboard-shell PR
+            (`claude/nyuchi-dashboard-shell`); until then the trigger
+            toggles an empty provider — harmless no-op on desktop, opens
+            a stub sheet on mobile. `defaultOpen={false}` keeps the portal
+            chrome-free for consumers still using Nextra's sidebar. */}
+        <SidebarProvider defaultOpen={false}>
+          <div className="w-full pl-1">
+            <Layout
+              navbar={navbar}
+              pageMap={await getPageMap()}
+              docsRepositoryBase="https://github.com/nyuchitech/design-portal/tree/main"
+              footer={footer}
+            >
+              {children}
+            </Layout>
+          </div>
+        </SidebarProvider>
       </body>
     </html>
   )

--- a/components/landing/header.tsx
+++ b/components/landing/header.tsx
@@ -1,27 +1,21 @@
 "use client"
 
-import Link from "next/link"
-import { Search, Wrench, User } from "lucide-react"
-import { NyuchiLogo } from "@/components/layout/nyuchi-logo"
-import { cn } from "@/lib/utils"
+import { Search, Wrench, User } from "@/lib/icons"
+import { NyuchiHeader, type NavItem, type PillAction } from "@/components/mukoko/mukoko-header"
 
 /**
- * Landing / portal-wide header.
+ * Portal-specific composition of the registry's `NyuchiHeader` (L7 shell).
  *
- * Layout is identical from 320px through ultra-wide: logo + wordmark on the
- * left, three-icon pill group on the right. The only breakpoint-gated bit is
- * the four top-level nav links in the middle, which only appear at `md` and
- * above (below that, the footer is the full navigation map).
+ * No design or behaviour lives here — this file only configures the
+ * `navItems` (the portal's four top-level architecture surfaces) and
+ * the three-icon `pillActions` group (Search, Fundi, Avatar) that PR #52
+ * established as the brand identity marker.
  *
- * Icons in the pill follow the registry's `nyuchi-header` "pill action group"
- * pattern — a rounded-full container in the brand primary colour with three
- * circular icon buttons. Search, Fundi (Wrench), and Avatar are the three
- * persistent identity anchors across every breakpoint.
- *
- * Theme toggle and all social links live in the footer (see `footer.tsx`).
+ * Anything that would require a different header shape (logo, sticky,
+ * scroll title, back button, blur background, etc.) belongs in
+ * `components/mukoko/mukoko-header.tsx` (the registry source of truth).
+ * Keep this file under 30 lines.
  */
-
-type NavItem = { label: string; href: string }
 
 const NAV_ITEMS: NavItem[] = [
   { label: "Components", href: "/components" },
@@ -30,12 +24,6 @@ const NAV_ITEMS: NavItem[] = [
   { label: "Docs", href: "/docs" },
 ]
 
-type PillAction = {
-  icon: React.ComponentType<{ className?: string }>
-  label: string
-  href: string
-}
-
 const PILL_ACTIONS: PillAction[] = [
   { icon: Search, label: "Search components", href: "/components" },
   { icon: Wrench, label: "Fundi — self-healing dashboard", href: "/fundi" },
@@ -43,56 +31,5 @@ const PILL_ACTIONS: PillAction[] = [
 ]
 
 export function Header() {
-  return (
-    <header
-      data-slot="header"
-      className="sticky top-0 z-50 border-b border-border bg-background/80 backdrop-blur-xl"
-    >
-      <div className="mx-auto flex h-14 max-w-6xl items-center gap-3 px-4 sm:px-6">
-        <Link
-          href="/"
-          className="flex shrink-0 items-center"
-          aria-label="Nyuchi Design Portal home"
-        >
-          <NyuchiLogo size={24} showWordmark suffix="design" />
-        </Link>
-
-        <nav className="ml-4 hidden items-center gap-1 md:flex" aria-label="Primary">
-          {NAV_ITEMS.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className="rounded-lg px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-            >
-              {item.label}
-            </Link>
-          ))}
-        </nav>
-
-        <div className="flex-1" />
-
-        {/* Pill action group — 3 icons, always visible */}
-        <div
-          data-slot="pill-actions"
-          className="flex shrink-0 items-center gap-1 rounded-full bg-primary p-1"
-        >
-          {PILL_ACTIONS.map(({ icon: Icon, label, href }) => (
-            <Link
-              key={label}
-              href={href}
-              aria-label={label}
-              className={cn(
-                "flex size-9 items-center justify-center rounded-full",
-                "bg-background/10 text-primary-foreground transition-colors",
-                "hover:bg-background/20 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-background",
-                "sm:size-10"
-              )}
-            >
-              <Icon className="size-4 sm:size-[18px]" />
-            </Link>
-          ))}
-        </div>
-      </div>
-    </header>
-  )
+  return <NyuchiHeader appName="design" navItems={NAV_ITEMS} pillActions={PILL_ACTIONS} scrolled />
 }

--- a/components/mukoko/mukoko-error-set.tsx
+++ b/components/mukoko/mukoko-error-set.tsx
@@ -1,0 +1,351 @@
+"use client"
+
+// ── INFRASTRUCTURE HARNESS (auto-wired) ──
+// Every brand component participates in observability, motion, a11y,
+// and health monitoring via the harness. Zero manual config.
+
+import * as React from "react"
+import {
+  AlertTriangle,
+  WifiOff,
+  Wifi,
+  RefreshCw,
+  ArrowLeft,
+  Home,
+  Shield,
+  ChevronRight,
+} from "@/lib/icons"
+import { cn } from "@/lib/utils"
+
+/* ═══════════════════════════════════════════════════════════════
+   NYUCHI ERROR SET — Brand Feedback Components
+   
+   Error states are part of brand identity. When things go wrong,
+   the experience should still feel like Mukoko — mineral colors,
+   branded typography, Ubuntu-spirited copy ("The community is
+   here to help"), and clear paths forward.
+   
+   The 7-layer architecture means errors are nuanced:
+   - Offline? Data may still be available from local layer
+   - Section failed? The page survives, only that section shows fallback
+   - Trust-gated? Show which tier is needed and how to get there
+   
+   These are BRAND components, not primitives. They compose
+   error-boundary, button, badge, and verified-badge primitives
+   into the Mukoko visual language.
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── 1. ERROR CARD (inline, within feeds/lists) ─────────────── */
+interface ErrorCardProps {
+  title?: string
+  message?: string
+  onRetry?: () => void
+  mineral?: "malachite" | "cobalt" | "gold" | "tanzanite" | "terracotta"
+  className?: string
+}
+
+function ErrorCard({
+  title = "Something went wrong",
+  message = "We could not load this content. Please try again.",
+  onRetry,
+  mineral = "terracotta",
+  className,
+}: ErrorCardProps) {
+  const mineralColors: Record<string, string> = {
+    malachite: "var(--status-success, #22C55E)",
+    cobalt: "var(--status-info, #3B82F6)",
+    gold: "var(--status-warning, #F59E0B)",
+    tanzanite: "var(--status-info, #3B82F6)",
+    terracotta: "var(--status-error, #EF4444)",
+  }
+  const color = mineralColors[mineral]
+
+  return (
+    <div
+      data-slot="nyuchi-error-card"
+      data-portal="https://design.nyuchi.com/components/nyuchi-error-card"
+      role="alert"
+      className={cn(
+        "flex items-center gap-3 rounded-[var(--radius-card,14px)] border-l-4 bg-card px-4 py-3 ring-1 ring-foreground/10",
+        className
+      )}
+      style={{ borderLeftColor: color }}
+    >
+      <div
+        className="flex size-9 shrink-0 items-center justify-center rounded-[var(--radius-inner,7px)]"
+        style={{ backgroundColor: `color-mix(in srgb, ${color} 15%, transparent)` }}
+      >
+        <AlertTriangle className="size-4" style={{ color }} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium text-foreground">{title}</div>
+        <div className="mt-0.5 text-xs text-muted-foreground">{message}</div>
+      </div>
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="flex size-9 shrink-0 items-center justify-center rounded-full transition-colors hover:bg-foreground/5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+        >
+          <RefreshCw className="size-4 text-muted-foreground" />
+        </button>
+      )}
+    </div>
+  )
+}
+
+/* ── 2. NOT FOUND (brand 404 page) ──────────────────────────── */
+interface NotFoundProps {
+  title?: string
+  message?: string
+  onBack?: () => void
+  onHome?: () => void
+  className?: string
+}
+
+function NotFound({
+  title = "Page not found",
+  message = "The page you are looking for does not exist or has been moved.",
+  onBack,
+  onHome,
+  className,
+}: NotFoundProps) {
+  return (
+    <div
+      data-slot="nyuchi-not-found"
+      className={cn(
+        "flex min-h-[60vh] flex-col items-center justify-center px-6 text-center",
+        className
+      )}
+    >
+      {/* 404 display with mineral dots */}
+      <div className="mb-6 flex items-baseline gap-1 text-7xl font-bold text-foreground/10">
+        <span>4</span>
+        <div className="flex gap-1.5 pb-2">
+          {[
+            "var(--status-info, #3B82F6)",
+            "var(--status-info, #3B82F6)",
+            "var(--status-success, #22C55E)",
+            "var(--status-warning, #F59E0B)",
+            "var(--status-error, #EF4444)",
+          ].map((c, i) => (
+            <div key={i} className="size-2.5 rounded-full" style={{ backgroundColor: c }} />
+          ))}
+        </div>
+        <span>4</span>
+      </div>
+
+      <h1 className="font-serif text-2xl font-bold text-foreground">{title}</h1>
+      <p className="mt-2 max-w-sm text-sm leading-relaxed text-muted-foreground">{message}</p>
+
+      <div className="mt-6 flex gap-3">
+        {onBack && (
+          <button
+            onClick={onBack}
+            className="flex h-11 items-center gap-2 rounded-full border border-border px-5 text-sm font-medium text-foreground transition-colors hover:bg-foreground/5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+          >
+            <ArrowLeft className="size-4" />
+            Go Back
+          </button>
+        )}
+        {onHome && (
+          <button
+            onClick={onHome}
+            className="bg-[var(--status-success, #22C55E)] flex h-11 items-center gap-2 rounded-full px-5 text-sm font-semibold text-background"
+          >
+            <Home className="size-4" />
+            Home
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/* ── 3. OFFLINE BANNER (local-first connection status) ──────── */
+interface OfflineBannerProps {
+  /** Whether the device is connected to the network */
+  isOnline: boolean
+  /** Whether data is being served from local cache */
+  isUsingCache?: boolean
+  /** Last successful sync timestamp */
+  lastSyncAt?: Date | string
+  className?: string
+}
+
+function OfflineBanner({
+  isOnline,
+  isUsingCache = false,
+  lastSyncAt,
+  className,
+}: OfflineBannerProps) {
+  if (isOnline && !isUsingCache) return null
+
+  const lastSync = lastSyncAt
+    ? typeof lastSyncAt === "string"
+      ? new Date(lastSyncAt)
+      : lastSyncAt
+    : null
+
+  return (
+    <div
+      data-slot="nyuchi-offline-banner"
+      className={cn(
+        "flex items-center justify-center gap-2 px-4 py-2 text-xs font-medium",
+        isOnline
+          ? "bg-[var(--status-warning, #F59E0B)]/10 text-[var(--status-warning, #F59E0B)]"
+          : "bg-foreground/5 text-muted-foreground",
+        className
+      )}
+    >
+      {isOnline ? (
+        <>
+          <Wifi className="size-3.5" />
+          <span>Showing cached data</span>
+          {lastSync && (
+            <span className="opacity-60">
+              · Last synced{" "}
+              {lastSync.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+            </span>
+          )}
+        </>
+      ) : (
+        <>
+          <WifiOff className="size-3.5" />
+          <span>You are offline</span>
+          {lastSync && (
+            <span className="opacity-60">
+              · Using data from{" "}
+              {lastSync.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+            </span>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+/* ── 4. PERMISSION GATE (trust-tier access restriction) ────── */
+interface PermissionGateProps {
+  /** The verification tier required to access this feature */
+  requiredTier: "community" | "otp" | "government" | "licensed"
+  /** The user current tier */
+  currentTier?: "unverified" | "community" | "otp" | "government" | "licensed"
+  /** Feature name that is restricted */
+  featureName?: string
+  /** CTA callback */
+  onVerify?: () => void
+  className?: string
+}
+
+const tierLabels: Record<string, string> = {
+  community: "Community Verified",
+  otp: "Contact Verified",
+  government: "Government Verified",
+  licensed: "Licensed Professional",
+}
+
+const tierColors: Record<string, string> = {
+  community: "var(--status-error, #EF4444)",
+  otp: "var(--status-info, #3B82F6)",
+  government: "var(--status-warning, #F59E0B)",
+  licensed: "var(--status-info, #3B82F6)",
+}
+
+function PermissionGate({
+  requiredTier,
+  currentTier: _currentTier = "unverified",
+  featureName = "this feature",
+  onVerify,
+  className,
+}: PermissionGateProps) {
+  const color = tierColors[requiredTier]
+
+  return (
+    <div
+      data-slot="nyuchi-permission-gate"
+      className={cn(
+        "flex flex-col items-center rounded-[var(--radius-card,14px)] bg-card px-6 py-8 text-center ring-1 ring-foreground/10",
+        className
+      )}
+    >
+      <div
+        className="mb-4 flex size-14 items-center justify-center rounded-full"
+        style={{ backgroundColor: `color-mix(in srgb, ${color} 15%, transparent)` }}
+      >
+        <Shield className="size-7" style={{ color }} />
+      </div>
+
+      <h3 className="font-serif text-lg font-bold text-foreground">Verification Required</h3>
+      <p className="mt-2 max-w-xs text-sm text-muted-foreground">
+        {featureName} requires{" "}
+        <span className="font-medium" style={{ color }}>
+          {tierLabels[requiredTier]}
+        </span>{" "}
+        status. Complete verification to unlock access.
+      </p>
+
+      {onVerify && (
+        <button
+          onClick={onVerify}
+          className="mt-5 flex h-11 items-center gap-2 rounded-full px-6 text-sm font-semibold text-background"
+          style={{ backgroundColor: color }}
+        >
+          <Shield className="size-4" />
+          Verify Now
+          <ChevronRight className="size-4" />
+        </button>
+      )}
+    </div>
+  )
+}
+
+/* ── 5. SECTION FALLBACK (section-level error with retry) ──── */
+interface SectionFallbackProps {
+  sectionName?: string
+  error?: Error | string
+  onRetry?: () => void
+  className?: string
+}
+
+function SectionFallback({
+  sectionName = "This section",
+  error,
+  onRetry,
+  className,
+}: SectionFallbackProps) {
+  return (
+    <div
+      data-slot="nyuchi-section-fallback"
+      className={cn(
+        "flex flex-col items-center rounded-[var(--radius-card,14px)] bg-card px-6 py-6 text-center ring-1 ring-foreground/10",
+        className
+      )}
+    >
+      <AlertTriangle className="text-[var(--status-error, #EF4444)] size-8" />
+      <p className="mt-3 text-sm font-medium text-foreground">{sectionName} could not load</p>
+      {error && (
+        <p className="mt-1 text-xs text-muted-foreground">
+          {typeof error === "string" ? error : error.message}
+        </p>
+      )}
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="mt-4 flex h-9 items-center gap-2 rounded-full border border-border px-4 text-xs font-medium text-foreground transition-colors hover:bg-foreground/5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+        >
+          <RefreshCw className="size-3.5" />
+          Try Again
+        </button>
+      )}
+    </div>
+  )
+}
+
+export { ErrorCard, NotFound, OfflineBanner, PermissionGate, SectionFallback }
+export type {
+  ErrorCardProps,
+  NotFoundProps,
+  OfflineBannerProps,
+  PermissionGateProps,
+  SectionFallbackProps,
+}

--- a/components/mukoko/mukoko-footer.tsx
+++ b/components/mukoko/mukoko-footer.tsx
@@ -1,0 +1,167 @@
+"use client"
+
+// ── INFRASTRUCTURE HARNESS (auto-wired) ──────────────────
+import { useNyuchiHarness } from "@/lib/harness"
+
+import { cn } from "@/lib/utils"
+import { NyuchiLogo } from "@/components/layout/nyuchi-logo"
+
+/* ═══════════════════════════════════════════════════════════════
+   NYUCHI FOOTER — Brand Shell Component (Enterprise)
+   
+   ✅ L1 TOKENS — CSS custom properties throughout
+   ✅ L2 MOTION — Fade-in on scroll into view
+   ✅ L3 A11Y — Footer landmark, focus ring tokens, 48px targets
+   ✅ L4 OBSERVABILITY — useNyuchiHarness, scoped logging
+   ✅ L5 RESILIENCE — Graceful degradation for missing data
+   ✅ L6 I18N — Year via Intl, no hardcoded strings
+   ✅ L7 PLATFORM — data-slot for CSS targeting
+   ═══════════════════════════════════════════════════════════════ */
+
+interface FooterLink {
+  label: string
+  href: string
+  external?: boolean
+}
+
+interface FooterSection {
+  title: string
+  links: FooterLink[]
+}
+
+interface NyuchiFooterProps {
+  sections?: FooterSection[]
+  companyName?: string
+  tagline?: string
+  showMineralStrip?: boolean
+  className?: string
+}
+
+/* ── Default footer sections (Nyuchi ecosystem) ─── */
+const DEFAULT_SECTIONS: FooterSection[] = [
+  {
+    title: "Platform",
+    links: [
+      { label: "nhimbe", href: "/nhimbe" },
+      { label: "Bush Trade", href: "/bushtrade" },
+      { label: "Shamwari", href: "/shamwari" },
+      { label: "Campfire", href: "/campfire" },
+    ],
+  },
+  {
+    title: "Developers",
+    links: [
+      { label: "Components", href: "/components" },
+      { label: "API", href: "/api-docs" },
+      { label: "Architecture", href: "/architecture" },
+      { label: "GitHub", href: "https://github.com/nyuchitech", external: true },
+    ],
+  },
+  {
+    title: "Company",
+    links: [
+      { label: "About Nyuchi", href: "/about" },
+      { label: "Brand", href: "/brand" },
+      { label: "Ubuntu Philosophy", href: "/ubuntu" },
+      { label: "Privacy", href: "/privacy" },
+    ],
+  },
+]
+
+export function NyuchiFooter({
+  sections = DEFAULT_SECTIONS,
+  companyName = "Nyuchi Africa",
+  tagline = "I am because we are.",
+  showMineralStrip = true,
+  className,
+}: NyuchiFooterProps) {
+  // ── L4: HARNESS — Observability + motion + a11y ──
+  useNyuchiHarness("footer")
+
+  // ── L6: I18N — Dynamic year via Intl-safe method ──
+  const year = new Date().getFullYear()
+
+  return (
+    <footer
+      data-slot="nyuchi-footer"
+      data-portal="https://design.nyuchi.com/components/nyuchi-footer"
+      role="contentinfo"
+      className={cn("border-t border-border bg-card", className)}
+    >
+      {/* L1: TOKENS — Mineral accent strip.
+          Portal's MineralStrip is vertical-only per CLAUDE.md §15.15;
+          the registry footer's `thickness` prop is not supported here.
+          Upstream tracking: the registry footer should honour the brand
+          rule or expose an orientation prop. Dropped for now. */}
+      {showMineralStrip && (
+        <div
+          aria-hidden="true"
+          className="h-[3px] w-full bg-gradient-to-r from-[var(--color-cobalt)] via-[var(--color-gold)] via-[var(--color-malachite)] via-[var(--color-tanzanite)] to-[var(--color-terracotta)]"
+        />
+      )}
+
+      <div className="mx-auto max-w-7xl px-5 py-10">
+        {/* Link sections grid */}
+        <div className="grid grid-cols-2 gap-8 md:grid-cols-3 lg:grid-cols-4">
+          {/* Brand column */}
+          <div className="col-span-2 md:col-span-1">
+            <NyuchiLogo size={28} />
+            {tagline && (
+              <p className="mt-3 font-sans text-sm text-muted-foreground italic">{tagline}</p>
+            )}
+          </div>
+
+          {/* L5: RESILIENCE — Guard against empty sections */}
+          {(sections ?? []).map((section) => (
+            <div key={section.title}>
+              <h4 className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                {section.title}
+              </h4>
+              <nav className="mt-3 flex flex-col gap-2" aria-label={section.title}>
+                {(section.links ?? []).map((link) => (
+                  <a
+                    key={link.href}
+                    href={link.href}
+                    target={link.external ? "_blank" : undefined}
+                    rel={link.external ? "noopener noreferrer" : undefined}
+                    className={cn(
+                      "text-sm text-muted-foreground transition-colors",
+                      "hover:text-[var(--brand-accent,var(--color-primary, #00B0FF))]",
+                      /* L3: A11Y — Focus ring tokens + min touch target */
+                      "flex min-h-[48px] items-center",
+                      "rounded-[var(--radius-inner,7px)]",
+                      "focus-visible:outline-[length:var(--focusRing-width,2px)]",
+                      "focus-visible:outline-[var(--color-primary)]",
+                      "focus-visible:outline-offset-[var(--focusRing-offset,2px)]"
+                    )}
+                  >
+                    {link.label}
+                  </a>
+                ))}
+              </nav>
+            </div>
+          ))}
+        </div>
+
+        {/* Bottom bar */}
+        <div className="mt-10 flex flex-col items-center justify-between gap-2 border-t border-border pt-6 md:flex-row">
+          <p className="text-xs text-muted-foreground">
+            &copy; {year} {companyName}. All rights reserved.
+          </p>
+          {/* L1: TOKENS — Five African Minerals dots */}
+          <div className="flex items-center gap-1.5" aria-hidden="true">
+            {[
+              "var(--color-primary, #00B0FF)",
+              "var(--color-primary, #00B0FF)",
+              "var(--color-accent, #B388FF)",
+              "var(--status-warning, #FFD740)",
+              "var(--status-error, #D4A574)",
+            ].map((c, i) => (
+              <div key={i} className="size-1.5 rounded-full" style={{ backgroundColor: c }} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/components/mukoko/mukoko-header.tsx
+++ b/components/mukoko/mukoko-header.tsx
@@ -1,0 +1,178 @@
+"use client"
+
+// ── INFRASTRUCTURE HARNESS (auto-wired) ──
+// Every brand component participates in observability, motion, a11y,
+// and health monitoring via the harness. Zero manual config.
+import { useNyuchiHarness } from "@/lib/harness"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { NyuchiLogo } from "@/components/layout/nyuchi-logo"
+import { ThemeToggle } from "@/components/theme-toggle"
+import { SidebarTrigger } from "@/components/ui/sidebar"
+import { ExternalLink } from "@/lib/icons"
+
+/* ═══════════════════════════════════════════════════════════════
+   NYUCHI HEADER — Brand Shell Component
+   
+   Two modes:
+   1. Desktop: Logo + nav links + actions area (traditional)
+   2. Mobile / App: Logo + pill action group (brand identity)
+   
+   The pill action group is a capsule-shaped container (9999px
+   radius) in the brand accent color with 2-3 circular icon
+   buttons inside. This is the brand identity — recognizable
+   across nhimbe, bushtrade, shamwari, and all ecosystem apps.
+   ═══════════════════════════════════════════════════════════════ */
+
+export interface NavItem {
+  label: string
+  href: string
+  external?: boolean
+}
+
+export interface PillAction {
+  /** Lucide icon component */
+  icon: React.ComponentType<{ className?: string }>
+  /** Accessible label */
+  label: string
+  /** Click handler or route */
+  onClick?: () => void
+  href?: string
+}
+
+interface NyuchiHeaderProps {
+  /** App name displayed after the ecosystem logo */
+  appName?: string
+  /** Desktop navigation items */
+  navItems?: NavItem[]
+  /** Right-side action slot (desktop) */
+  actions?: React.ReactNode
+  /** Pill action buttons (mobile app identity pattern) */
+  pillActions?: PillAction[]
+  /** Whether header has scrolled (enables blur background) */
+  scrolled?: boolean
+  /** Custom page title shown when scrolled */
+  scrollTitle?: string
+  /** Show back button instead of sidebar trigger */
+  showBack?: boolean
+  onBack?: () => void
+  className?: string
+}
+
+const DEFAULT_NAV_ITEMS: NavItem[] = [
+  { label: "Components", href: "/components" },
+  { label: "Brand", href: "/brand" },
+  { label: "Architecture", href: "/architecture" },
+  { label: "API", href: "/api-docs" },
+]
+
+export function NyuchiHeader({
+  appName,
+  navItems = DEFAULT_NAV_ITEMS,
+  actions,
+  pillActions,
+  scrolled = false,
+  scrollTitle,
+  showBack = false,
+  onBack,
+  className,
+}: NyuchiHeaderProps) {
+  useNyuchiHarness("header") // harness pre-wires observability + motion + a11y
+
+  return (
+    <header
+      data-slot="nyuchi-header"
+      data-portal="https://design.nyuchi.com/components/nyuchi-header"
+      className={cn(
+        "sticky top-0 z-50 flex h-14 items-center gap-2 px-5 transition-all duration-300",
+        scrolled ? "border-b border-border/50 bg-background/80 backdrop-blur-xl" : "bg-transparent",
+        className
+      )}
+    >
+      {/* Left: sidebar trigger / back button + logo */}
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        {showBack ? (
+          <button onClick={onBack} className="flex items-center p-0" aria-label="Go back">
+            <svg
+              className="size-[22px] text-muted-foreground"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
+        ) : (
+          <SidebarTrigger className="md:hidden" />
+        )}
+
+        {/* App icon — rounded-lg square with border (brand marker) */}
+        <a href="/" className="flex items-center gap-3">
+          <NyuchiLogo size={24} suffix={appName} />
+        </a>
+
+        {/* Scroll title override */}
+        {scrolled && scrollTitle && (
+          <span className="truncate text-lg font-bold text-foreground transition-opacity">
+            {scrollTitle}
+          </span>
+        )}
+      </div>
+
+      {/* Desktop navigation */}
+      <nav className="ml-6 hidden items-center gap-1 md:flex">
+        {navItems.map((item) => (
+          <a
+            key={item.href}
+            href={item.href}
+            target={item.external ? "_blank" : undefined}
+            rel={item.external ? "noopener noreferrer" : undefined}
+            className="inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          >
+            {item.label}
+            {item.external && <ExternalLink className="size-3 opacity-50" />}
+          </a>
+        ))}
+      </nav>
+
+      {/* Spacer */}
+      <div className="flex-1" />
+
+      {/* ── PILL ACTION GROUP (brand identity pattern) ──────── */}
+      {pillActions && pillActions.length > 0 && (
+        <div
+          data-slot="pill-actions"
+          className="bg-[var(--brand-accent,var(--color-primary, #00B0FF))] flex items-center gap-1 rounded-full p-1"
+        >
+          {pillActions.map((action, i) => {
+            const Icon = action.icon
+            const shared = cn(
+              "flex size-10 items-center justify-center rounded-full",
+              "bg-black/10 transition-colors hover:bg-black/20"
+            )
+            if (action.href) {
+              return (
+                <a key={i} href={action.href} aria-label={action.label} className={shared}>
+                  <Icon className="size-5 text-background" />
+                </a>
+              )
+            }
+            return (
+              <button key={i} onClick={action.onClick} aria-label={action.label} className={shared}>
+                <Icon className="size-5 text-background" />
+              </button>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Desktop actions area */}
+      <div className="flex items-center gap-1">
+        {actions}
+        {!pillActions && <ThemeToggle />}
+      </div>
+    </header>
+  )
+}

--- a/components/mukoko/mukoko-skeleton-set.tsx
+++ b/components/mukoko/mukoko-skeleton-set.tsx
@@ -1,0 +1,297 @@
+"use client"
+
+// ── INFRASTRUCTURE HARNESS (auto-wired) ──
+// Every brand component participates in observability, motion, a11y,
+// and health monitoring via the harness. Zero manual config.
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+/* ═══════════════════════════════════════════════════════════════
+   MUKOKO SKELETON SET — Brand Loading States
+   
+   The 7-layer architecture means data arrives at different
+   speeds from different sources (local SQLite, edge D1,
+   cloud Supabase). Every brand component needs a skeleton
+   that mirrors its exact layout proportions.
+   
+   Strategy: skeletons ARE the components in loading state.
+   Same radius, same spacing, same visual weight — just
+   pulsing placeholders instead of real content.
+   
+   Design identity markers maintained in loading state:
+   - 14px card radius
+   - 7px inner element radius
+   - Correct spacing (20px margins, 16px padding)
+   - Mineral accent dot on applicable skeletons
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Base shimmer block ─────────────────────────────────────── */
+function Bone({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "animate-pulse rounded-[var(--radius-inner,7px)] bg-foreground/[0.06]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+/* ── 1. LISTING SKELETON ────────────────────────────────────── */
+function ListingSkeleton({
+  variant = "row",
+  className,
+}: {
+  variant?: "row" | "compact" | "hero"
+  className?: string
+}) {
+  if (variant === "hero") {
+    return (
+      <div
+        className={cn(
+          "min-h-[200px] animate-pulse rounded-[var(--radius-card,14px)] bg-foreground/[0.04] p-5",
+          className
+        )}
+      >
+        <div className="flex h-full flex-col justify-end gap-2">
+          <Bone className="h-4 w-16 rounded-full" />
+          <Bone className="h-6 w-3/4" />
+          <Bone className="h-3 w-1/2" />
+        </div>
+      </div>
+    )
+  }
+
+  if (variant === "compact") {
+    return (
+      <div
+        className={cn(
+          "overflow-hidden rounded-[var(--radius-card,14px)] bg-card ring-1 ring-foreground/10",
+          className
+        )}
+      >
+        <Bone className="aspect-video w-full rounded-none" />
+        <div className="flex flex-col gap-2 p-4">
+          <Bone className="h-4 w-3/4" />
+          <Bone className="h-3 w-full" />
+          <div className="flex gap-2">
+            <Bone className="h-5 w-14 rounded-full" />
+            <Bone className="h-5 w-10 rounded-full" />
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  /* Row variant */
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-[var(--radius-card,14px)] border-l-4 border-l-foreground/[0.06] bg-card py-3 pr-4 pl-3 ring-1 ring-foreground/10",
+        className
+      )}
+    >
+      <Bone className="size-12 shrink-0" />
+      <div className="flex flex-1 flex-col gap-1.5">
+        <Bone className="h-4 w-2/3" />
+        <Bone className="h-3 w-full" />
+      </div>
+      <Bone className="h-5 w-10 shrink-0 rounded-full" />
+    </div>
+  )
+}
+
+/* ── 2. PROFILE SKELETON ────────────────────────────────────── */
+function ProfileSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("flex animate-pulse flex-col items-center px-5 py-3", className)}>
+      <Bone className="size-20 rounded-full" />
+      <Bone className="mt-3.5 h-6 w-40" />
+      <Bone className="mt-2 h-3 w-28" />
+      {/* Trust indicators */}
+      <div className="mt-4 flex gap-3">
+        <Bone className="h-6 w-28 rounded-full" />
+        <Bone className="h-6 w-16 rounded-full" />
+      </div>
+      {/* Trust meter */}
+      <div className="mt-3 w-full max-w-xs">
+        <Bone className="h-1.5 w-full rounded-full" />
+      </div>
+      {/* Stats row */}
+      <div className="mt-5 flex gap-8">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="flex flex-col items-center gap-1">
+            <Bone className="h-6 w-8" />
+            <Bone className="h-3 w-12" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/* ── 3. STATS SKELETON ──────────────────────────────────────── */
+function StatsSkeleton({
+  layout = "inline",
+  count = 4,
+  className,
+}: {
+  layout?: "inline" | "grid"
+  count?: number
+  className?: string
+}) {
+  if (layout === "grid") {
+    return (
+      <div className={cn("grid grid-cols-2 gap-3", className)}>
+        {Array.from({ length: count }).map((_, i) => (
+          <div
+            key={i}
+            className="flex animate-pulse flex-col gap-2 rounded-[var(--radius-card,14px)] bg-card p-4 ring-1 ring-foreground/10"
+          >
+            <Bone className="size-8 rounded-[var(--radius-inner,7px)]" />
+            <Bone className="h-7 w-16" />
+            <Bone className="h-3 w-20" />
+          </div>
+        ))}
+      </div>
+    )
+  }
+  return (
+    <div
+      className={cn(
+        "flex animate-pulse gap-4 rounded-[var(--radius-card,14px)] bg-card p-3 ring-1 ring-foreground/10",
+        className
+      )}
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="flex min-w-[120px] items-center gap-2">
+          <Bone className="size-8 shrink-0 rounded-[var(--radius-inner,7px)]" />
+          <div className="flex flex-col gap-1">
+            <Bone className="h-2.5 w-16" />
+            <Bone className="h-3.5 w-10" />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/* ── 4. FEED SKELETON (stack of listing skeletons) ──────────── */
+function FeedSkeleton({
+  count = 4,
+  variant = "row",
+  className,
+}: {
+  count?: number
+  variant?: "row" | "compact" | "hero"
+  className?: string
+}) {
+  if (variant === "compact") {
+    return (
+      <div className={cn("grid grid-cols-2 gap-3", className)}>
+        {Array.from({ length: count }).map((_, i) => (
+          <ListingSkeleton key={i} variant="compact" />
+        ))}
+      </div>
+    )
+  }
+  return (
+    <div className={cn("flex flex-col gap-2", className)}>
+      {variant === "hero" && <ListingSkeleton variant="hero" />}
+      {Array.from({ length: count }).map((_, i) => (
+        <ListingSkeleton key={i} variant="row" />
+      ))}
+    </div>
+  )
+}
+
+/* ── 5. DETAIL SKELETON ─────────────────────────────────────── */
+function DetailSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("animate-pulse", className)}>
+      {/* Hero area */}
+      <Bone className="min-h-[220px] rounded-none" />
+      {/* Info card */}
+      <div className="p-5">
+        <div className="flex flex-col gap-3 rounded-[var(--radius-card,14px)] bg-card p-4 ring-1 ring-foreground/10">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="flex items-center gap-3">
+              <Bone className="size-9 rounded-[var(--radius-inner,7px)]" />
+              <div className="flex flex-1 flex-col gap-1">
+                <Bone className="h-4 w-1/2" />
+                <Bone className="h-3 w-1/3" />
+              </div>
+            </div>
+          ))}
+        </div>
+        {/* Description block */}
+        <div className="mt-4 rounded-[var(--radius-card,14px)] bg-card p-4 ring-1 ring-foreground/10">
+          <Bone className="mb-2 h-3 w-full" />
+          <Bone className="mb-2 h-3 w-full" />
+          <Bone className="h-3 w-2/3" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ── 6. CALENDAR SKELETON ───────────────────────────────────── */
+function CalendarSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("animate-pulse", className)}>
+      {/* Month header */}
+      <div className="mb-4 flex items-center justify-between">
+        <Bone className="size-5 rounded-full" />
+        <Bone className="h-5 w-28" />
+        <Bone className="size-5 rounded-full" />
+      </div>
+      {/* Day headers */}
+      <div className="mb-2 grid grid-cols-7 gap-1">
+        {Array.from({ length: 7 }).map((_, i) => (
+          <Bone key={i} className="mx-auto h-3 w-6" />
+        ))}
+      </div>
+      {/* Calendar grid */}
+      <div className="rounded-[var(--radius-card,14px)] bg-card p-2 ring-1 ring-foreground/10">
+        <div className="grid grid-cols-7 gap-[2px]">
+          {Array.from({ length: 35 }).map((_, i) => (
+            <Bone key={i} className="h-11 rounded-[var(--radius-inner,7px)]" />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ── 7. CHAT SKELETON ───────────────────────────────────────── */
+function ChatSkeleton({ count = 5, className }: { count?: number; className?: string }) {
+  return (
+    <div className={cn("flex animate-pulse flex-col gap-3 p-4", className)}>
+      {Array.from({ length: count }).map((_, i) => {
+        const isReceived = i % 3 !== 1
+        return (
+          <div key={i} className={cn("flex gap-2", isReceived ? "justify-start" : "justify-end")}>
+            {isReceived && <Bone className="size-8 shrink-0 rounded-full" />}
+            <Bone
+              className={cn("rounded-2xl px-4 py-3", isReceived ? "w-3/5" : "w-2/5")}
+              style={{ height: 20 + Math.random() * 30 }}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export {
+  Bone,
+  ListingSkeleton,
+  ProfileSkeleton,
+  StatsSkeleton,
+  FeedSkeleton,
+  DetailSkeleton,
+  CalendarSkeleton,
+  ChatSkeleton,
+}

--- a/components/mukoko/mukoko-theme-provider.tsx
+++ b/components/mukoko/mukoko-theme-provider.tsx
@@ -1,0 +1,135 @@
+"use client"
+
+import * as React from "react"
+import { generateCSSVariables, type ThemeMode, type BrandId } from "@/lib/tokens"
+
+/* ═══════════════════════════════════════════════════════════════
+   MUKOKO THEME PROVIDER
+   
+   Wraps the application root and provides:
+   1. CSS custom properties generated from the token system
+   2. React context for runtime theme/brand switching
+   3. System preference detection (prefers-color-scheme, prefers-contrast)
+   4. Persistence via localStorage
+   5. Class-based theme application for Tailwind dark: prefix
+   ═══════════════════════════════════════════════════════════════ */
+
+interface ThemeContextValue {
+  theme: ThemeMode
+  brand: BrandId
+  setTheme: (theme: ThemeMode) => void
+  setBrand: (brand: BrandId) => void
+  systemPreference: ThemeMode
+  /** Whether reduced motion is preferred */
+  prefersReducedMotion: boolean
+  /** Whether high contrast is preferred */
+  prefersHighContrast: boolean
+}
+
+const ThemeContext = React.createContext<ThemeContextValue | null>(null)
+
+export function useTheme() {
+  const ctx = React.useContext(ThemeContext)
+  if (!ctx) throw new Error("useTheme must be used within NyuchiThemeProvider")
+  return ctx
+}
+
+interface NyuchiThemeProviderProps {
+  children: React.ReactNode
+  /** Default theme mode */
+  defaultTheme?: ThemeMode
+  /** Brand identity (changes primary accent color) */
+  brand?: BrandId
+  /** Use system preference for initial theme */
+  useSystemPreference?: boolean
+  /** Storage key for persisting theme choice */
+  storageKey?: string
+}
+
+export function NyuchiThemeProvider({
+  children,
+  defaultTheme = "dark",
+  brand: initialBrand = "mukoko",
+  useSystemPreference = true,
+  storageKey = "nyuchi-theme",
+}: NyuchiThemeProviderProps) {
+  /* Detect system preferences */
+  const [systemPreference, setSystemPreference] = React.useState<ThemeMode>("dark")
+  const [prefersReducedMotion, setPrefersReducedMotion] = React.useState(false)
+  const [prefersHighContrast, setPrefersHighContrast] = React.useState(false)
+
+  React.useEffect(() => {
+    const darkMq = window.matchMedia("(prefers-color-scheme: dark)")
+    const contrastMq = window.matchMedia("(prefers-contrast: more)")
+    const motionMq = window.matchMedia("(prefers-reduced-motion: reduce)")
+
+    setSystemPreference(contrastMq.matches ? "high-contrast" : darkMq.matches ? "dark" : "light")
+    setPrefersHighContrast(contrastMq.matches)
+    setPrefersReducedMotion(motionMq.matches)
+
+    const onDark = (e: MediaQueryListEvent) => setSystemPreference(e.matches ? "dark" : "light")
+    const onContrast = (e: MediaQueryListEvent) => {
+      setPrefersHighContrast(e.matches)
+      if (e.matches) setSystemPreference("high-contrast")
+    }
+    const onMotion = (e: MediaQueryListEvent) => setPrefersReducedMotion(e.matches)
+
+    darkMq.addEventListener("change", onDark)
+    contrastMq.addEventListener("change", onContrast)
+    motionMq.addEventListener("change", onMotion)
+    return () => {
+      darkMq.removeEventListener("change", onDark)
+      contrastMq.removeEventListener("change", onContrast)
+      motionMq.removeEventListener("change", onMotion)
+    }
+  }, [])
+
+  /* Theme state with persistence */
+  const [theme, setThemeState] = React.useState<ThemeMode>(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem(storageKey) as ThemeMode | null
+      if (stored) return stored
+    }
+    return useSystemPreference ? systemPreference : defaultTheme
+  })
+  const [brand, setBrand] = React.useState<BrandId>(initialBrand)
+
+  const setTheme = React.useCallback(
+    (t: ThemeMode) => {
+      setThemeState(t)
+      if (typeof window !== "undefined") localStorage.setItem(storageKey, t)
+    },
+    [storageKey]
+  )
+
+  /* Generate and inject CSS variables */
+  const cssVars = React.useMemo(() => generateCSSVariables(theme, brand), [theme, brand])
+
+  /* Apply dark/light class for Tailwind */
+  React.useEffect(() => {
+    const root = document.documentElement
+    root.classList.remove("light", "dark")
+    root.classList.add(theme === "light" ? "light" : "dark")
+    root.setAttribute("data-theme", theme)
+    root.setAttribute("data-brand", brand)
+    if (prefersReducedMotion) root.setAttribute("data-reduced-motion", "true")
+    else root.removeAttribute("data-reduced-motion")
+  }, [theme, brand, prefersReducedMotion])
+
+  const value: ThemeContextValue = {
+    theme,
+    brand,
+    setTheme,
+    setBrand,
+    systemPreference,
+    prefersReducedMotion,
+    prefersHighContrast,
+  }
+
+  return (
+    <ThemeContext.Provider value={value}>
+      <style dangerouslySetInnerHTML={{ __html: cssVars }} />
+      {children}
+    </ThemeContext.Provider>
+  )
+}

--- a/components/mukoko/mukoko-verified-badge.tsx
+++ b/components/mukoko/mukoko-verified-badge.tsx
@@ -1,0 +1,244 @@
+"use client"
+
+// ── INFRASTRUCTURE HARNESS (auto-wired) ──
+// Every brand component participates in observability, motion, a11y,
+// and health monitoring via the harness. Zero manual config.
+import { useNyuchiHarness } from "@/lib/harness"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Users, Phone, ShieldCheck, Award, Ban, Flower2 } from "@/lib/icons"
+import { cn } from "@/lib/utils"
+
+/* ═══════════════════════════════════════════════════════════════
+   MUKOKO VERIFIED BADGE — Brand Identity Component
+   
+   Three-axis trust model (nyuchi_platform_db):
+   
+   AXIS 1 — STATUS (identity.person.mit_status)
+     Platform lifecycle. Independent of verification.
+     pre_verification | living | liveness_pending |
+     suspended | presumed_ancestral | verified_ancestral
+   
+   AXIS 2 — VERIFICATION TIER (system.verification_tier)
+     Identity ladder. How real are you?
+     Level 0: Unverified     — no badge
+     Level 1: Community      — Terracotta (var(--color-terracotta,#D4A574)) — +0.10
+     Level 2: OTP            — Cobalt (var(--tier-otp,var(--color-cobalt,#00B0FF)))     — +0.10 (cumulative 0.20)
+     Level 3: Government     — Gold (var(--tier-licensed,var(--color-gold,#FFD740)))       — +0.10 (cumulative 0.30)
+     Level 4: Licensed       — Tanzanite (var(--tier-government,var(--color-tanzanite,#B388FF)))  — +0.20 (cumulative 0.50)
+   
+   AXIS 3 — TRUST SCORE (computed output)
+     trust = sum(tier_increments up to current level) + status_modifier
+     Suspended/ancestral = fixed at status modifier (trust frozen)
+   
+   The badge renders based on TIER (which mineral check you see)
+   but respects STATUS (dimmed if suspended, memorial if ancestral).
+   ═══════════════════════════════════════════════════════════════ */
+
+/** Verification tier codes from system.verification_tier.tier_code */
+type VerificationTier = "unverified" | "community" | "otp" | "government" | "licensed"
+
+/** Platform status from identity.person.mit_status */
+type PlatformStatus =
+  | "pre_verification"
+  | "living"
+  | "liveness_pending"
+  | "suspended"
+  | "presumed_ancestral"
+  | "verified_ancestral"
+
+/** Full tier configuration mapping to system.verification_tier */
+const TIER_CONFIG = {
+  unverified: {
+    level: 0,
+    mineral: null,
+    label: "Unverified",
+    trustIncrement: 0.0,
+    cumulativeTrust: 0.0,
+    fg: "transparent",
+    bg: "transparent",
+    fgLight: "transparent",
+    bgLight: "transparent",
+    icon: null,
+  },
+  community: {
+    level: 1,
+    mineral: "Terracotta",
+    label: "Community Verified",
+    trustIncrement: 0.1,
+    cumulativeTrust: 0.1,
+    fg: "var(--color-terracotta,#D4A574)",
+    bg: "rgba(212,165,116,0.15)",
+    fgLight: "var(--color-terracotta-light,#8B4513)",
+    bgLight: "rgba(139,69,19,0.12)",
+    icon: Users,
+  },
+  otp: {
+    level: 2,
+    mineral: "Cobalt",
+    label: "Contact Verified",
+    trustIncrement: 0.1,
+    cumulativeTrust: 0.2,
+    fg: "var(--tier-otp,var(--color-cobalt,#00B0FF))",
+    bg: "rgba(0,176,255,0.15)",
+    fgLight: "var(--color-cobalt-light,#0047AB)",
+    bgLight: "rgba(0,71,171,0.12)",
+    icon: Phone,
+  },
+  government: {
+    level: 3,
+    mineral: "Gold",
+    label: "Government Verified",
+    trustIncrement: 0.1,
+    cumulativeTrust: 0.3,
+    fg: "var(--tier-licensed,var(--color-gold,#FFD740))",
+    bg: "rgba(255,215,64,0.15)",
+    fgLight: "var(--color-gold-light,#5D4037)",
+    bgLight: "rgba(93,64,55,0.12)",
+    icon: ShieldCheck,
+  },
+  licensed: {
+    level: 4,
+    mineral: "Tanzanite",
+    label: "Licensed Professional",
+    trustIncrement: 0.2,
+    cumulativeTrust: 0.5,
+    fg: "var(--tier-government,var(--color-tanzanite,#B388FF))",
+    bg: "rgba(179,136,255,0.15)",
+    fgLight: "var(--color-tanzanite-light,#4B0082)",
+    bgLight: "rgba(75,0,130,0.12)",
+    icon: Award,
+  },
+} as const
+
+/** Status overlay configuration from system.platform_status_trust */
+const STATUS_OVERLAY = {
+  pre_verification: { modifier: 0.0, active: true, overlay: null },
+  living: { modifier: 0.0, active: true, overlay: null },
+  liveness_pending: { modifier: 0.0, active: true, overlay: null },
+  suspended: { modifier: -0.05, active: false, overlay: "suspended" as const },
+  presumed_ancestral: { modifier: 0.05, active: false, overlay: "ancestral" as const },
+  verified_ancestral: { modifier: 0.05, active: false, overlay: "ancestral" as const },
+} as const
+
+const badgeSizeVariants = cva(
+  "inline-flex shrink-0 items-center justify-center rounded-full transition-opacity",
+  {
+    variants: {
+      size: {
+        sm: "size-3.5" /* Inline with text — next to names */,
+        md: "size-[18px]" /* Default — cards, headers */,
+        lg: "size-6" /* Profile pages */,
+        xl: "size-8" /* Verification detail views */,
+      },
+    },
+    defaultVariants: { size: "md" },
+  }
+)
+
+const iconSizeMap = { sm: 10, md: 12, lg: 16, xl: 20 } as const
+
+interface NyuchiVerifiedBadgeProps extends VariantProps<typeof badgeSizeVariants> {
+  /** Verification tier code (system.verification_tier.tier_code) */
+  tier: VerificationTier
+  /** Platform status (identity.person.mit_status). Affects badge appearance. */
+  status?: PlatformStatus
+  /** Show tooltip with tier name on hover */
+  showTooltip?: boolean
+  /** Render a skeleton placeholder instead of the badge */
+  loading?: boolean
+  className?: string
+}
+
+function NyuchiVerifiedBadge({
+  tier,
+  status = "living",
+  size = "md",
+  showTooltip = true,
+  loading = false,
+  className,
+}: NyuchiVerifiedBadgeProps) {
+  useNyuchiHarness("verified-badge") // harness pre-wires observability + motion + a11y
+  if (loading)
+    return (
+      <span
+        data-slot="nyuchi-verified-badge"
+        data-portal="https://design.nyuchi.com/components/nyuchi-verified-badge"
+        data-loading
+        className="inline-flex size-4 animate-pulse rounded-full bg-muted"
+      />
+    )
+
+  const config = TIER_CONFIG[tier]
+  const statusConfig = STATUS_OVERLAY[status]
+  const iconSize = iconSizeMap[size || "md"]
+
+  /* Level 0 = no badge */
+  if (!config.icon || tier === "unverified") return null
+
+  /* Suspended: show ban overlay instead of tier icon */
+  if (statusConfig.overlay === "suspended") {
+    return (
+      <span
+        data-slot="nyuchi-verified-badge"
+        data-tier={tier}
+        data-status="suspended"
+        aria-label="Account Suspended"
+        title={showTooltip ? "Account Suspended" : undefined}
+        className={cn(badgeSizeVariants({ size }), "opacity-40", className)}
+        style={{ backgroundColor: "rgba(107,107,102,0.15)" }}
+      >
+        <Ban width={iconSize} height={iconSize} strokeWidth={2.5} color="#6B6B66" />
+      </span>
+    )
+  }
+
+  /* Ancestral: show memorial flower with dimmed tier color */
+  if (statusConfig.overlay === "ancestral") {
+    return (
+      <span
+        data-slot="nyuchi-verified-badge"
+        data-tier={tier}
+        data-status={status}
+        aria-label={`${config.label} — Memorial`}
+        title={showTooltip ? `${config.label} — Memorial` : undefined}
+        className={cn(badgeSizeVariants({ size }), "opacity-60", className)}
+        style={{ backgroundColor: config.bg }}
+      >
+        <Flower2 width={iconSize} height={iconSize} strokeWidth={2} style={{ color: config.fg }} />
+      </span>
+    )
+  }
+
+  /* Active: show full tier badge */
+  const Icon = config.icon
+  return (
+    <span
+      data-slot="nyuchi-verified-badge"
+      data-tier={tier}
+      data-level={config.level}
+      data-trust={config.cumulativeTrust}
+      aria-label={config.label}
+      title={showTooltip ? `${config.label} · Trust ${config.cumulativeTrust}` : undefined}
+      className={cn(badgeSizeVariants({ size }), className)}
+      style={{ backgroundColor: config.bg }}
+    >
+      <Icon width={iconSize} height={iconSize} strokeWidth={2.5} style={{ color: config.fg }} />
+    </span>
+  )
+}
+
+/* ── Utility: compute trust score on the client ──────────────── */
+function computeTrustScore(tier: VerificationTier, status: PlatformStatus): number {
+  const statusConfig = STATUS_OVERLAY[status]
+
+  // Suspended/ancestral = fixed at modifier only
+  if (!statusConfig.active) return statusConfig.modifier
+
+  // Active = cumulative tier score + status modifier
+  return TIER_CONFIG[tier].cumulativeTrust + statusConfig.modifier
+}
+
+export { NyuchiVerifiedBadge, computeTrustScore, TIER_CONFIG, STATUS_OVERLAY }
+export type { NyuchiVerifiedBadgeProps, VerificationTier, PlatformStatus }

--- a/components/ui/user-menu.tsx
+++ b/components/ui/user-menu.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import { useNyuchiHarness } from "@/lib/harness"
+import * as React from "react"
+import { LogOut, Settings, User, ChevronsUpDown } from "@/lib/icons"
+import { cn } from "@/lib/utils"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+interface UserMenuProps {
+  /** User display name */
+  name: string
+  /** User email */
+  email?: string
+  /** Avatar image URL */
+  avatarUrl?: string
+  /** Called when Sign Out is clicked */
+  onSignOut?: () => void
+  /** Additional menu items rendered before the sign-out group */
+  children?: React.ReactNode
+  /** Additional links (e.g., Profile, Settings) */
+  menuItems?: UserMenuItem[]
+  className?: string
+}
+
+interface UserMenuItem {
+  label: string
+  icon?: React.ComponentType<{ className?: string }>
+  href?: string
+  onClick?: () => void
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2)
+}
+
+function UserMenu({
+  name,
+  email,
+  avatarUrl,
+  onSignOut,
+  children,
+  menuItems = [],
+  className,
+}: UserMenuProps) {
+  // Harness pre-wires observability + motion + a11y; user-menu's current
+  // render path doesn't consume those surfaces yet, but keeping the hook
+  // call registers the component with the global health monitor.
+  useNyuchiHarness("user-menu")
+  const defaultItems: UserMenuItem[] = [
+    { label: "Profile", icon: User, href: "/profile" },
+    { label: "Settings", icon: Settings, href: "/settings" },
+  ]
+
+  const items = menuItems.length > 0 ? menuItems : defaultItems
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          data-slot="user-menu"
+          data-portal="https://design.nyuchi.com/components/user-menu"
+          role="menu"
+          aria-label="User menu"
+          className={cn(
+            "flex min-h-[48px] items-center gap-2 rounded-lg p-1.5 text-left text-sm transition-colors outline-none hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]",
+            className
+          )}
+        >
+          <Avatar className="size-8">
+            <AvatarImage src={avatarUrl} alt={name} />
+            <AvatarFallback className="text-xs">{getInitials(name)}</AvatarFallback>
+          </Avatar>
+          <div className="hidden flex-col sm:flex">
+            <span className="text-sm leading-none font-medium">{name}</span>
+            {email && <span className="text-xs text-muted-foreground">{email}</span>}
+          </div>
+          <ChevronsUpDown className="ml-auto hidden size-4 text-muted-foreground sm:block" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56" align="end" forceMount>
+        <DropdownMenuLabel className="font-normal">
+          <div className="flex flex-col space-y-1">
+            <p className="text-sm leading-none font-medium">{name}</p>
+            {email && <p className="text-xs leading-none text-muted-foreground">{email}</p>}
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          {items.map((item) => {
+            const Icon = item.icon
+            return (
+              <DropdownMenuItem key={item.label} onClick={item.onClick} asChild={!!item.href}>
+                {item.href ? (
+                  <a href={item.href}>
+                    {Icon && <Icon className="mr-2 size-4" />}
+                    {item.label}
+                  </a>
+                ) : (
+                  <>
+                    {Icon && <Icon className="mr-2 size-4" />}
+                    {item.label}
+                  </>
+                )}
+              </DropdownMenuItem>
+            )
+          })}
+        </DropdownMenuGroup>
+        {children && (
+          <>
+            <DropdownMenuSeparator />
+            {children}
+          </>
+        )}
+        {onSignOut && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={onSignOut}>
+              <LogOut className="mr-2 size-4" />
+              Sign out
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+export { UserMenu }
+export type { UserMenuProps, UserMenuItem }

--- a/lib/a11y/index.tsx
+++ b/lib/a11y/index.tsx
@@ -1,0 +1,242 @@
+"use client"
+
+// Infrastructure lib — accessibility primitives for brand components.
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+/* ═══════════════════════════════════════════════════════════════
+   MUKOKO ACCESSIBILITY INFRASTRUCTURE
+   
+   Accessibility is not a feature — it is infrastructure.
+   Every brand component depends on these utilities.
+   
+   WCAG 2.2 AA minimum. Our target is AAA where possible.
+   
+   Exports:
+   - FocusTrap: Contains focus within modals/overlays
+   - LiveRegion: Announces dynamic content to screen readers
+   - SkipNav: Keyboard shortcut to skip navigation
+   - VisuallyHidden: Content visible only to screen readers
+   - useAnnounce: Imperative screen reader announcements
+   - a11yTokens: Focus ring, touch targets, contrast pairs
+   ═══════════════════════════════════════════════════════════════ */
+
+// ─── A11Y TOKENS ───────────────────────────────────────────
+// Accessibility design decisions as tokens so they are
+// consistent and auditable across all components.
+
+export const a11yTokens = {
+  /** Focus ring: 2px solid malachite with 2px offset */
+  focusRing: {
+    width: "2px",
+    style: "solid",
+    color: "var(--color-primary, #64FFDA)",
+    offset: "2px",
+    css: "outline: 2px solid var(--color-primary, #64FFDA); outline-offset: 2px;",
+  },
+
+  /** Minimum touch target size — Nyuchi exceeds WCAG 2.2 (44px) for the African mobile market */
+  minTouchTarget: {
+    width: "48px",
+    height: "48px",
+    css: "min-width: 48px; min-height: 48px;",
+    default: "56px",
+    defaultCss: "min-width: 56px; min-height: 56px;",
+    note: "Default 56px, minimum 48px. Never below 48px.",
+  },
+
+  /** Contrast-safe mineral color pairings.
+   *  Each mineral paired with its safe text color for both themes. */
+  contrastPairs: {
+    dark: {
+      malachite: { bg: "#64FFDA", text: "#0A0A0A", ratio: 15.9 },
+      cobalt: { bg: "#00B0FF", text: "#0A0A0A", ratio: 8.2 },
+      tanzanite: { bg: "#B388FF", text: "#0A0A0A", ratio: 7.4 },
+      gold: { bg: "#FFD740", text: "#0A0A0A", ratio: 14.2 },
+      terracotta: { bg: "#D4A574", text: "#0A0A0A", ratio: 8.9 },
+    },
+    light: {
+      malachite: { bg: "#004D40", text: "#FFFFFF", ratio: 9.1 },
+      cobalt: { bg: "#0047AB", text: "#FFFFFF", ratio: 7.3 },
+      tanzanite: { bg: "#4B0082", text: "#FFFFFF", ratio: 12.6 },
+      gold: { bg: "#5D4037", text: "#FFFFFF", ratio: 7.5 },
+      terracotta: { bg: "#8B4513", text: "#FFFFFF", ratio: 6.8 },
+    },
+  },
+
+  /** Screen reader text for trust/verification tiers */
+  trustAnnouncements: {
+    unverified: "Unverified account",
+    community: "Community verified — trust level one of four",
+    otp: "Contact verified — trust level two of four",
+    government: "Government verified — trust level three of four",
+    licensed: "Licensed professional — trust level four of four, highest tier",
+    suspended: "Account suspended",
+    ancestral: "Memorial account",
+  },
+} as const
+
+// ─── FOCUS TRAP ────────────────────────────────────────────
+// Contains tab focus within a boundary (modals, drawers, overlays).
+// Traps focus on mount, restores previous focus on unmount.
+
+interface FocusTrapProps {
+  children: React.ReactNode
+  /** Whether the trap is active */
+  active?: boolean
+  /** Restore focus to previously focused element on unmount */
+  restoreFocus?: boolean
+  className?: string
+}
+
+export function FocusTrap({
+  children,
+  active = true,
+  restoreFocus = true,
+  className,
+}: FocusTrapProps) {
+  const containerRef = React.useRef<HTMLDivElement>(null)
+  const previousFocusRef = React.useRef<HTMLElement | null>(null)
+
+  React.useEffect(() => {
+    if (!active) return
+    previousFocusRef.current = document.activeElement as HTMLElement
+
+    const container = containerRef.current
+    if (!container) return
+
+    // Focus first focusable element
+    const focusable = container.querySelectorAll<HTMLElement>(
+      'a[href], button:not(:disabled), input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
+    )
+    if (focusable.length > 0) focusable[0].focus()
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Tab" || !container) return
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last?.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first?.focus()
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown)
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown)
+      if (restoreFocus && previousFocusRef.current) previousFocusRef.current.focus()
+    }
+  }, [active, restoreFocus])
+
+  return (
+    <div ref={containerRef} className={className}>
+      {children}
+    </div>
+  )
+}
+
+// ─── LIVE REGION ───────────────────────────────────────────
+// Screen reader announcement zone for dynamic content.
+// Renders a visually hidden aria-live region that announces
+// changes to assistive technology.
+
+interface LiveRegionProps {
+  /** The message to announce */
+  message: string
+  /** Politeness level: polite waits, assertive interrupts */
+  politeness?: "polite" | "assertive"
+  className?: string
+}
+
+export function LiveRegion({ message, politeness = "polite", className }: LiveRegionProps) {
+  return (
+    <div
+      role="status"
+      aria-live={politeness}
+      aria-atomic="true"
+      className={cn(
+        "absolute -m-px size-px overflow-hidden border-0 p-0 whitespace-nowrap",
+        "[clip:rect(0,0,0,0)]",
+        className
+      )}
+    >
+      {message}
+    </div>
+  )
+}
+
+// ─── useAnnounce HOOK ──────────────────────────────────────
+// Imperatively announce a message to screen readers.
+// Use for: trust score changes, notification arrivals,
+// loading completions, RSVP confirmations, etc.
+
+export function useAnnounce() {
+  const [message, setMessage] = React.useState("")
+  const [politeness, setPoliteness] = React.useState<"polite" | "assertive">("polite")
+
+  const announce = React.useCallback((msg: string, level: "polite" | "assertive" = "polite") => {
+    // Clear then set to force re-announcement of same message
+    setMessage("")
+    setPoliteness(level)
+    requestAnimationFrame(() => setMessage(msg))
+  }, [])
+
+  const Region = React.useMemo(
+    () => <LiveRegion message={message} politeness={politeness} />,
+    [message, politeness]
+  )
+
+  return { announce, Region }
+}
+
+// ─── SKIP NAV ──────────────────────────────────────────────
+// Keyboard shortcut link that skips past navigation to main content.
+// Visually hidden until focused.
+
+interface SkipNavProps {
+  /** ID of the main content container to skip to */
+  contentId?: string
+  /** Skip link text */
+  label?: string
+}
+
+export function SkipNav({ contentId = "main-content", label = "Skip to content" }: SkipNavProps) {
+  return (
+    <a
+      href={`#${contentId}`}
+      className={cn(
+        "fixed top-4 left-4 z-[100] -translate-y-full rounded-full px-4 py-2",
+        "bg-[var(--color-primary)] text-sm font-semibold text-[var(--color-background)]",
+        "transition-transform focus:translate-y-0",
+        "outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-2"
+      )}
+    >
+      {label}
+    </a>
+  )
+}
+
+// ─── VISUALLY HIDDEN ───────────────────────────────────────
+// Content visible only to screen readers, not sighted users.
+// Use for: additional context, relationship descriptions,
+// trust tier explanations, action confirmations.
+
+export function VisuallyHidden({ children, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      {...props}
+      className={cn(
+        "absolute -m-px size-px overflow-hidden border-0 p-0 whitespace-nowrap",
+        "[clip:rect(0,0,0,0)]",
+        props.className
+      )}
+    >
+      {children}
+    </span>
+  )
+}
+
+export type { FocusTrapProps, LiveRegionProps, SkipNavProps }

--- a/lib/bulkhead.ts
+++ b/lib/bulkhead.ts
@@ -1,0 +1,196 @@
+/**
+ * Bulkhead pattern for the Nyuchi ecosystem.
+ * Inspired by Resilience4j Bulkhead — limits concurrent calls to a dependency
+ * so one slow service cannot starve all available connections.
+ *
+ * Named after ship bulkheads: isolated compartments that prevent a single
+ * breach from flooding the entire vessel.
+ *
+ * Two modes:
+ * - Semaphore: limits max concurrent executions (default)
+ * - Queue: limits max concurrent + max waiting in queue
+ *
+ * Install via: npx shadcn@latest add https://design.nyuchi.com/api/v1/ui/bulkhead
+ */
+
+import { createLogger } from "@/lib/observability"
+
+const logger = createLogger("bulkhead")
+
+export interface BulkheadConfig {
+  /** Identifier for this bulkhead (e.g., "supabase-queries", "api-calls") */
+  name: string
+  /** Maximum number of concurrent executions allowed (default: 10) */
+  maxConcurrent: number
+  /** Maximum number of calls waiting in queue when at capacity (default: 0 = no queue, reject immediately) */
+  maxQueue: number
+  /** Maximum time in ms a call can wait in the queue before being rejected (default: 5000) */
+  maxQueueWaitMs: number
+  /** Called when a call is rejected due to bulkhead full */
+  onReject?: (name: string, concurrent: number, queued: number) => void
+}
+
+const DEFAULT_CONFIG: Omit<BulkheadConfig, "name"> = {
+  maxConcurrent: 10,
+  maxQueue: 0,
+  maxQueueWaitMs: 5_000,
+}
+
+/**
+ * Error thrown when the bulkhead rejects a call because it is at capacity.
+ */
+export class BulkheadFullError extends Error {
+  readonly bulkheadName: string
+  readonly concurrent: number
+  readonly queued: number
+
+  constructor(name: string, concurrent: number, queued: number) {
+    super(`Bulkhead "${name}" is full — ${concurrent} concurrent, ${queued} queued`)
+    this.name = "BulkheadFullError"
+    this.bulkheadName = name
+    this.concurrent = concurrent
+    this.queued = queued
+  }
+}
+
+/**
+ * Bulkhead that limits concurrent access to a resource.
+ *
+ * @example
+ * ```ts
+ * import { Bulkhead } from "@/lib/bulkhead"
+ *
+ * // Allow max 5 concurrent Supabase queries
+ * const dbBulkhead = new Bulkhead({ name: "supabase", maxConcurrent: 5 })
+ *
+ * // With queue: allow 5 concurrent, 10 waiting
+ * const apiBulkhead = new Bulkhead({ name: "external-api", maxConcurrent: 5, maxQueue: 10 })
+ *
+ * try {
+ *   const data = await dbBulkhead.execute(() => supabase.from("events").select("*"))
+ * } catch (error) {
+ *   if (error instanceof BulkheadFullError) {
+ *     // All slots occupied — show cached data or queue message
+ *   }
+ * }
+ * ```
+ */
+export class Bulkhead {
+  private activeCalls = 0
+  private waitingQueue: Array<{
+    resolve: () => void
+    reject: (err: Error) => void
+    timer: ReturnType<typeof setTimeout>
+  }> = []
+  private readonly config: BulkheadConfig
+
+  constructor(config: Partial<BulkheadConfig> & { name: string }) {
+    this.config = { ...DEFAULT_CONFIG, ...config }
+  }
+
+  /** Current number of active concurrent executions */
+  get concurrent(): number {
+    return this.activeCalls
+  }
+
+  /** Current number of calls waiting in queue */
+  get queued(): number {
+    return this.waitingQueue.length
+  }
+
+  /** Whether the bulkhead can accept another call */
+  get isAvailable(): boolean {
+    return (
+      this.activeCalls < this.config.maxConcurrent ||
+      this.waitingQueue.length < this.config.maxQueue
+    )
+  }
+
+  /** Metrics snapshot */
+  get metrics() {
+    return {
+      name: this.config.name,
+      concurrent: this.activeCalls,
+      queued: this.waitingQueue.length,
+      maxConcurrent: this.config.maxConcurrent,
+      maxQueue: this.config.maxQueue,
+      utilization: this.activeCalls / this.config.maxConcurrent,
+    }
+  }
+
+  /**
+   * Execute a function within the bulkhead.
+   * If at capacity, either queues (if maxQueue > 0) or rejects immediately.
+   */
+  async execute<T>(fn: () => Promise<T>): Promise<T> {
+    // If under capacity, execute immediately
+    if (this.activeCalls < this.config.maxConcurrent) {
+      return this.executeProtected(fn)
+    }
+
+    // If no queue configured or queue full, reject
+    if (this.config.maxQueue <= 0 || this.waitingQueue.length >= this.config.maxQueue) {
+      const error = new BulkheadFullError(
+        this.config.name,
+        this.activeCalls,
+        this.waitingQueue.length
+      )
+      logger.warn("Call rejected — bulkhead full", {
+        data: {
+          name: this.config.name,
+          concurrent: this.activeCalls,
+          queued: this.waitingQueue.length,
+        },
+      })
+      this.config.onReject?.(this.config.name, this.activeCalls, this.waitingQueue.length)
+      throw error
+    }
+
+    // Queue the call
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        // Remove from queue on timeout
+        this.waitingQueue = this.waitingQueue.filter((w) => w.timer !== timer)
+        reject(new BulkheadFullError(this.config.name, this.activeCalls, this.waitingQueue.length))
+      }, this.config.maxQueueWaitMs)
+
+      this.waitingQueue.push({
+        resolve: () => {
+          clearTimeout(timer)
+          this.executeProtected(fn).then(resolve, reject)
+        },
+        reject: (err: Error) => {
+          clearTimeout(timer)
+          reject(err)
+        },
+        timer,
+      })
+
+      logger.info("Call queued", {
+        data: {
+          name: this.config.name,
+          queuePosition: this.waitingQueue.length,
+          concurrent: this.activeCalls,
+        },
+      })
+    })
+  }
+
+  private async executeProtected<T>(fn: () => Promise<T>): Promise<T> {
+    this.activeCalls++
+    try {
+      const result = await fn()
+      return result
+    } finally {
+      this.activeCalls--
+      this.dequeueNext()
+    }
+  }
+
+  private dequeueNext(): void {
+    if (this.waitingQueue.length > 0 && this.activeCalls < this.config.maxConcurrent) {
+      const next = this.waitingQueue.shift()
+      next?.resolve()
+    }
+  }
+}

--- a/lib/chaos.ts
+++ b/lib/chaos.ts
@@ -1,0 +1,153 @@
+/**
+ * Chaos testing utilities for the Nyuchi ecosystem.
+ *
+ * Netflix chaos engineering patterns for testing application resilience.
+ * Inject random errors and latency to verify that circuit breakers,
+ * fallback chains, and error boundaries work under stress.
+ *
+ * SAFETY: All chaos functions are disabled by default. You must explicitly
+ * set `enabled: true` to activate them. Never enable in production.
+ *
+ * Install via: npx shadcn@latest add https://design.nyuchi.com/api/v1/ui/chaos
+ */
+
+import { createLogger } from "@/lib/observability"
+
+const logger = createLogger("chaos")
+
+export interface ChaosConfig {
+  /** Master kill switch — chaos functions are no-ops when false (default: false) */
+  enabled: boolean
+  /** Probability of injecting an error, 0–1 (default: 0.3 = 30%) */
+  errorRate: number
+  /** Range for random latency injection in ms [min, max] (default: [100, 500]) */
+  latencyMs: [number, number]
+}
+
+const DEFAULT_CONFIG: ChaosConfig = {
+  enabled: false,
+  errorRate: 0.3,
+  latencyMs: [100, 500],
+}
+
+/**
+ * Error injected by chaos testing. Distinguishable from real errors.
+ */
+export class ChaosError extends Error {
+  readonly injected = true as const
+  readonly chaosType: "error" | "latency"
+
+  constructor(type: "error" | "latency", message?: string) {
+    super(message ?? `Chaos ${type} injected`)
+    this.name = "ChaosError"
+    this.chaosType = type
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Wrap an async function with chaos injection.
+ *
+ * When enabled, randomly:
+ * - Throws a ChaosError based on `errorRate`
+ * - Adds random latency within `latencyMs` range
+ *
+ * When disabled (default), the function passes through unchanged.
+ *
+ * @example
+ * ```ts
+ * import { withChaos } from "@/lib/chaos"
+ *
+ * // In development/testing only
+ * const data = await withChaos(
+ *   () => fetch("/api/weather"),
+ *   { enabled: process.env.NODE_ENV === "development", errorRate: 0.5 }
+ * )
+ *
+ * // Combined with circuit breaker for resilience testing
+ * const result = await breaker.execute(() =>
+ *   withChaos(() => fetchProvider(), { enabled: true, errorRate: 0.4 })
+ * )
+ * ```
+ */
+export async function withChaos<T>(
+  fn: () => Promise<T>,
+  config?: Partial<ChaosConfig>
+): Promise<T> {
+  const cfg = { ...DEFAULT_CONFIG, ...config }
+
+  if (!cfg.enabled) {
+    return fn()
+  }
+
+  // Random error injection
+  if (Math.random() < cfg.errorRate) {
+    logger.warn("Injecting random error", {
+      data: { errorRate: cfg.errorRate },
+    })
+    throw new ChaosError(
+      "error",
+      `Chaos: random failure (${Math.round(cfg.errorRate * 100)}% rate)`
+    )
+  }
+
+  // Random latency injection
+  const [minLatency, maxLatency] = cfg.latencyMs
+  const latency = Math.round(minLatency + Math.random() * (maxLatency - minLatency))
+  if (latency > 0) {
+    logger.info(`Injecting ${latency}ms latency`, {
+      data: { latencyMs: latency, range: cfg.latencyMs },
+    })
+    await sleep(latency)
+  }
+
+  return fn()
+}
+
+/**
+ * Create a chaos middleware function with fixed configuration.
+ *
+ * @example
+ * ```ts
+ * import { chaosMiddleware } from "@/lib/chaos"
+ *
+ * const devChaos = chaosMiddleware({
+ *   enabled: true,
+ *   errorRate: 0.2,
+ *   latencyMs: [50, 200],
+ * })
+ *
+ * // Wrap any operation
+ * const data = await devChaos(() => fetchWeather())
+ * const user = await devChaos(() => getUser(id))
+ * ```
+ */
+export function chaosMiddleware(
+  config?: Partial<ChaosConfig>
+): <T>(fn: () => Promise<T>) => Promise<T> {
+  return <T>(fn: () => Promise<T>) => withChaos(fn, config)
+}
+
+/**
+ * Create a chaos-wrapped version of a function for testing.
+ *
+ * @example
+ * ```ts
+ * const riskyFetch = chaosWrap(
+ *   (url: string) => fetch(url).then(r => r.json()),
+ *   { enabled: true, errorRate: 0.5 }
+ * )
+ *
+ * // Use like the original function — chaos is injected transparently
+ * const data = await riskyFetch("/api/data")
+ * ```
+ */
+export function chaosWrap<TArgs extends unknown[], TResult>(
+  fn: (...args: TArgs) => Promise<TResult>,
+  config?: Partial<ChaosConfig>
+): (...args: TArgs) => Promise<TResult> {
+  return (...args: TArgs) => withChaos(() => fn(...args), config)
+}

--- a/lib/circuit-breaker.ts
+++ b/lib/circuit-breaker.ts
@@ -1,0 +1,217 @@
+/**
+ * Netflix Hystrix-inspired circuit breaker for the Nyuchi ecosystem.
+ *
+ * Prevents cascading failures by tracking error rates per external dependency
+ * and short-circuiting calls when a provider is unhealthy. Ported from
+ * mukoko-weather's production Python implementation.
+ *
+ * State machine: CLOSED → OPEN → HALF_OPEN → CLOSED (success) or OPEN (failure)
+ *
+ * Install via: npx shadcn@latest add https://design.nyuchi.com/api/v1/ui/circuit-breaker
+ */
+
+import { withTimeout } from "@/lib/timeout"
+import { createLogger } from "@/lib/observability"
+
+const logger = createLogger("circuit-breaker")
+
+export type CircuitState = "closed" | "open" | "half_open"
+
+export interface CircuitBreakerConfig {
+  /** Identifier for this breaker (e.g., "tomorrow-io", "mongodb") */
+  name: string
+  /** Number of failures within windowMs before opening the circuit (default: 3) */
+  failureThreshold: number
+  /** Time in ms to stay OPEN before transitioning to HALF_OPEN (default: 30000) */
+  cooldownMs: number
+  /** Sliding window in ms for counting failures (default: 60000) */
+  windowMs: number
+  /** Per-call timeout in ms — calls exceeding this are treated as failures (default: 5000) */
+  timeoutMs: number
+  /** Optional callback when the circuit changes state */
+  onStateChange?: (from: CircuitState, to: CircuitState, name: string) => void
+}
+
+const DEFAULT_CONFIG: Omit<CircuitBreakerConfig, "name"> = {
+  failureThreshold: 3,
+  cooldownMs: 30_000,
+  windowMs: 60_000,
+  timeoutMs: 5_000,
+}
+
+/**
+ * Pre-configured breaker settings for common Nyuchi providers.
+ * Based on production tuning from mukoko-weather.
+ */
+export const PROVIDER_CONFIGS = {
+  /** Tomorrow.io: aggressive — fails fast, recovers quickly */
+  "tomorrow-io": { failureThreshold: 3, cooldownMs: 120_000, windowMs: 300_000, timeoutMs: 5_000 },
+  /** Open-Meteo: lenient — tolerates more failures, longer cooldown */
+  "open-meteo": { failureThreshold: 5, cooldownMs: 300_000, windowMs: 300_000, timeoutMs: 8_000 },
+  /** Anthropic Claude: conservative — protect AI budget */
+  anthropic: { failureThreshold: 3, cooldownMs: 300_000, windowMs: 600_000, timeoutMs: 15_000 },
+  /** MongoDB: very lenient — database should be highly available */
+  mongodb: { failureThreshold: 5, cooldownMs: 60_000, windowMs: 120_000, timeoutMs: 10_000 },
+} as const satisfies Record<string, Omit<CircuitBreakerConfig, "name">>
+
+/**
+ * Error thrown when a call is rejected because the circuit is open.
+ */
+export class CircuitOpenError extends Error {
+  readonly breakerName: string
+  readonly state: CircuitState
+
+  constructor(name: string) {
+    super(`Circuit breaker "${name}" is open — call rejected`)
+    this.name = "CircuitOpenError"
+    this.breakerName = name
+    this.state = "open"
+  }
+}
+
+/**
+ * Circuit breaker that wraps async operations with failure tracking and
+ * automatic short-circuiting.
+ *
+ * @example
+ * ```ts
+ * import { CircuitBreaker, PROVIDER_CONFIGS } from "@/lib/circuit-breaker"
+ *
+ * const weatherBreaker = new CircuitBreaker({
+ *   name: "tomorrow-io",
+ *   ...PROVIDER_CONFIGS["tomorrow-io"],
+ * })
+ *
+ * try {
+ *   const data = await weatherBreaker.execute(() =>
+ *     fetch("https://api.tomorrow.io/v4/weather/forecast")
+ *   )
+ * } catch (error) {
+ *   if (error instanceof CircuitOpenError) {
+ *     // Circuit is open — use fallback
+ *     return getCachedWeather()
+ *   }
+ * }
+ * ```
+ */
+export class CircuitBreaker {
+  private _state: CircuitState = "closed"
+  private failures: number[] = [] // timestamps of recent failures
+  private lastFailureTime = 0
+  private readonly config: CircuitBreakerConfig
+
+  constructor(config: Partial<CircuitBreakerConfig> & { name: string }) {
+    this.config = { ...DEFAULT_CONFIG, ...config }
+  }
+
+  /** Current circuit state */
+  get state(): CircuitState {
+    this.evaluateState()
+    return this._state
+  }
+
+  /** Whether the circuit will allow the next call through */
+  get isAllowed(): boolean {
+    this.evaluateState()
+    return this._state !== "open"
+  }
+
+  /** Number of failures in the current sliding window */
+  get failureCount(): number {
+    this.pruneOldFailures()
+    return this.failures.length
+  }
+
+  /**
+   * Execute an async function through the circuit breaker.
+   *
+   * - If CLOSED: executes normally, tracks failures
+   * - If OPEN: rejects immediately with CircuitOpenError
+   * - If HALF_OPEN: allows one probe call — success closes, failure re-opens
+   */
+  async execute<T>(fn: () => Promise<T>): Promise<T> {
+    this.evaluateState()
+
+    if (this._state === "open") {
+      logger.warn(`Call rejected — circuit open`, {
+        data: { name: this.config.name, failureCount: this.failures.length },
+      })
+      throw new CircuitOpenError(this.config.name)
+    }
+
+    try {
+      const result = await withTimeout(fn, this.config.timeoutMs, this.config.name)
+      this.recordSuccess()
+      return result
+    } catch (error) {
+      this.recordFailure()
+      throw error
+    }
+  }
+
+  /** Manually reset the circuit to CLOSED state */
+  reset(): void {
+    const prev = this._state
+    this._state = "closed"
+    this.failures = []
+    this.lastFailureTime = 0
+    if (prev !== "closed") {
+      this.transition(prev, "closed")
+    }
+  }
+
+  private evaluateState(): void {
+    const now = Date.now()
+    this.pruneOldFailures()
+
+    if (this._state === "closed") {
+      if (this.failures.length >= this.config.failureThreshold) {
+        this.transition("closed", "open")
+        this._state = "open"
+      }
+    } else if (this._state === "open") {
+      if (now - this.lastFailureTime >= this.config.cooldownMs) {
+        this.transition("open", "half_open")
+        this._state = "half_open"
+      }
+    }
+    // half_open stays until success (→ closed) or failure (→ open)
+  }
+
+  private recordSuccess(): void {
+    if (this._state === "half_open") {
+      this.transition("half_open", "closed")
+      this._state = "closed"
+      this.failures = []
+    }
+  }
+
+  private recordFailure(): void {
+    const now = Date.now()
+    this.failures.push(now)
+    this.lastFailureTime = now
+
+    if (this._state === "half_open") {
+      this.transition("half_open", "open")
+      this._state = "open"
+    }
+  }
+
+  private pruneOldFailures(): void {
+    const cutoff = Date.now() - this.config.windowMs
+    this.failures = this.failures.filter((t) => t > cutoff)
+  }
+
+  private transition(from: CircuitState, to: CircuitState): void {
+    logger.info(`State transition: ${from} → ${to}`, {
+      data: {
+        name: this.config.name,
+        from,
+        to,
+        failureCount: this.failures.length,
+        threshold: this.config.failureThreshold,
+      },
+    })
+    this.config.onStateChange?.(from, to, this.config.name)
+  }
+}

--- a/lib/fallback-chain.ts
+++ b/lib/fallback-chain.ts
@@ -1,0 +1,119 @@
+/**
+ * Fallback chain for the Nyuchi ecosystem.
+ *
+ * Implements the sequential fallback strategy from mukoko-weather:
+ * try stages in order, return the first success. Each stage has an
+ * independent timeout. If all stages fail, throw with all collected errors.
+ *
+ * Production example from mukoko-weather:
+ *   MongoDB cache (15min TTL) → Tomorrow.io → Open-Meteo → seasonal estimates
+ *
+ * Install via: npx shadcn@latest add https://design.nyuchi.com/api/v1/ui/fallback-chain
+ */
+
+import { withTimeout, TimeoutError } from "@/lib/timeout"
+import { createLogger } from "@/lib/observability"
+
+const logger = createLogger("fallback")
+
+export interface FallbackStage<T> {
+  /** Human-readable name for logging (e.g., "mongodb-cache", "tomorrow-io") */
+  name: string
+  /** The async operation to attempt */
+  execute: () => Promise<T>
+  /** Per-stage timeout in ms (default: no timeout) */
+  timeoutMs?: number
+}
+
+/**
+ * Error thrown when all fallback stages fail.
+ */
+export class AllStagesFailedError extends Error {
+  readonly stageErrors: Array<{ stage: string; error: unknown }>
+
+  constructor(stageErrors: Array<{ stage: string; error: unknown }>) {
+    const names = stageErrors.map((s) => s.stage).join(" → ")
+    super(`All fallback stages failed: ${names}`)
+    this.name = "AllStagesFailedError"
+    this.stageErrors = stageErrors
+  }
+}
+
+/**
+ * Execute stages in order, returning the first successful result.
+ *
+ * @example
+ * ```ts
+ * import { withFallback } from "@/lib/fallback-chain"
+ *
+ * // Weather data fallback (from mukoko-weather production)
+ * const weather = await withFallback([
+ *   {
+ *     name: "mongodb-cache",
+ *     execute: () => getCachedWeather(slug),
+ *     timeoutMs: 2000,
+ *   },
+ *   {
+ *     name: "tomorrow-io",
+ *     execute: () => fetchTomorrowIO(lat, lon),
+ *     timeoutMs: 5000,
+ *   },
+ *   {
+ *     name: "open-meteo",
+ *     execute: () => fetchOpenMeteo(lat, lon),
+ *     timeoutMs: 8000,
+ *   },
+ *   {
+ *     name: "seasonal-estimate",
+ *     execute: () => getSeasonalEstimate(lat, lon, month),
+ *   },
+ * ])
+ * ```
+ */
+export async function withFallback<T>(stages: FallbackStage<T>[]): Promise<T> {
+  if (stages.length === 0) {
+    throw new Error("withFallback requires at least one stage")
+  }
+
+  const errors: Array<{ stage: string; error: unknown }> = []
+
+  for (const stage of stages) {
+    try {
+      const result = stage.timeoutMs
+        ? await withTimeout(stage.execute, stage.timeoutMs, stage.name)
+        : await stage.execute()
+
+      logger.info(`Stage "${stage.name}" succeeded`, {
+        data: {
+          stage: stage.name,
+          attemptNumber: errors.length + 1,
+          totalStages: stages.length,
+        },
+      })
+
+      return result
+    } catch (error) {
+      const isTimeout = error instanceof TimeoutError
+      errors.push({ stage: stage.name, error })
+
+      logger.warn(`Stage "${stage.name}" failed${isTimeout ? " (timeout)" : ""}`, {
+        data: {
+          stage: stage.name,
+          attemptNumber: errors.length,
+          totalStages: stages.length,
+          isTimeout,
+        },
+        error: error instanceof Error ? error : new Error(String(error)),
+      })
+    }
+  }
+
+  logger.error("All fallback stages exhausted", {
+    data: {
+      stages: errors.map((e) => e.stage),
+      totalStages: stages.length,
+    },
+  })
+
+  throw new AllStagesFailedError(errors)
+}

--- a/lib/harness/index.tsx
+++ b/lib/harness/index.tsx
@@ -1,0 +1,517 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+/* ═══════════════════════════════════════════════════════════════
+   NYUCHI COMPONENT HARNESS — Zero-Config Infrastructure Wiring
+   
+   The vertical spine that connects Layers 3, 4, and 5 to
+   infrastructure. Every brand component (L3), safety gate (L4),
+   and resilience wrapper (L5) uses the harness for:
+   
+   - Observability (scoped logging, render timing, health reporting)
+   - Accessibility (LiveRegion auto-mount, announce(), focus ring)
+   - Motion (enter animations, reduced-motion, stagger)
+   
+   Layer 2 (primitives) does NOT use the harness — raw building blocks.
+   Layer 1 (tokens) does NOT use the harness — pure data.
+   
+   TWO USAGE PATTERNS:
+   
+   1. NyuchiHarness — declarative wrapper for page sections:
+      <NyuchiHarness name="events-feed" skeleton={<FeedSkeleton />}>
+        <EventsFeed />
+      </NyuchiHarness>
+   
+   2. useNyuchiHarness — imperative hook for L3/L4/L5 components:
+      function NyuchiListingCard(props) {            // L3 Brand
+        const { log, motion, announce } = useNyuchiHarness("listing-card")
+      }
+      function NyuchiPermissionGate(props) {          // L4 Safety
+        const { log, motion, announce } = useNyuchiHarness("permission-gate")
+      }
+      function NyuchiSection(props) {                 // L5 Resilience
+        const { log, motion, announce } = useNyuchiHarness("section")
+      }
+   
+   WHAT THE HARNESS PROVIDES:
+   
+   1. OBSERVABILITY — Scoped logger for the component, render timing
+      reported to health monitor, errors tracked with structured context
+   
+   2. ERROR BOUNDARY — React error boundary with branded fallback
+      (mineral-colored error card, retry button, error count tracking)
+   
+   3. MOTION — Entry animation on mount using the motion token system,
+      respects prefers-reduced-motion automatically
+   
+   4. A11Y — Focus ring CSS variables applied, aria-live region for
+      dynamic announcements, screen reader text for trust/verification
+   
+   5. TOKENS — Verifies CSS custom properties are present (theme
+      provider is mounted), warns in dev if tokens are missing
+   
+   6. HEALTH — Reports section status (healthy/degraded/error/loading)
+      to the global NyuchiHealthMonitor singleton
+   
+   7. LOCALE — Provides text direction (RTL/LTR) and string token
+      accessor via useLocale
+   ═══════════════════════════════════════════════════════════════ */
+
+// ─── SCOPED LOGGER (from observability) ────────────────────
+// Each component gets its own logger prefixed with the component name.
+
+interface ScopedLogger {
+  debug: (message: string, data?: Record<string, unknown>) => void
+  info: (message: string, data?: Record<string, unknown>) => void
+  warn: (message: string, data?: Record<string, unknown>) => void
+  error: (message: string, error?: Error, data?: Record<string, unknown>) => void
+}
+
+function createScopedLogger(componentName: string): ScopedLogger {
+  const prefix = `[mukoko:${componentName}]`
+  return {
+    // eslint-disable-next-line no-console -- logger wrapper forwards debug/info to console
+    debug: (msg, data) => console.debug(`${prefix} ${msg}`, data || ""),
+    // eslint-disable-next-line no-console -- logger wrapper forwards debug/info to console
+    info: (msg, data) => console.info(`${prefix} ${msg}`, data || ""),
+    warn: (msg, data) => console.warn(`${prefix} ${msg}`, data || ""),
+    error: (msg, err, data) => console.error(`${prefix} ${msg}`, err || "", data || ""),
+  }
+}
+
+// ─── MOTION CONFIG (from nyuchi-motion) ────────────────────
+// Provides the correct duration/easing for the current user preference.
+
+interface MotionConfig {
+  /** Whether user prefers reduced motion */
+  prefersReduced: boolean
+  /** Duration for entry animations (0 if reduced motion) */
+  enterDuration: number
+  /** Duration for exit animations */
+  exitDuration: number
+  /** CSS easing for entry */
+  enterEasing: string
+  /** CSS easing for exit */
+  exitEasing: string
+  /** Get stagger delay for item at index in a list */
+  staggerDelay: (index: number) => number
+  /** CSS class for entry animation */
+  enterClass: string
+}
+
+function getMotionConfig(): MotionConfig {
+  const prefersReduced =
+    typeof window !== "undefined"
+      ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      : false
+
+  return {
+    prefersReduced,
+    enterDuration: prefersReduced ? 0 : 200,
+    exitDuration: prefersReduced ? 0 : 100,
+    enterEasing: prefersReduced ? "linear" : "cubic-bezier(0, 0, 0.2, 1)",
+    exitEasing: prefersReduced ? "linear" : "cubic-bezier(0.4, 0, 1, 1)",
+    staggerDelay: (index: number) => (prefersReduced ? 0 : Math.min(index, 8) * 50),
+    enterClass: prefersReduced ? "" : "nyuchi-animate-in",
+  }
+}
+
+// ─── ANNOUNCER (from nyuchi-a11y) ──────────────────────────
+// Imperative screen reader announcements for dynamic content.
+
+interface Announcer {
+  /** Announce a message to screen readers (polite — waits for current speech) */
+  announce: (message: string) => void
+  /** Announce urgently (assertive — interrupts current speech) */
+  announceUrgent: (message: string) => void
+  /** The live region element to render (must be in the DOM) */
+  LiveRegion: React.ReactNode
+}
+
+function useAnnouncer(): Announcer {
+  const [message, setMessage] = React.useState("")
+  const [politeness, setPoliteness] = React.useState<"polite" | "assertive">("polite")
+  const portalRef = React.useRef<HTMLDivElement | null>(null)
+
+  // Auto-mount LiveRegion via Portal — components no longer need to render <LiveRegion />
+  React.useEffect(() => {
+    if (typeof document === "undefined") return
+    let el = document.getElementById("nyuchi-live-region")
+    if (!el) {
+      el = document.createElement("div")
+      el.id = "nyuchi-live-region"
+      el.setAttribute("role", "status")
+      el.setAttribute("aria-live", "polite")
+      el.setAttribute("aria-atomic", "true")
+      el.className = "sr-only"
+      document.body.appendChild(el)
+    }
+    portalRef.current = el as HTMLDivElement
+    return () => {
+      /* keep mounted — shared across components */
+    }
+  }, [])
+
+  const announce = React.useCallback((msg: string) => {
+    setMessage("")
+    setPoliteness("polite")
+    requestAnimationFrame(() => {
+      setMessage(msg)
+      if (portalRef.current) {
+        portalRef.current.setAttribute("aria-live", "polite")
+        portalRef.current.textContent = msg
+      }
+    })
+  }, [])
+
+  const announceUrgent = React.useCallback((msg: string) => {
+    setMessage("")
+    setPoliteness("assertive")
+    requestAnimationFrame(() => {
+      setMessage(msg)
+      if (portalRef.current) {
+        portalRef.current.setAttribute("aria-live", "assertive")
+        portalRef.current.textContent = msg
+      }
+    })
+  }, [])
+
+  const LiveRegion = React.useMemo(
+    () => (
+      <div
+        role="status"
+        aria-live={politeness}
+        aria-atomic="true"
+        style={{
+          position: "absolute",
+          width: 1,
+          height: 1,
+          margin: -1,
+          padding: 0,
+          overflow: "hidden",
+          clip: "rect(0,0,0,0)",
+          whiteSpace: "nowrap",
+          border: 0,
+        }}
+      >
+        {message}
+      </div>
+    ),
+    [message, politeness]
+  )
+
+  return { announce, announceUrgent, LiveRegion }
+}
+
+// ─── HEALTH REPORTER ───────────────────────────────────────
+// Reports component health to the global singleton.
+
+type HealthStatus = "healthy" | "degraded" | "error" | "loading"
+
+interface HealthReporter {
+  reportHealthy: () => void
+  reportDegraded: (reason?: string) => void
+  reportError: (error: Error) => void
+  reportLoading: () => void
+}
+
+function useHealthReporter(componentName: string): HealthReporter {
+  // In a full implementation, this writes to the HealthMonitor singleton
+  // from nyuchi-resilience. For now, it logs structured health events
+  // that the monitor can pick up.
+  const log = createScopedLogger(componentName)
+
+  return {
+    reportHealthy: () => log.debug("status: healthy"),
+    reportDegraded: (reason) => log.warn(`status: degraded${reason ? ` — ${reason}` : ""}`),
+    reportError: (error) => log.error("status: error", error),
+    reportLoading: () => log.debug("status: loading"),
+  }
+}
+
+// ─── TOKEN VERIFIER ────────────────────────────────────────
+// Dev-only check that CSS custom properties are present.
+
+function useTokenVerifier(componentName: string) {
+  React.useEffect(() => {
+    if (process.env.NODE_ENV !== "development") return
+    if (typeof window === "undefined") return
+
+    const root = document.documentElement
+    const style = getComputedStyle(root)
+
+    const requiredTokens = [
+      "--color-malachite",
+      "--color-cobalt",
+      "--color-tanzanite",
+      "--color-gold",
+      "--color-terracotta",
+      "--radius-card",
+      "--radius-inner",
+      "--radius-pill",
+    ]
+
+    const missing = requiredTokens.filter((token) => {
+      const value = style.getPropertyValue(token).trim()
+      return !value
+    })
+
+    if (missing.length > 0) {
+      console.warn(
+        `[mukoko:${componentName}] Missing CSS tokens: ${missing.join(", ")}. ` +
+          `Wrap your app in <NyuchiThemeProvider> to inject design tokens.`
+      )
+    }
+  }, [componentName])
+}
+
+// ─── useNyuchiHarness HOOK ──────────────────────────────
+// The imperative API for leaf components.
+// Use this inside any brand component to get the full infrastructure.
+
+export interface ComponentHarnessResult {
+  /** Scoped observability logger */
+  log: ScopedLogger
+  /** Motion configuration respecting user preferences */
+  motion: MotionConfig
+  /** Screen reader announcer */
+  announce: (message: string) => void
+  announceUrgent: (message: string) => void
+  /** Health reporter */
+  health: HealthReporter
+  /** Live region element (render this in the component) */
+  LiveRegion: React.ReactNode
+  /** Render timing tracker — call at start of render */
+  trackRenderStart: () => void
+  /** Render timing tracker — call at end of render (useEffect) */
+  trackRenderEnd: () => void
+  /** data-portal attribute map (empty off-domain for privacy). */
+  portalAttrs: Record<string, string>
+}
+
+// ─── PORTAL OBSERVABILITY (domain-gated) ─────────────────────
+// Portal links and observability only render on allowed domains.
+// This protects privacy: no tracking on unauthorized domains.
+// Domains are controlled via the observability_domains table.
+
+const INTERNAL_DOMAINS = ["nyuchi.com", "mukoko.com", "localhost"]
+
+function isPortalDomain(): boolean {
+  if (typeof window === "undefined") return false
+  const hostname = window.location.hostname
+  return INTERNAL_DOMAINS.some((d) => hostname === d || hostname.endsWith("." + d))
+}
+
+function getPortalAttrs(componentName: string): Record<string, string> {
+  if (!isPortalDomain()) return {}
+  return { "data-portal": `https://design.nyuchi.com/components/${componentName}` }
+}
+
+export function useNyuchiHarness(componentName: string): ComponentHarnessResult {
+  const log = React.useMemo(() => createScopedLogger(componentName), [componentName])
+  const motion = React.useMemo(() => getMotionConfig(), [])
+  const { announce, announceUrgent, LiveRegion } = useAnnouncer()
+  const health = useHealthReporter(componentName)
+  const renderStartRef = React.useRef(0)
+
+  // Token verification (dev only)
+  useTokenVerifier(componentName)
+
+  // Report healthy on mount
+  React.useEffect(() => {
+    health.reportHealthy()
+    log.debug("mounted")
+    return () => {
+      log.debug("unmounted")
+    }
+  }, [])
+
+  const trackRenderStart = React.useCallback(() => {
+    renderStartRef.current = performance.now()
+  }, [])
+
+  const trackRenderEnd = React.useCallback(() => {
+    if (renderStartRef.current > 0) {
+      const duration = Math.round((performance.now() - renderStartRef.current) * 100) / 100
+      if (duration > 16) {
+        // Only log slow renders (>1 frame)
+        log.warn(`slow render: ${duration}ms`, { duration })
+      }
+    }
+  }, [log])
+
+  const portalAttrs = React.useMemo(() => getPortalAttrs(componentName), [componentName])
+  return {
+    log,
+    motion,
+    announce,
+    announceUrgent,
+    health,
+    LiveRegion,
+    trackRenderStart,
+    trackRenderEnd,
+    portalAttrs,
+  }
+}
+
+// ─── NyuchiHarness COMPONENT ───────────────────────────────
+// The declarative wrapper for page sections.
+// Provides error boundary + skeleton + observability + motion.
+
+interface NyuchiHarnessProps {
+  /** Unique name for this section (used in logs and health reports) */
+  name: string
+  /** Content to render */
+  children: React.ReactNode
+  /** Whether the section is loading */
+  loading?: boolean
+  /** Custom skeleton for loading state */
+  skeleton?: React.ReactNode
+  /** Custom fallback for error state */
+  fallback?: React.ReactNode
+  /** Whether errors should bubble up instead of being caught */
+  critical?: boolean
+  /** Animate entry */
+  animate?: boolean
+  className?: string
+}
+
+interface HarnessState {
+  hasError: boolean
+  error: Error | null
+  retryCount: number
+}
+
+class NyuchiHarnessBoundary extends React.Component<NyuchiHarnessProps, HarnessState> {
+  private log: ScopedLogger
+  private renderStart = 0
+
+  constructor(props: NyuchiHarnessProps) {
+    super(props)
+    this.state = { hasError: false, error: null, retryCount: 0 }
+    this.log = createScopedLogger(props.name)
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<HarnessState> {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error) {
+    this.log.error("render crash", error, {
+      retryCount: this.state.retryCount,
+      componentStack: error.stack?.split("\\n").slice(0, 5),
+    })
+  }
+
+  componentDidMount() {
+    this.trackRender()
+    this.log.debug("mounted")
+  }
+
+  componentDidUpdate() {
+    this.trackRender()
+  }
+
+  componentWillUnmount() {
+    this.log.debug("unmounted")
+  }
+
+  private trackRender() {
+    if (this.renderStart > 0) {
+      const duration = Math.round((performance.now() - this.renderStart) * 100) / 100
+      if (duration > 16) {
+        this.log.warn(`slow render: ${duration}ms`)
+      }
+    }
+  }
+
+  private handleRetry = () => {
+    this.log.info(`retry attempt ${this.state.retryCount + 1}`)
+    this.setState((prev) => ({ hasError: false, error: null, retryCount: prev.retryCount + 1 }))
+  }
+
+  render() {
+    this.renderStart = performance.now()
+    const { name, children, loading, skeleton, fallback, critical, animate, className } = this.props
+
+    // Loading state
+    if (loading) {
+      return (
+        <div
+          data-slot="nyuchi-harness"
+          data-section={name}
+          data-status="loading"
+          className={className}
+          role="status"
+          aria-label={`${name} loading`}
+        >
+          {skeleton || (
+            <div className="animate-pulse rounded-[var(--radius-card,14px)] bg-card p-4 ring-1 ring-foreground/10">
+              <div className="h-4 w-2/3 rounded-[var(--radius-inner,7px)] bg-foreground/[0.06]" />
+              <div className="mt-2 h-3 w-full rounded-[var(--radius-inner,7px)] bg-foreground/[0.06]" />
+              <div className="mt-2 h-3 w-1/2 rounded-[var(--radius-inner,7px)] bg-foreground/[0.06]" />
+            </div>
+          )}
+        </div>
+      )
+    }
+
+    // Error state
+    if (this.state.hasError) {
+      if (critical) throw this.state.error
+
+      return (
+        <div
+          data-slot="nyuchi-harness"
+          data-section={name}
+          data-status="error"
+          data-retry-count={this.state.retryCount}
+          className={className}
+          role="alert"
+          aria-label={`${name} error`}
+        >
+          {fallback || (
+            <div className="flex flex-col items-center rounded-[var(--radius-card,14px)] bg-card px-6 py-6 text-center ring-1 ring-foreground/10">
+              <div className="mb-3 flex size-10 items-center justify-center rounded-full bg-[var(--color-terracotta,#D4A574)]/10">
+                <span className="text-lg text-[var(--color-terracotta,#D4A574)]">!</span>
+              </div>
+              <p className="text-sm font-medium text-foreground">{name} could not load</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {this.state.error?.message || "An unexpected error occurred"}
+              </p>
+              <button
+                onClick={this.handleRetry}
+                className={cn(
+                  "mt-4 flex h-9 items-center gap-2 rounded-full px-4 text-xs font-medium transition-colors",
+                  "border border-[var(--color-border,#2A2A2A)] text-foreground hover:bg-foreground/[0.05]"
+                )}
+              >
+                Try Again{this.state.retryCount > 0 ? ` (${this.state.retryCount})` : ""}
+              </button>
+            </div>
+          )}
+        </div>
+      )
+    }
+
+    // Healthy state — render with optional entry animation
+    return (
+      <div
+        data-slot="nyuchi-harness"
+        data-section={name}
+        data-status="healthy"
+        className={cn(animate && "nyuchi-animate-in", className)}
+      >
+        {children}
+      </div>
+    )
+  }
+}
+
+export function NyuchiHarness(props: NyuchiHarnessProps) {
+  return <NyuchiHarnessBoundary {...props} />
+}
+
+export type { NyuchiHarnessProps, ScopedLogger, MotionConfig, HealthReporter, HealthStatus }

--- a/lib/icons.ts
+++ b/lib/icons.ts
@@ -1,0 +1,7 @@
+/**
+ * Central icon re-export — the registry's brand components import
+ * Lucide icons via `@/lib/icons` so consumers can swap in a different
+ * icon set without touching every component. For the portal, we just
+ * pass Lucide through unchanged.
+ */
+export * from "lucide-react"

--- a/lib/motion/index.tsx
+++ b/lib/motion/index.tsx
@@ -1,0 +1,210 @@
+// Infrastructure lib — motion tokens + presets for brand components.
+
+/**
+ * MUKOKO MOTION SYSTEM
+ *
+ * Motion is not decoration — it is feedback, hierarchy, and spatial orientation.
+ * Every animation in the Nyuchi ecosystem follows these tokens so that nhimbe,
+ * Bush Trade, Campfire, and every app FEELS the same even when they look different.
+ *
+ * FOUR DURATION TIERS:
+ *   quick:     100ms — micro-interactions (button press, toggle)
+ *   standard:  200ms — most transitions (card appear, tab switch)
+ *   emphasis:  350ms — important state changes (modal open, page transition)
+ *   dramatic:  500ms — hero animations (trust meter fill, onboarding)
+ *
+ * FOUR EASING CURVES:
+ *   entrance:  cubic-bezier(0, 0, 0.2, 1)   — elements arriving (decelerate)
+ *   exit:      cubic-bezier(0.4, 0, 1, 1)    — elements leaving (accelerate)
+ *   standard:  cubic-bezier(0.4, 0, 0.2, 1)  — moving between states
+ *   spring:    cubic-bezier(0.34, 1.56, 0.64, 1) — interactive bounce (FAB, like)
+ *
+ * REDUCED MOTION: When prefers-reduced-motion is set, all durations collapse
+ * to 0ms and transforms become instant opacity fades. Motion tokens carry
+ * accessibility by default — you never need to remember to check.
+ */
+
+// ─── Duration Tokens ───────────────────────────────────────
+export const duration = {
+  quick: 100, // ms — button press, toggle switch, ripple
+  standard: 200, // ms — card appear, tab switch, dropdown open
+  emphasis: 350, // ms — modal open, page transition, trust meter
+  dramatic: 500, // ms — hero animation, onboarding, celebration
+} as const
+
+// ─── Easing Curves ─────────────────────────────────────────
+export const easing = {
+  entrance: "cubic-bezier(0, 0, 0.2, 1)", // decelerate in
+  exit: "cubic-bezier(0.4, 0, 1, 1)", // accelerate out
+  standard: "cubic-bezier(0.4, 0, 0.2, 1)", // smooth between
+  spring: "cubic-bezier(0.34, 1.56, 0.64, 1)", // bounce/overshoot
+} as const
+
+// ─── Choreography Patterns ─────────────────────────────────
+export const choreography = {
+  /** Delay between items in a list animation (ms per item) */
+  listStagger: 50,
+  /** Direction of cascade: which edge items animate from */
+  cascadeDirection: "top" as "top" | "bottom" | "left" | "right",
+  /** Max number of items to stagger (beyond this, all appear together) */
+  maxStaggerItems: 8,
+  /** Overlap ratio: how much items overlap in their animations (0-1) */
+  overlapRatio: 0.3,
+} as const
+
+// ─── Animation Presets ─────────────────────────────────────
+// Pre-built animation configs for common brand component behaviors.
+
+export const presets = {
+  // Cards and listings fade-slide-up when entering a feed
+  feedItemEnter: {
+    from: { opacity: 0, transform: "translateY(12px)" },
+    to: { opacity: 1, transform: "translateY(0)" },
+    duration: duration.standard,
+    easing: easing.entrance,
+  },
+  // Cards fade-slide-down when exiting
+  feedItemExit: {
+    from: { opacity: 1, transform: "translateY(0)" },
+    to: { opacity: 0, transform: "translateY(-8px)" },
+    duration: duration.quick,
+    easing: easing.exit,
+  },
+  // Modal/bottom sheet slides up
+  overlayEnter: {
+    from: { opacity: 0, transform: "translateY(100%)" },
+    to: { opacity: 1, transform: "translateY(0)" },
+    duration: duration.emphasis,
+    easing: easing.entrance,
+  },
+  // FAB press spring
+  fabPress: {
+    from: { transform: "scale(1)" },
+    to: { transform: "scale(0.92)" },
+    duration: duration.quick,
+    easing: easing.spring,
+  },
+  // Verified badge appear
+  badgeAppear: {
+    from: { opacity: 0, transform: "scale(0.5)" },
+    to: { opacity: 1, transform: "scale(1)" },
+    duration: duration.standard,
+    easing: easing.spring,
+  },
+  // Trust meter fill
+  meterFill: {
+    from: { width: "0%" },
+    to: { width: "var(--meter-target)" },
+    duration: duration.dramatic,
+    easing: easing.entrance,
+  },
+  // Tab switch content
+  tabSwitch: {
+    from: { opacity: 0 },
+    to: { opacity: 1 },
+    duration: duration.quick,
+    easing: easing.standard,
+  },
+  // Notification slide in from right
+  notificationEnter: {
+    from: { opacity: 0, transform: "translateX(100%)" },
+    to: { opacity: 1, transform: "translateX(0)" },
+    duration: duration.emphasis,
+    easing: easing.entrance,
+  },
+  // Skeleton pulse
+  skeletonPulse: {
+    keyframes: [{ opacity: 0.06 }, { opacity: 0.12 }, { opacity: 0.06 }],
+    duration: 1500,
+    easing: "ease-in-out",
+    iterations: Infinity,
+  },
+} as const
+
+// ─── Reduced Motion Fallbacks ──────────────────────────────
+// When prefers-reduced-motion is set, every preset collapses
+// to an instant opacity transition (no movement).
+
+export const reducedMotionPreset = {
+  from: { opacity: 0 },
+  to: { opacity: 1 },
+  duration: 0,
+  easing: "linear",
+} as const
+
+// ─── CSS Keyframes Generator ───────────────────────────────
+export function generateMotionCSS(): string {
+  return `
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes nyuchi-fade-slide-up {
+    from { opacity: 0; transform: translateY(12px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  @keyframes nyuchi-fade-slide-down {
+    from { opacity: 1; transform: translateY(0); }
+    to   { opacity: 0; transform: translateY(-8px); }
+  }
+  @keyframes nyuchi-scale-spring {
+    0%   { transform: scale(0.5); opacity: 0; }
+    70%  { transform: scale(1.08); opacity: 1; }
+    100% { transform: scale(1); }
+  }
+  @keyframes nyuchi-slide-up {
+    from { transform: translateY(100%); opacity: 0; }
+    to   { transform: translateY(0); opacity: 1; }
+  }
+  @keyframes nyuchi-slide-right {
+    from { transform: translateX(100%); opacity: 0; }
+    to   { transform: translateX(0); opacity: 1; }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  @keyframes nyuchi-fade-slide-up { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes nyuchi-fade-slide-down { from { opacity: 1; } to { opacity: 0; } }
+  @keyframes nyuchi-scale-spring { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes nyuchi-slide-up { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes nyuchi-slide-right { from { opacity: 0; } to { opacity: 1; } }
+}
+
+/* Utility classes */
+.nyuchi-animate-in    { animation: nyuchi-fade-slide-up ${duration.standard}ms ${easing.entrance} both; }
+.nyuchi-animate-out   { animation: nyuchi-fade-slide-down ${duration.quick}ms ${easing.exit} both; }
+.nyuchi-animate-spring { animation: nyuchi-scale-spring ${duration.standard}ms ${easing.spring} both; }
+.nyuchi-animate-slide  { animation: nyuchi-slide-up ${duration.emphasis}ms ${easing.entrance} both; }
+`
+}
+
+// ─── useMotion Hook ────────────────────────────────────────
+// Returns the appropriate motion config based on user preference.
+
+import { useTheme } from "@/components/mukoko/mukoko-theme-provider"
+
+export function useMotion() {
+  let prefersReduced = false
+  try {
+    const { prefersReducedMotion } = useTheme()
+    prefersReduced = prefersReducedMotion
+  } catch {
+    // Outside provider — check directly
+    if (typeof window !== "undefined") {
+      prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    }
+  }
+
+  return {
+    duration: prefersReduced ? { quick: 0, standard: 0, emphasis: 0, dramatic: 0 } : duration,
+    easing: prefersReduced
+      ? { entrance: "linear", exit: "linear", standard: "linear", spring: "linear" }
+      : easing,
+    presets: prefersReduced
+      ? Object.fromEntries(Object.keys(presets).map((k) => [k, reducedMotionPreset]))
+      : presets,
+    prefersReduced,
+    /** Get stagger delay for item at index */
+    staggerDelay: (index: number) =>
+      prefersReduced ? 0 : Math.min(index, choreography.maxStaggerItems) * choreography.listStagger,
+  }
+}
+
+export { duration as durations, easing as easings }

--- a/lib/rate-limiter.ts
+++ b/lib/rate-limiter.ts
@@ -1,0 +1,229 @@
+/**
+ * Token bucket rate limiter for the Nyuchi ecosystem.
+ * Inspired by Resilience4j RateLimiter.
+ *
+ * Controls how many operations can execute within a time window.
+ * Critical for protecting external API quotas (Tomorrow.io has 500/day,
+ * Anthropic has token limits, government registries have strict throttles).
+ *
+ * Uses the token bucket algorithm:
+ * - Bucket starts full (capacity = limit)
+ * - Each call consumes one token
+ * - Tokens refill at a fixed rate (limit per window)
+ * - When empty, calls either wait or are rejected
+ *
+ * Install via: npx shadcn@latest add https://design.nyuchi.com/api/v1/ui/rate-limiter
+ */
+
+import { createLogger } from "@/lib/observability"
+
+const logger = createLogger("rate-limiter")
+
+export interface RateLimiterConfig {
+  /** Identifier for this limiter (e.g., "tomorrow-io", "anthropic") */
+  name: string
+  /** Maximum number of calls allowed per window (default: 100) */
+  limit: number
+  /** Time window in ms (default: 60000 = 1 minute) */
+  windowMs: number
+  /** Maximum burst above the limit (default: 0 = no burst) */
+  burstAllowance: number
+  /** Whether to queue calls that exceed the limit instead of rejecting (default: false) */
+  queueExcess: boolean
+  /** Maximum time in ms to wait in queue (default: 5000) */
+  maxWaitMs: number
+  /** Called when a call is rate-limited */
+  onLimit?: (name: string, remainingTokens: number) => void
+}
+
+const DEFAULT_CONFIG: Omit<RateLimiterConfig, "name"> = {
+  limit: 100,
+  windowMs: 60_000,
+  burstAllowance: 0,
+  queueExcess: false,
+  maxWaitMs: 5_000,
+}
+
+/** Pre-configured limiter settings for known Nyuchi API providers */
+export const API_RATE_CONFIGS = {
+  /** Tomorrow.io: 500 calls/day, 25 per hour */
+  "tomorrow-io": { limit: 25, windowMs: 3_600_000, burstAllowance: 5 },
+  /** Open-Meteo: generous free tier, 10K/day */
+  "open-meteo": { limit: 600, windowMs: 3_600_000, burstAllowance: 50 },
+  /** Anthropic Claude: token-limited, rate varies by plan */
+  anthropic: { limit: 60, windowMs: 60_000, burstAllowance: 10 },
+  /** Government registries (ZIMRA, CIPC): very strict */
+  "government-api": { limit: 10, windowMs: 60_000, burstAllowance: 0 },
+  /** Supabase: generous but protect connection pool */
+  supabase: { limit: 200, windowMs: 60_000, burstAllowance: 50 },
+  /** Stytch auth: protect auth endpoints */
+  stytch: { limit: 30, windowMs: 60_000, burstAllowance: 10 },
+} as const satisfies Record<string, Partial<Omit<RateLimiterConfig, "name">>>
+
+/**
+ * Error thrown when a call is rejected by the rate limiter.
+ */
+export class RateLimitExceededError extends Error {
+  readonly limiterName: string
+  readonly limit: number
+  readonly windowMs: number
+  readonly retryAfterMs: number
+
+  constructor(name: string, limit: number, windowMs: number, retryAfterMs: number) {
+    super(
+      `Rate limit exceeded for "${name}" — ${limit} calls per ${windowMs}ms. Retry after ${retryAfterMs}ms`
+    )
+    this.name = "RateLimitExceededError"
+    this.limiterName = name
+    this.limit = limit
+    this.windowMs = windowMs
+    this.retryAfterMs = retryAfterMs
+  }
+}
+
+/**
+ * Token bucket rate limiter.
+ *
+ * @example
+ * ```ts
+ * import { RateLimiter, API_RATE_CONFIGS } from "@/lib/rate-limiter"
+ *
+ * // Protect Tomorrow.io API quota
+ * const weatherLimiter = new RateLimiter({
+ *   name: "tomorrow-io",
+ *   ...API_RATE_CONFIGS["tomorrow-io"],
+ * })
+ *
+ * try {
+ *   const data = await weatherLimiter.execute(() =>
+ *     fetch("https://api.tomorrow.io/v4/weather/forecast")
+ *   )
+ * } catch (error) {
+ *   if (error instanceof RateLimitExceededError) {
+ *     // Use cached weather data instead
+ *     return getCachedWeather()
+ *   }
+ * }
+ *
+ * // Check before calling
+ * if (weatherLimiter.isAllowed) {
+ *   await weatherLimiter.execute(() => fetchWeather())
+ * }
+ * ```
+ */
+export class RateLimiter {
+  private tokens: number
+  private lastRefill: number
+  private readonly config: RateLimiterConfig
+
+  constructor(config: Partial<RateLimiterConfig> & { name: string }) {
+    this.config = { ...DEFAULT_CONFIG, ...config }
+    this.tokens = this.config.limit + this.config.burstAllowance
+    this.lastRefill = Date.now()
+  }
+
+  /** Whether a call is currently allowed */
+  get isAllowed(): boolean {
+    this.refill()
+    return this.tokens > 0
+  }
+
+  /** Number of remaining tokens in the bucket */
+  get remaining(): number {
+    this.refill()
+    return Math.max(0, Math.floor(this.tokens))
+  }
+
+  /** Metrics snapshot */
+  get metrics() {
+    this.refill()
+    return {
+      name: this.config.name,
+      remaining: Math.floor(this.tokens),
+      limit: this.config.limit,
+      burstAllowance: this.config.burstAllowance,
+      windowMs: this.config.windowMs,
+      utilization: 1 - this.tokens / (this.config.limit + this.config.burstAllowance),
+    }
+  }
+
+  /** Time in ms until the next token is available */
+  get retryAfterMs(): number {
+    if (this.tokens > 0) return 0
+    const refillRate = (this.config.limit + this.config.burstAllowance) / this.config.windowMs
+    return Math.ceil(1 / refillRate)
+  }
+
+  /**
+   * Execute a function through the rate limiter.
+   * Consumes one token. If no tokens available, either waits or rejects.
+   */
+  async execute<T>(fn: () => Promise<T>): Promise<T> {
+    this.refill()
+
+    if (this.tokens >= 1) {
+      this.tokens--
+      return fn()
+    }
+
+    // No tokens available
+    if (this.config.queueExcess) {
+      // Wait for a token to become available
+      const waitMs = Math.min(this.retryAfterMs, this.config.maxWaitMs)
+      if (waitMs > this.config.maxWaitMs) {
+        throw new RateLimitExceededError(
+          this.config.name,
+          this.config.limit,
+          this.config.windowMs,
+          waitMs
+        )
+      }
+
+      logger.info(`Rate limited — waiting ${waitMs}ms for token`, {
+        data: { name: this.config.name, remaining: Math.floor(this.tokens), waitMs },
+      })
+      await new Promise((r) => setTimeout(r, waitMs))
+
+      this.refill()
+      if (this.tokens >= 1) {
+        this.tokens--
+        return fn()
+      }
+    }
+
+    const retryAfter = this.retryAfterMs
+    logger.warn("Rate limit exceeded", {
+      data: {
+        name: this.config.name,
+        limit: this.config.limit,
+        windowMs: this.config.windowMs,
+        retryAfterMs: retryAfter,
+      },
+    })
+    this.config.onLimit?.(this.config.name, Math.floor(this.tokens))
+    throw new RateLimitExceededError(
+      this.config.name,
+      this.config.limit,
+      this.config.windowMs,
+      retryAfter
+    )
+  }
+
+  /** Manually reset the limiter (refills all tokens) */
+  reset(): void {
+    this.tokens = this.config.limit + this.config.burstAllowance
+    this.lastRefill = Date.now()
+  }
+
+  /** Refill tokens based on elapsed time */
+  private refill(): void {
+    const now = Date.now()
+    const elapsed = now - this.lastRefill
+    const maxTokens = this.config.limit + this.config.burstAllowance
+    const refillRate = maxTokens / this.config.windowMs // tokens per ms
+    const tokensToAdd = elapsed * refillRate
+
+    this.tokens = Math.min(maxTokens, this.tokens + tokensToAdd)
+    this.lastRefill = now
+  }
+}

--- a/lib/resilience/index.tsx
+++ b/lib/resilience/index.tsx
@@ -1,0 +1,532 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+/* ═══════════════════════════════════════════════════════════════
+   MUKOKO RESILIENCE — Self-Monitoring Infrastructure
+   
+   The principle: infrastructure monitors itself. When something
+   breaks, the system degrades gracefully, logs the failure,
+   tracks the pattern, and self-heals when the issue resolves.
+   
+   EVERY brand component renders inside a NyuchiSection. This is
+   non-negotiable. The section boundary provides:
+   
+   1. ERROR ISOLATION — React error boundary catches render crashes.
+      The section shows a fallback; the rest of the page survives.
+   
+   2. LOADING ORCHESTRATION — Section manages its own loading state
+      with the branded skeleton, using lazy-section's FIFO queue so
+      sections mount one at a time (TikTok-style).
+   
+   3. OBSERVABILITY — Every render, error, and recovery is logged
+      via structured observability. Section name, error type, stack
+      trace, recovery attempts — all captured automatically.
+   
+   4. HEALTH TRACKING — Each section reports its health status
+      (healthy/degraded/error) to the NyuchiHealthMonitor singleton.
+      The monitor aggregates across all sections and can report to
+      system.service_health in nyuchi_platform_db.
+   
+   5. CIRCUIT BREAKING — When a section's data source fails
+      repeatedly, the circuit breaker prevents hammering a dead
+      service. The section shows cached/fallback data instead.
+   
+   6. SELF-HEALING — When the circuit breaker transitions from
+      OPEN to HALF_OPEN, it sends a probe request. If the probe
+      succeeds, the circuit closes and the section automatically
+      re-renders with fresh data. No user action needed.
+   
+   This is what separates a component library from production
+   infrastructure. Components don't just render — they participate
+   in the observability and resilience system automatically.
+   ═══════════════════════════════════════════════════════════════ */
+
+// ─── HEALTH STATUS TYPES ───────────────────────────────────
+
+export type SectionHealth = "healthy" | "degraded" | "error" | "loading"
+
+export interface SectionHealthReport {
+  sectionName: string
+  status: SectionHealth
+  lastError?: Error
+  errorCount: number
+  lastRecovery?: Date
+  renderCount: number
+  avgRenderMs: number
+  dataSource?: "local" | "edge" | "cloud" | "cache" | "none"
+  circuitState?: "closed" | "open" | "half_open"
+  timestamp: Date
+}
+
+// ─── HEALTH MONITOR SINGLETON ──────────────────────────────
+// Aggregates health from all NyuchiSections on the page.
+// This is the central nervous system of the UI.
+
+class HealthMonitor {
+  private sections = new Map<string, SectionHealthReport>()
+  private listeners = new Set<(reports: Map<string, SectionHealthReport>) => void>()
+
+  /** Report health status from a section */
+  report(sectionName: string, report: Partial<SectionHealthReport>) {
+    const existing = this.sections.get(sectionName) || {
+      sectionName,
+      status: "loading" as SectionHealth,
+      errorCount: 0,
+      renderCount: 0,
+      avgRenderMs: 0,
+      timestamp: new Date(),
+    }
+
+    const updated: SectionHealthReport = {
+      ...existing,
+      ...report,
+      sectionName,
+      timestamp: new Date(),
+    }
+
+    this.sections.set(sectionName, updated)
+    this.notifyListeners()
+  }
+
+  /** Get health report for all sections */
+  getAll(): Map<string, SectionHealthReport> {
+    return new Map(this.sections)
+  }
+
+  /** Get overall system health */
+  getSystemHealth(): SectionHealth {
+    const reports = Array.from(this.sections.values())
+    if (reports.length === 0) return "loading"
+    if (reports.some((r) => r.status === "error")) return "error"
+    if (reports.some((r) => r.status === "degraded")) return "degraded"
+    if (reports.some((r) => r.status === "loading")) return "loading"
+    return "healthy"
+  }
+
+  /** Subscribe to health changes */
+  subscribe(listener: (reports: Map<string, SectionHealthReport>) => void) {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  /** Record a section error */
+  recordError(sectionName: string, error: Error) {
+    const existing = this.sections.get(sectionName)
+    this.report(sectionName, {
+      status: "error",
+      lastError: error,
+      errorCount: (existing?.errorCount || 0) + 1,
+    })
+
+    // Log to observability (structured logging)
+    if (typeof console !== "undefined") {
+      console.error(
+        `[mukoko:resilience] Section "${sectionName}" error #${(existing?.errorCount || 0) + 1}`,
+        { section: sectionName, error: error.message, stack: error.stack?.split("\\n").slice(0, 5) }
+      )
+    }
+  }
+
+  /** Record a section recovery */
+  recordRecovery(sectionName: string) {
+    this.report(sectionName, {
+      status: "healthy",
+      lastRecovery: new Date(),
+    })
+
+    if (typeof console !== "undefined") {
+      console.warn(`[mukoko:resilience] Section "${sectionName}" recovered`)
+    }
+  }
+
+  /** Record a render with timing */
+  recordRender(sectionName: string, durationMs: number) {
+    const existing = this.sections.get(sectionName)
+    const renderCount = (existing?.renderCount || 0) + 1
+    const prevAvg = existing?.avgRenderMs || 0
+    const newAvg = prevAvg + (durationMs - prevAvg) / renderCount
+
+    this.report(sectionName, {
+      status: "healthy",
+      renderCount,
+      avgRenderMs: Math.round(newAvg * 100) / 100,
+    })
+  }
+
+  private notifyListeners() {
+    const reports = this.getAll()
+    this.listeners.forEach((l) => l(reports))
+  }
+}
+
+/** Global health monitor instance */
+export const healthMonitor = new HealthMonitor()
+
+// ─── useHealthMonitor HOOK ─────────────────────────────────
+// Subscribe to health changes from any component.
+
+export function useHealthMonitor() {
+  const [reports, setReports] = React.useState<Map<string, SectionHealthReport>>(() =>
+    healthMonitor.getAll()
+  )
+
+  React.useEffect(() => {
+    return healthMonitor.subscribe(setReports)
+  }, [])
+
+  return {
+    reports,
+    systemHealth: healthMonitor.getSystemHealth(),
+    getSection: (name: string) => reports.get(name),
+  }
+}
+
+// ─── MUKOKO SECTION ────────────────────────────────────────
+// The mandatory wrapper for every brand component section.
+// Provides error isolation, loading state, and health reporting.
+
+interface NyuchiSectionProps {
+  /** Unique section name for logging and health tracking */
+  name: string
+  /** Section content */
+  children: React.ReactNode
+  /** Loading state — shows branded skeleton */
+  loading?: boolean
+  /** Custom skeleton to show while loading */
+  skeleton?: React.ReactNode
+  /** Custom fallback to show on error */
+  fallback?: React.ReactNode
+  /** Whether this section is critical (errors bubble up vs. are contained) */
+  critical?: boolean
+  /** Called when an error is caught */
+  onError?: (error: Error) => void
+  /** Called when the section recovers from an error */
+  onRecovery?: () => void
+  className?: string
+}
+
+interface SectionState {
+  hasError: boolean
+  error: Error | null
+  retryCount: number
+}
+
+class NyuchiSectionBoundary extends React.Component<NyuchiSectionProps, SectionState> {
+  private renderStart = 0
+
+  constructor(props: NyuchiSectionProps) {
+    super(props)
+    this.state = { hasError: false, error: null, retryCount: 0 }
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<SectionState> {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error) {
+    const { name, onError } = this.props
+
+    // Report to health monitor
+    healthMonitor.recordError(name, error)
+
+    // Call external error handler
+    onError?.(error)
+  }
+
+  componentDidMount() {
+    this.trackRender()
+    healthMonitor.report(this.props.name, { status: "healthy" })
+  }
+
+  componentDidUpdate() {
+    this.trackRender()
+  }
+
+  private trackRender() {
+    if (this.renderStart > 0) {
+      const duration = performance.now() - this.renderStart
+      healthMonitor.recordRender(this.props.name, duration)
+    }
+  }
+
+  private handleRetry = () => {
+    healthMonitor.recordRecovery(this.props.name)
+    this.props.onRecovery?.()
+    this.setState((prev) => ({
+      hasError: false,
+      error: null,
+      retryCount: prev.retryCount + 1,
+    }))
+  }
+
+  render() {
+    this.renderStart = performance.now()
+    const { name, children, loading, skeleton, fallback, critical, className } = this.props
+
+    // Loading state — show branded skeleton
+    if (loading) {
+      healthMonitor.report(name, { status: "loading" })
+      return (
+        <div
+          data-slot="nyuchi-section"
+          data-portal="https://design.nyuchi.com/components/nyuchi-section"
+          data-section={name}
+          data-status="loading"
+          className={className}
+          role="status"
+          aria-label={`${name} loading`}
+        >
+          {skeleton || (
+            <div className="animate-pulse rounded-[var(--radius-card,14px)] bg-card p-4 ring-1 ring-foreground/10">
+              <div className="h-4 w-2/3 rounded bg-foreground/[0.06]" />
+              <div className="mt-2 h-3 w-full rounded bg-foreground/[0.06]" />
+              <div className="mt-2 h-3 w-1/2 rounded bg-foreground/[0.06]" />
+            </div>
+          )}
+        </div>
+      )
+    }
+
+    // Error state — show branded fallback with retry
+    if (this.state.hasError) {
+      if (critical) throw this.state.error // Bubble up for critical sections
+
+      return (
+        <div
+          data-slot="nyuchi-section"
+          data-section={name}
+          data-status="error"
+          data-retry-count={this.state.retryCount}
+          className={className}
+          role="alert"
+          aria-label={`${name} error`}
+        >
+          {fallback || (
+            <div className="flex flex-col items-center rounded-[var(--radius-card,14px)] bg-card px-6 py-6 text-center ring-1 ring-foreground/10">
+              <div className="mb-3 flex size-10 items-center justify-center rounded-full bg-[var(--color-terracotta,#D4A574)]/10">
+                <span className="text-lg text-[var(--color-terracotta,#D4A574)]">!</span>
+              </div>
+              <p className="text-sm font-medium text-foreground">{name} could not load</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {this.state.error?.message || "An unexpected error occurred"}
+              </p>
+              <button
+                onClick={this.handleRetry}
+                className="mt-4 flex h-9 items-center gap-2 rounded-full border border-[var(--color-border,#2A2A2A)] px-4 text-xs font-medium text-foreground transition-colors hover:bg-foreground/[0.05]"
+              >
+                Try Again{this.state.retryCount > 0 ? ` (${this.state.retryCount})` : ""}
+              </button>
+            </div>
+          )}
+        </div>
+      )
+    }
+
+    // Healthy state — render children with tracking
+    return (
+      <div
+        data-slot="nyuchi-section"
+        data-section={name}
+        data-status="healthy"
+        className={className}
+      >
+        {children}
+      </div>
+    )
+  }
+}
+
+// ─── Functional wrapper for NyuchiSection ──────────────────
+export function NyuchiSection(props: NyuchiSectionProps) {
+  return <NyuchiSectionBoundary {...props} />
+}
+
+// ─── RESILIENT FETCH ───────────────────────────────────────
+// Data fetching with circuit breaker + retry + fallback chain
+// + observability, all wired together.
+
+interface ResilientFetchOptions<T> {
+  /** Section name for logging */
+  section: string
+  /** Primary fetch function */
+  fetcher: () => Promise<T>
+  /** Fallback fetch function (e.g., cached data) */
+  fallback?: () => Promise<T>
+  /** Maximum retry attempts (default: 2) */
+  maxRetries?: number
+  /** Timeout per attempt in ms (default: 5000) */
+  timeoutMs?: number
+  /** Circuit breaker failure threshold (default: 3) */
+  failureThreshold?: number
+  /** Circuit breaker cooldown in ms (default: 30000) */
+  cooldownMs?: number
+}
+
+interface ResilientFetchResult<T> {
+  data: T | null
+  error: Error | null
+  source: "primary" | "fallback" | "none"
+  attempts: number
+  durationMs: number
+}
+
+export async function resilientFetch<T>({
+  section,
+  fetcher,
+  fallback,
+  maxRetries = 2,
+  timeoutMs = 5000,
+}: ResilientFetchOptions<T>): Promise<ResilientFetchResult<T>> {
+  const start = performance.now()
+  let attempts = 0
+  let lastError: Error | null = null
+
+  // Try primary with retries
+  for (let i = 0; i <= maxRetries; i++) {
+    attempts++
+    try {
+      const result = await Promise.race([
+        fetcher(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error(`Timeout after ${timeoutMs}ms`)), timeoutMs)
+        ),
+      ])
+      const durationMs = Math.round(performance.now() - start)
+
+      healthMonitor.report(section, { status: "healthy", dataSource: "cloud" })
+      console.warn(
+        `[mukoko:resilience] ${section} fetched in ${durationMs}ms (attempt ${attempts})`
+      )
+
+      return { data: result, error: null, source: "primary", attempts, durationMs }
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err))
+      console.warn(
+        `[mukoko:resilience] ${section} attempt ${attempts} failed: ${lastError.message}`
+      )
+
+      // Exponential backoff between retries
+      if (i < maxRetries) {
+        await new Promise((r) => setTimeout(r, Math.min(1000 * Math.pow(2, i), 5000)))
+      }
+    }
+  }
+
+  // Primary failed — try fallback
+  if (fallback) {
+    try {
+      const result = await fallback()
+      const durationMs = Math.round(performance.now() - start)
+
+      healthMonitor.report(section, { status: "degraded", dataSource: "cache" })
+      console.warn(
+        `[mukoko:resilience] ${section} using fallback after ${attempts} failed attempts`
+      )
+
+      return { data: result, error: lastError, source: "fallback", attempts, durationMs }
+    } catch (fallbackErr) {
+      lastError = fallbackErr instanceof Error ? fallbackErr : new Error(String(fallbackErr))
+    }
+  }
+
+  // Everything failed
+  const durationMs = Math.round(performance.now() - start)
+  healthMonitor.recordError(section, lastError || new Error("Unknown error"))
+
+  return { data: null, error: lastError, source: "none", attempts, durationMs }
+}
+
+// ─── HEALTH STATUS PANEL (for admin/debug views) ───────────
+// Shows the health of all sections on the page.
+
+interface NyuchiHealthPanelProps {
+  className?: string
+}
+
+export function NyuchiHealthPanel({ className }: NyuchiHealthPanelProps) {
+  const { reports, systemHealth } = useHealthMonitor()
+  const entries = Array.from(reports.entries())
+
+  const healthColors: Record<SectionHealth, string> = {
+    healthy: "#4ADE80",
+    degraded: "#FBBF24",
+    error: "#F87171",
+    loading: "#00B0FF",
+  }
+
+  return (
+    <div
+      data-slot="nyuchi-health-panel"
+      className={cn(
+        "rounded-[var(--radius-card,14px)] bg-card p-4 ring-1 ring-foreground/10",
+        className
+      )}
+    >
+      {/* System status */}
+      <div className="mb-3 flex items-center justify-between">
+        <span className="text-sm font-medium text-foreground">System Health</span>
+        <span
+          className="flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase"
+          style={{
+            backgroundColor: `color-mix(in srgb, ${healthColors[systemHealth]} 15%, transparent)`,
+            color: healthColors[systemHealth],
+          }}
+        >
+          <span
+            className="size-1.5 rounded-full"
+            style={{ backgroundColor: healthColors[systemHealth] }}
+          />
+          {systemHealth}
+        </span>
+      </div>
+
+      {/* Section list */}
+      <div className="flex flex-col gap-1.5">
+        {entries.map(([name, report]) => (
+          <div
+            key={name}
+            className="flex items-center gap-2 rounded-[var(--radius-inner,7px)] px-3 py-2 text-xs"
+            style={{
+              backgroundColor: report.status === "error" ? "rgba(248,113,113,0.05)" : "transparent",
+            }}
+          >
+            <span
+              className="size-2 shrink-0 rounded-full"
+              style={{ backgroundColor: healthColors[report.status] }}
+            />
+            <span className="flex-1 font-medium text-foreground">{name}</span>
+            <span className="text-muted-foreground">
+              {report.avgRenderMs > 0 ? `${report.avgRenderMs}ms` : "—"}
+            </span>
+            {report.errorCount > 0 && (
+              <span className="rounded bg-[var(--color-error,#F87171)]/10 px-1.5 py-0.5 text-[10px] font-medium text-[var(--color-error,#F87171)]">
+                {report.errorCount} errors
+              </span>
+            )}
+            {report.dataSource && report.dataSource !== "cloud" && (
+              <span className="rounded bg-[var(--color-warning,#FBBF24)]/10 px-1.5 py-0.5 text-[10px] font-medium text-[var(--color-warning,#FBBF24)]">
+                {report.dataSource}
+              </span>
+            )}
+          </div>
+        ))}
+        {entries.length === 0 && (
+          <span className="py-4 text-center text-xs text-muted-foreground">
+            No sections reporting
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export type {
+  NyuchiSectionProps,
+  ResilientFetchOptions,
+  ResilientFetchResult,
+  NyuchiHealthPanelProps,
+}

--- a/lib/retry.ts
+++ b/lib/retry.ts
@@ -1,0 +1,145 @@
+/**
+ * Retry with exponential backoff for the Nyuchi ecosystem.
+ *
+ * Wraps async operations with configurable retry logic, exponential delays,
+ * and jitter to prevent thundering herd problems.
+ *
+ * Install via: npx shadcn@latest add https://design.nyuchi.com/api/v1/ui/retry
+ */
+
+import { createLogger } from "@/lib/observability"
+
+const logger = createLogger("retry")
+
+export interface RetryConfig {
+  /** Maximum number of attempts including the first try (default: 3) */
+  maxAttempts: number
+  /** Base delay in ms before first retry (default: 1000) */
+  baseDelayMs: number
+  /** Maximum delay in ms — caps exponential growth (default: 30000) */
+  maxDelayMs: number
+  /** Add random jitter to prevent thundering herd (default: true) */
+  jitter: boolean
+  /** Custom predicate — return false to skip retry for certain errors */
+  retryIf?: (error: unknown, attempt: number) => boolean
+  /** Called before each retry — useful for logging or metrics */
+  onRetry?: (error: unknown, attempt: number, delayMs: number) => void
+}
+
+const DEFAULT_CONFIG: RetryConfig = {
+  maxAttempts: 3,
+  baseDelayMs: 1000,
+  maxDelayMs: 30_000,
+  jitter: true,
+}
+
+/**
+ * Error thrown when all retry attempts are exhausted.
+ */
+export class RetriesExhaustedError extends Error {
+  readonly attempts: number
+  readonly lastError: unknown
+
+  constructor(attempts: number, lastError: unknown) {
+    const msg = lastError instanceof Error ? lastError.message : String(lastError)
+    super(`All ${attempts} retry attempts exhausted. Last error: ${msg}`)
+    this.name = "RetriesExhaustedError"
+    this.attempts = attempts
+    this.lastError = lastError
+  }
+}
+
+function computeDelay(attempt: number, config: RetryConfig): number {
+  // Exponential: baseDelay * 2^attempt
+  const exponential = config.baseDelayMs * Math.pow(2, attempt)
+  const capped = Math.min(exponential, config.maxDelayMs)
+
+  if (config.jitter) {
+    // Add 0–50% random jitter
+    return capped + Math.random() * capped * 0.5
+  }
+  return capped
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Retry an async operation with exponential backoff.
+ *
+ * @example
+ * ```ts
+ * import { withRetry } from "@/lib/retry"
+ *
+ * // Basic usage — 3 attempts with 1s base delay
+ * const data = await withRetry(() => fetch("/api/weather").then(r => r.json()))
+ *
+ * // Custom configuration
+ * const result = await withRetry(
+ *   () => fetchFromProvider(),
+ *   {
+ *     maxAttempts: 5,
+ *     baseDelayMs: 500,
+ *     retryIf: (error) => {
+ *       // Don't retry 404s or 400s
+ *       if (error instanceof Response && error.status < 500) return false
+ *       return true
+ *     },
+ *   }
+ * )
+ *
+ * // With git push retry pattern (from CLAUDE.md)
+ * await withRetry(() => gitPush(), {
+ *   maxAttempts: 4,
+ *   baseDelayMs: 2000,  // 2s, 4s, 8s, 16s
+ *   jitter: false,
+ * })
+ * ```
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  config?: Partial<RetryConfig>
+): Promise<T> {
+  const cfg = { ...DEFAULT_CONFIG, ...config }
+  let lastError: unknown
+
+  for (let attempt = 0; attempt < cfg.maxAttempts; attempt++) {
+    try {
+      return await fn()
+    } catch (error) {
+      lastError = error
+      const isLastAttempt = attempt === cfg.maxAttempts - 1
+
+      // Check if we should retry this error
+      if (!isLastAttempt && cfg.retryIf && !cfg.retryIf(error, attempt)) {
+        logger.info("Retry skipped by predicate", {
+          data: { attempt: attempt + 1, maxAttempts: cfg.maxAttempts },
+        })
+        throw error
+      }
+
+      if (!isLastAttempt) {
+        const delay = computeDelay(attempt, cfg)
+        logger.warn(
+          `Attempt ${attempt + 1}/${cfg.maxAttempts} failed, retrying in ${Math.round(delay)}ms`,
+          {
+            data: {
+              attempt: attempt + 1,
+              maxAttempts: cfg.maxAttempts,
+              delayMs: Math.round(delay),
+            },
+          }
+        )
+        cfg.onRetry?.(error, attempt + 1, delay)
+        await sleep(delay)
+      }
+    }
+  }
+
+  logger.error(`All ${cfg.maxAttempts} attempts exhausted`, {
+    data: { maxAttempts: cfg.maxAttempts },
+    error: lastError instanceof Error ? lastError : new Error(String(lastError)),
+  })
+  throw new RetriesExhaustedError(cfg.maxAttempts, lastError)
+}

--- a/lib/timeout.ts
+++ b/lib/timeout.ts
@@ -1,0 +1,96 @@
+/**
+ * Promise timeout wrapper for the Nyuchi ecosystem.
+ *
+ * Wraps any async operation with a configurable timeout. Used by the circuit
+ * breaker, fallback chain, and any operation that should not hang indefinitely.
+ *
+ * Install via: npx shadcn@latest add https://design.nyuchi.com/api/v1/ui/timeout
+ */
+
+/**
+ * Error thrown when an operation exceeds its timeout.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await withTimeout(() => fetch("/api/weather"), 5000)
+ * } catch (error) {
+ *   if (error instanceof TimeoutError) {
+ *     console.log(error.durationMs) // 5000
+ *   }
+ * }
+ * ```
+ */
+export class TimeoutError extends Error {
+  readonly durationMs: number
+  readonly label: string
+
+  constructor(ms: number, label?: string) {
+    const tag = label ? ` [${label}]` : ""
+    super(`Operation timed out after ${ms}ms${tag}`)
+    this.name = "TimeoutError"
+    this.durationMs = ms
+    this.label = label ?? "unknown"
+  }
+}
+
+/**
+ * Wrap an async function with a timeout.
+ *
+ * If the function does not resolve within `ms` milliseconds, the promise
+ * rejects with a `TimeoutError`. The underlying operation is NOT cancelled
+ * (JavaScript has no cancellation primitive), but its result is ignored.
+ *
+ * @example
+ * ```ts
+ * import { withTimeout, TimeoutError } from "@/lib/timeout"
+ *
+ * // Basic usage
+ * const data = await withTimeout(() => fetch("/api/data"), 5000)
+ *
+ * // With label for debugging
+ * const weather = await withTimeout(
+ *   () => fetch("https://api.tomorrow.io/v4/weather"),
+ *   5000,
+ *   "tomorrow-io-fetch"
+ * )
+ *
+ * // Catch timeout specifically
+ * try {
+ *   await withTimeout(() => slowOperation(), 3000, "slow-op")
+ * } catch (error) {
+ *   if (error instanceof TimeoutError) {
+ *     log.warn(`${error.label} timed out`, { data: { ms: error.durationMs } })
+ *   }
+ * }
+ * ```
+ */
+export async function withTimeout<T>(fn: () => Promise<T>, ms: number, label?: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true
+        reject(new TimeoutError(ms, label))
+      }
+    }, ms)
+
+    fn().then(
+      (result) => {
+        if (!settled) {
+          settled = true
+          clearTimeout(timer)
+          resolve(result)
+        }
+      },
+      (error) => {
+        if (!settled) {
+          settled = true
+          clearTimeout(timer)
+          reject(error)
+        }
+      }
+    )
+  })
+}

--- a/lib/tokens/index.ts
+++ b/lib/tokens/index.ts
@@ -1,0 +1,1515 @@
+/**
+ * NYUCHI DESIGN TOKENS — Layer 1: The Mathematical Substrate
+ *
+ * Canonical source: design.nyuchi.com
+ * W3C Design Tokens Specification (2025.10) compliant
+ * Nyuchi Frontend Architecture Layer 1 of 7
+ *
+ * THREE-TIER TOKEN ARCHITECTURE:
+ *   1. Primitive: Raw values — never change regardless of theme or brand
+ *   2. Semantic: Purpose-mapped aliases that adapt per theme (light/dark/high-contrast)
+ *   3. Component: Scoped tokens for specific brand components
+ *
+ * MULTI-PLATFORM OUTPUT:
+ *   This file is the source of truth. Platform generators read from it:
+ *   - Next.js/React: CSS custom properties + Tailwind @theme
+ *   - Swift/SwiftUI: Asset catalog + Color extensions
+ *   - Kotlin/Compose: NyuchiTheme composable
+ *   - ArkTS/ArkUI: Resource files
+ *   - React Native: StyleSheet constants
+ *   - Rust: const values + config structs
+ *   - Python: Config dataclass
+ *
+ * TEN LISTING THEMES:
+ *   Five African Minerals (geological) + Five Heritage Colors (atmospheric)
+ *
+ * "Thou hast ordered all things in measure, and number, and weight."
+ * — The Mukoko Order, v4.0.2
+ */
+
+// ═══════════════════════════════════════════════════════════════
+// TIER 1 — PRIMITIVE TOKENS
+// These are absolute values. They never change.
+// ═══════════════════════════════════════════════════════════════
+
+export const primitives = {
+  // ─── FIVE AFRICAN MINERALS (geological, from underground) ───
+  // Each mineral has a dark-mode and light-mode value.
+  // Dark mode values are used in the Nyuchi default dark theme.
+  // Light mode values are used for light theme and text-on-light.
+  color: {
+    // Minerals
+    cobalt: { value: "#00B0FF", description: "Primary blue, links, CTAs" },
+    cobaltLight: { value: "#0047AB", description: "Cobalt on light backgrounds" },
+    tanzanite: { value: "#B388FF", description: "Purple accent, brand/logo, social" },
+    tanzaniteLight: { value: "#4B0082", description: "Tanzanite on light backgrounds" },
+    malachite: {
+      value: "#64FFDA",
+      description: "Success states, positive actions, Mukoko identity",
+    },
+    malachiteLight: { value: "#004D40", description: "Malachite on light backgrounds" },
+    gold: { value: "#FFD740", description: "Achievements, rewards, highlights" },
+    goldLight: { value: "#5D4037", description: "Gold on light backgrounds" },
+    terracotta: { value: "#D4A574", description: "Community features, warmth, earth" },
+    terracottaLight: { value: "#8B4513", description: "Terracotta on light backgrounds" },
+
+    // ─── MINERAL CONTAINER COLORS ─────────────────────────────
+    // Subtle background surfaces when a mineral needs to be an area fill.
+    // Used for cards, banners, alerts, and category-tinted sections.
+    // Each mineral has a light container and dark container variant.
+    cobaltContainer: { value: "#E3F2FD", description: "Cobalt-tinted surface (light)" },
+    cobaltContainerDark: { value: "#001F3F", description: "Cobalt-tinted surface (dark)" },
+    tanzaniteContainer: { value: "#F3E5F5", description: "Tanzanite-tinted surface (light)" },
+    tanzaniteContainerDark: { value: "#1A0033", description: "Tanzanite-tinted surface (dark)" },
+    malachiteContainer: { value: "#E0F2F1", description: "Malachite-tinted surface (light)" },
+    malachiteContainerDark: { value: "#00251A", description: "Malachite-tinted surface (dark)" },
+    goldContainer: { value: "#FFF8E1", description: "Gold-tinted surface (light)" },
+    goldContainerDark: { value: "#332200", description: "Gold-tinted surface (dark)" },
+    terracottaContainer: { value: "#FBE9E7", description: "Terracotta-tinted surface (light)" },
+    terracottaContainerDark: { value: "#3E1A00", description: "Terracotta-tinted surface (dark)" },
+
+    // ─── ON-CONTAINER COLORS (text/icons on container surfaces) ──
+    // High-contrast foreground colors for use on mineral container backgrounds.
+    // These ensure WCAG AAA readability when text sits on a container surface.
+    cobaltOnContainer: { value: "#002966", description: "Text on cobalt container (light)" },
+    cobaltOnContainerDark: { value: "#B3E5FC", description: "Text on cobalt container (dark)" },
+    tanzaniteOnContainer: { value: "#2E004D", description: "Text on tanzanite container (light)" },
+    tanzaniteOnContainerDark: {
+      value: "#E1BEE7",
+      description: "Text on tanzanite container (dark)",
+    },
+    malachiteOnContainer: { value: "#00332B", description: "Text on malachite container (light)" },
+    malachiteOnContainerDark: {
+      value: "#A7FFEB",
+      description: "Text on malachite container (dark)",
+    },
+    goldOnContainer: { value: "#3E2723", description: "Text on gold container (light)" },
+    goldOnContainerDark: { value: "#FFECB3", description: "Text on gold container (dark)" },
+    terracottaOnContainer: {
+      value: "#5D2906",
+      description: "Text on terracotta container (light)",
+    },
+    terracottaOnContainerDark: {
+      value: "#FFCCBC",
+      description: "Text on terracotta container (dark)",
+    },
+
+    // ─── FIVE HERITAGE COLORS (atmospheric, from above ground) ───
+    // African fashion, sunset, savanna, rivers, ancient and biblical.
+    indigo: {
+      value: "#8C9EFF",
+      description: "Yoruba adire dye pits, Shweshwe cloth — longevity, resilience",
+    },
+    indigoLight: { value: "#1A237E", description: "Indigo on light backgrounds" },
+    savanna: {
+      value: "#FFCC80",
+      description: "Golden grasslands, Sahel to Southern Africa — the journey",
+    },
+    savannaLight: { value: "#5D4037", description: "Savanna on light backgrounds" },
+    baobab: {
+      value: "#A5D6A7",
+      description: "Tree of life, ancestral wisdom — endurance, community roots",
+    },
+    baobabLight: { value: "#2E4A2E", description: "Baobab on light backgrounds" },
+    sunset: {
+      value: "#FF8A80",
+      description: "African dusk, rose-copper sky — endings that are beginnings",
+    },
+    sunsetLight: { value: "#8B2500", description: "Sunset on light backgrounds" },
+    river: { value: "#80DEEA", description: "Zambezi, Limpopo, Nile — life-giving waterways" },
+    riverLight: { value: "#00525A", description: "River on light backgrounds" },
+
+    // Neutrals — warm stone palette (April 2026, AAA-optimised)
+    // Named by role, not arbitrary grey percentage.
+    white: { value: "#FAFAFA" },
+    cream: { value: "#FAF9F5", description: "Light mode muted fill / warm cream" },
+    warmGrey: { value: "#F3F2EE", description: "Light mode ambient background" },
+    stone68: { value: "#B2AFA8", description: "Dark mode muted-foreground (AAA on all surfaces)" },
+    stone27: { value: "#494840", description: "Light mode muted-foreground (AAA on all surfaces)" },
+    overlay: { value: "#252421", description: "Dark mode modal/sheet surface (L14%)" },
+    ambient: { value: "#1B1A17", description: "Dark mode page background (L10%, warm stone)" },
+    surface: { value: "#100F0E", description: "Dark mode card surface (L6%)" },
+    deep: { value: "#050504", description: "Dark mode deepest fill (L2%, max text contrast)" },
+    black: { value: "#000000" },
+
+    // Semantic raw values
+    success: { value: "#4ADE80" },
+    warning: { value: "#FBBF24" },
+    error: { value: "#F87171" },
+    info: { value: "#00B0FF" },
+  },
+
+  // ─── SPACING SCALE (design portal canonical) ───────────────
+  spacing: {
+    "0": { value: "0px" },
+    xs: { value: "4px", description: "Tight gaps, icon padding" },
+    sm: { value: "8px", description: "Compact spacing, inline gaps" },
+    md: { value: "12px", description: "Default component padding" },
+    base: { value: "16px", description: "Standard spacing" },
+    lg: { value: "24px", description: "Section padding, card gaps" },
+    xl: { value: "32px", description: "Page margins, large gaps" },
+    "2xl": { value: "48px", description: "Section margins" },
+    "3xl": { value: "64px", description: "Page section spacing" },
+  },
+
+  // ─── BORDER RADIUS (design portal canonical) ──────────────
+  // Base unit: 7px (--radius-unit). Ecosystem numbers: 7, 12, 14, 17.
+  // Buttons are ALWAYS pill (rounded-full, 9999px).
+  radius: {
+    none: { value: "0px" },
+    sm: { value: "7px", description: "Subtle rounding, checkboxes, small elements" },
+    md: { value: "12px", description: "Cards, inputs, containers" },
+    lg: { value: "14px", description: "Default radius, medium containers" },
+    xl: { value: "17px", description: "Large cards, dialogs, prominent surfaces" },
+    full: { value: "9999px", description: "Buttons, badges, pills, avatars — ALWAYS pill" },
+    circle: { value: "50%", description: "Perfect circles" },
+  },
+
+  // ─── TYPOGRAPHY (design portal canonical) ─────────────────
+  // Noto Sans/Serif chosen for cross-language compatibility
+  // (800+ languages including African languages and diacritics)
+  fontFamily: {
+    sans: {
+      value: '"Noto Sans", system-ui, -apple-system, sans-serif',
+      description: "Body/UI — all text, labels, descriptions",
+    },
+    serif: {
+      value: '"Noto Serif", Georgia, "Times New Roman", serif',
+      description: "Display — page titles, hero text, H1-H3",
+    },
+    mono: {
+      value: '"JetBrains Mono", "Fira Code", monospace',
+      description: "Code — blocks, terminal, technical",
+    },
+  },
+
+  // Type scale (design portal canonical)
+  fontSize: {
+    caption: { value: "12px", description: "0.75rem — Labels, metadata, timestamps" },
+    bodySmall: { value: "14px", description: "0.875rem — Secondary text, descriptions" },
+    body: { value: "16px", description: "1rem — Default body text" },
+    bodyLarge: { value: "18px", description: "1.125rem — Lead paragraphs" },
+    h5: { value: "20px", description: "1.25rem — Noto Sans 600 — Small headings" },
+    h4: { value: "24px", description: "1.5rem — Noto Sans 600 — Card titles" },
+    h3: { value: "30px", description: "1.875rem — Noto Serif 600 — Sub-sections" },
+    h2: { value: "36px", description: "2.25rem — Noto Serif 600 — Section headings" },
+    h1: { value: "48px", description: "3rem — Noto Serif 700 — Page titles" },
+    display: { value: "72px", description: "4.5rem — Noto Serif 700 — Hero headlines" },
+  },
+
+  fontWeight: {
+    light: { value: "300" },
+    regular: { value: "400" },
+    medium: { value: "500" },
+    semibold: { value: "600" },
+    bold: { value: "700" },
+  },
+
+  // ─── TOUCH TARGETS (design portal canonical) ──────────────
+  // APCA 3.0 AAA accessibility standard
+  touchTarget: {
+    default: { value: "56px", description: "Default interactive element height" },
+    sm: { value: "48px", description: "Minimum — NEVER below this" },
+  },
+
+  // ─── MOTION (design portal canonical) ─────────────────────
+  motion: {
+    duration: {
+      quick: { value: "100ms", description: "Micro-interactions, toggles" },
+      standard: { value: "200ms", description: "Default transitions" },
+      emphasis: { value: "350ms", description: "Entry/exit animations" },
+      dramatic: { value: "500ms", description: "Page transitions, celebrations" },
+    },
+    easing: {
+      entrance: { value: "cubic-bezier(0.0, 0.0, 0.2, 1)", description: "Elements entering view" },
+      exit: { value: "cubic-bezier(0.4, 0.0, 1, 1)", description: "Elements leaving view" },
+      standard: { value: "cubic-bezier(0.4, 0.0, 0.2, 1)", description: "General movement" },
+      spring: { value: "cubic-bezier(0.175, 0.885, 0.32, 1.275)", description: "Bouncy, playful" },
+    },
+    stagger: {
+      delay: { value: "50ms", description: "Per-item delay in lists" },
+      maxItems: {
+        value: "8",
+        description: "Max items to stagger (beyond this, all appear together)",
+      },
+    },
+  },
+
+  // ─── SHADOWS / ELEVATION ──────────────────────────────────
+  shadow: {
+    sm: { value: "0 1px 2px rgba(0,0,0,0.15)" },
+    md: { value: "0 4px 12px rgba(0,0,0,0.2)" },
+    lg: { value: "0 8px 24px rgba(0,0,0,0.25)" },
+    xl: { value: "0 20px 60px rgba(0,0,0,0.4)" },
+    glow: { value: "0 4px 20px rgba(100,255,218,0.3)", description: "Malachite glow for FABs" },
+  },
+
+  // ─── Z-INDEX SCALE ────────────────────────────────────────
+  zIndex: {
+    base: { value: "0" },
+    dropdown: { value: "10" },
+    sticky: { value: "20" },
+    overlay: { value: "30" },
+    modal: { value: "40" },
+    toast: { value: "50" },
+    tooltip: { value: "60" },
+  },
+
+  // ─── BREAKPOINTS ──────────────────────────────────────────
+  breakpoint: {
+    mobile: { value: "0px" },
+    tablet: { value: "640px" },
+    desktop: { value: "1024px" },
+    wide: { value: "1440px" },
+  },
+} as const
+
+// ═══════════════════════════════════════════════════════════════
+// TIER 2 — SEMANTIC TOKENS
+// These change per theme. Values from design portal canonical.
+// ═══════════════════════════════════════════════════════════════
+
+export type ThemeMode = "dark" | "light" | "high-contrast"
+
+export const semanticTokens: Record<ThemeMode, Record<string, { value: string }>> = {
+  dark: {
+    // Surfaces — SWAPPED arrangement, AAA-optimised (April 2026)
+    // background is the AMBIENT page base (lighter, L10%)
+    // card is the CONTENT surface (darker, L6%)
+    // muted is the DEEPEST fill (L2%, maximum text contrast)
+    // overlay is the MODAL/SHEET surface (L14%, scrim creates pop)
+    background: { value: "#1B1A17" },
+    foreground: { value: "#F5F5F4" },
+    card: { value: "#100F0E" },
+    "card-foreground": { value: "#F5F5F4" },
+    muted: { value: "#050504" },
+    "muted-foreground": { value: "#B2AFA8" },
+    overlay: { value: "#252421" },
+    scrim: { value: "rgba(0,0,0,0.60)" },
+    primary: { value: "#F5F5F4" },
+    "primary-foreground": { value: "#1B1A17" },
+    secondary: { value: "#050504" },
+    "secondary-foreground": { value: "#F5F5F4" },
+    accent: { value: "#050504" },
+    "accent-foreground": { value: "#F5F5F4" },
+    destructive: { value: "#F2B8B5" },
+    border: { value: "rgba(255,255,255,0.06)" },
+    input: { value: "rgba(255,255,255,0.06)" },
+    ring: { value: "#F5F5F4" },
+  },
+  light: {
+    // Surfaces — SWAPPED arrangement, AAA-optimised (April 2026)
+    // background is the AMBIENT page base (warm grey, slightly tinted)
+    // card is the CONTENT surface (pure white)
+    // muted is the WARM CREAM fill
+    // overlay is the MODAL/SHEET surface (white, same as card in light mode)
+    background: { value: "#F3F2EE" },
+    foreground: { value: "#141413" },
+    card: { value: "#FFFFFF" },
+    "card-foreground": { value: "#141413" },
+    muted: { value: "#FAF9F5" },
+    "muted-foreground": { value: "#494840" },
+    overlay: { value: "#FFFFFF" },
+    scrim: { value: "rgba(0,0,0,0.40)" },
+    primary: { value: "#141413" },
+    "primary-foreground": { value: "#FFFFFF" },
+    secondary: { value: "#FAF9F5" },
+    "secondary-foreground": { value: "#141413" },
+    accent: { value: "#FAF9F5" },
+    "accent-foreground": { value: "#141413" },
+    destructive: { value: "#B3261E" },
+    border: { value: "rgba(10,10,10,0.06)" },
+    input: { value: "rgba(10,10,10,0.06)" },
+    ring: { value: "#141413" },
+  },
+  "high-contrast": {
+    background: { value: "#000000" },
+    foreground: { value: "#FFFFFF" },
+    card: { value: "#1A1A1A" },
+    "card-foreground": { value: "#FFFFFF" },
+    muted: { value: "#2A2A2A" },
+    "muted-foreground": { value: "#E0E0E0" },
+    primary: { value: "#FFFFFF" },
+    "primary-foreground": { value: "#000000" },
+    secondary: { value: "#2A2A2A" },
+    "secondary-foreground": { value: "#FFFFFF" },
+    accent: { value: "#2A2A2A" },
+    "accent-foreground": { value: "#FFFFFF" },
+    destructive: { value: "#FCA5A5" },
+    border: { value: "#FFFFFF" },
+    input: { value: "#FFFFFF" },
+    ring: { value: "#FFFFFF" },
+  },
+}
+
+// ═══════════════════════════════════════════════════════════════
+// LISTING THEMES — Ten Colors of Africa
+// Five Minerals (geological) + Five Heritage (atmospheric)
+// Each theme provides a background gradient for listing pages.
+// ═══════════════════════════════════════════════════════════════
+
+export type ListingTheme =
+  | "default"
+  | "cobalt"
+  | "tanzanite"
+  | "malachite"
+  | "gold"
+  | "terracotta"
+  | "indigo"
+  | "savanna"
+  | "baobab"
+  | "sunset"
+  | "river"
+
+export const listingThemes: Record<
+  ListingTheme,
+  {
+    name: string
+    accent: string | null
+    bg: string
+    surface: string
+    gradient: string | null
+    family: "mineral" | "heritage" | "default"
+    origin: string
+  }
+> = {
+  default: {
+    name: "Default",
+    accent: null,
+    bg: "#1B1A17",
+    surface: "#100F0E",
+    gradient: null,
+    family: "default",
+    origin: "",
+  },
+  // Minerals
+  cobalt: {
+    name: "Cobalt",
+    accent: "#00B0FF",
+    bg: "#001833",
+    surface: "#002244",
+    gradient: "linear-gradient(145deg, #000D1A 0%, #001833 50%, #002244 100%)",
+    family: "mineral",
+    origin: "Katanga (DRC), Zambian Copperbelt",
+  },
+  tanzanite: {
+    name: "Tanzanite",
+    accent: "#B388FF",
+    bg: "#1A0033",
+    surface: "#2A0055",
+    gradient: "linear-gradient(145deg, #0D001A 0%, #1A0033 50%, #2A0055 100%)",
+    family: "mineral",
+    origin: "Merelani Hills, Tanzania",
+  },
+  malachite: {
+    name: "Malachite",
+    accent: "#64FFDA",
+    bg: "#002E25",
+    surface: "#003D32",
+    gradient: "linear-gradient(145deg, #001A14 0%, #002E25 50%, #003D32 100%)",
+    family: "mineral",
+    origin: "Congo Copper Belt",
+  },
+  gold: {
+    name: "Gold",
+    accent: "#FFD740",
+    bg: "#1A1400",
+    surface: "#2A2200",
+    gradient: "linear-gradient(145deg, #0D0A00 0%, #1A1400 50%, #2A2200 100%)",
+    family: "mineral",
+    origin: "Ghana, South Africa, Mali",
+  },
+  terracotta: {
+    name: "Terracotta",
+    accent: "#D4A574",
+    bg: "#1A0F05",
+    surface: "#2A1A0A",
+    gradient: "linear-gradient(145deg, #0D0800 0%, #1A0F05 50%, #2A1A0A 100%)",
+    family: "mineral",
+    origin: "Pan-African Sahel",
+  },
+  // Heritage
+  indigo: {
+    name: "Indigo",
+    accent: "#8C9EFF",
+    bg: "#0D1040",
+    surface: "#141866",
+    gradient: "linear-gradient(145deg, #050820 0%, #0D1040 50%, #141866 100%)",
+    family: "heritage",
+    origin: "Yoruba adire, Kano dye pits, Shweshwe cloth",
+  },
+  savanna: {
+    name: "Savanna",
+    accent: "#FFCC80",
+    bg: "#1A1408",
+    surface: "#2A2010",
+    gradient: "linear-gradient(145deg, #0D0A03 0%, #1A1408 50%, #2A2010 100%)",
+    family: "heritage",
+    origin: "Golden grasslands, Sahel to Southern Africa",
+  },
+  baobab: {
+    name: "Baobab",
+    accent: "#A5D6A7",
+    bg: "#0F1A0F",
+    surface: "#1A2A1A",
+    gradient: "linear-gradient(145deg, #060D06 0%, #0F1A0F 50%, #1A2A1A 100%)",
+    family: "heritage",
+    origin: "Tree of life, sub-Saharan Africa",
+  },
+  sunset: {
+    name: "Sunset",
+    accent: "#FF8A80",
+    bg: "#2A0A02",
+    surface: "#3D1005",
+    gradient: "linear-gradient(145deg, #1A0500 0%, #2A0A02 50%, #3D1005 100%)",
+    family: "heritage",
+    origin: "African dusk, rose-copper sky",
+  },
+  river: {
+    name: "River",
+    accent: "#80DEEA",
+    bg: "#002025",
+    surface: "#003035",
+    gradient: "linear-gradient(145deg, #001418 0%, #002025 50%, #003035 100%)",
+    family: "heritage",
+    origin: "Zambezi, Limpopo, Nile, Congo",
+  },
+}
+
+// ═══════════════════════════════════════════════════════════════
+// BRAND OVERRIDES — Per-app accent colors
+// Each mini-app overrides the primary accent.
+// ═══════════════════════════════════════════════════════════════
+
+export type BrandId =
+  | "mukoko"
+  | "nhimbe"
+  | "bushtrade"
+  | "lingo"
+  | "shamwari"
+  | "campfire"
+  | "bytes"
+  | "novels"
+  | "news"
+  | "places"
+  | "circles"
+  | "planner"
+  | "transport"
+  | "weather"
+  | "health"
+  | "jobs"
+  | "wallet"
+
+export const brandOverrides: Record<
+  BrandId,
+  {
+    primary: string
+    mineral: string
+    primaryHover: string
+    primaryMuted: string
+    container: string
+    onContainer: string
+  }
+> = {
+  // ─── Mini-App accents (canonical from brand_ecosystem table) ──
+  // Mineral assignments: tanzanite=identity/social/premium, cobalt=info/education/productivity,
+  // malachite=events/health/nature, gold=commerce/places/wallet, terracotta=community
+  mukoko: {
+    primary: "#B388FF",
+    mineral: "tanzanite",
+    primaryHover: "#CE9FFF",
+    primaryMuted: "rgba(179,136,255,0.12)",
+    container: "#F3E5F5",
+    onContainer: "#2E004D",
+  },
+  nhimbe: {
+    primary: "#64FFDA",
+    mineral: "malachite",
+    primaryHover: "#80FFE4",
+    primaryMuted: "rgba(100,255,218,0.12)",
+    container: "#E0F2F1",
+    onContainer: "#00332B",
+  },
+  bushtrade: {
+    primary: "#FFD740",
+    mineral: "gold",
+    primaryHover: "#FFDF6B",
+    primaryMuted: "rgba(255,215,64,0.12)",
+    container: "#FFF8E1",
+    onContainer: "#3E2723",
+  },
+  lingo: {
+    primary: "#00B0FF",
+    mineral: "cobalt",
+    primaryHover: "#40C4FF",
+    primaryMuted: "rgba(0,176,255,0.12)",
+    container: "#E3F2FD",
+    onContainer: "#002966",
+  },
+  shamwari: {
+    primary: "#B388FF",
+    mineral: "tanzanite",
+    primaryHover: "#CE9FFF",
+    primaryMuted: "rgba(179,136,255,0.12)",
+    container: "#F3E5F5",
+    onContainer: "#2E004D",
+  },
+  campfire: {
+    primary: "#64FFDA",
+    mineral: "malachite",
+    primaryHover: "#80FFE4",
+    primaryMuted: "rgba(100,255,218,0.12)",
+    container: "#E0F2F1",
+    onContainer: "#00332B",
+  },
+  bytes: {
+    primary: "#B388FF",
+    mineral: "tanzanite",
+    primaryHover: "#CE9FFF",
+    primaryMuted: "rgba(179,136,255,0.12)",
+    container: "#F3E5F5",
+    onContainer: "#2E004D",
+  },
+  novels: {
+    primary: "#64FFDA",
+    mineral: "malachite",
+    primaryHover: "#80FFE4",
+    primaryMuted: "rgba(100,255,218,0.12)",
+    container: "#E0F2F1",
+    onContainer: "#00332B",
+  },
+  news: {
+    primary: "#00B0FF",
+    mineral: "cobalt",
+    primaryHover: "#40C4FF",
+    primaryMuted: "rgba(0,176,255,0.12)",
+    container: "#E3F2FD",
+    onContainer: "#002966",
+  },
+  places: {
+    primary: "#FFD740",
+    mineral: "gold",
+    primaryHover: "#FFDF6B",
+    primaryMuted: "rgba(255,215,64,0.12)",
+    container: "#FFF8E1",
+    onContainer: "#3E2723",
+  },
+  circles: {
+    primary: "#D4A574",
+    mineral: "terracotta",
+    primaryHover: "#E0B88A",
+    primaryMuted: "rgba(212,165,116,0.12)",
+    container: "#FBE9E7",
+    onContainer: "#5D2906",
+  },
+  planner: {
+    primary: "#00B0FF",
+    mineral: "cobalt",
+    primaryHover: "#40C4FF",
+    primaryMuted: "rgba(0,176,255,0.12)",
+    container: "#E3F2FD",
+    onContainer: "#002966",
+  },
+  transport: {
+    primary: "#FFD740",
+    mineral: "gold",
+    primaryHover: "#FFDF6B",
+    primaryMuted: "rgba(255,215,64,0.12)",
+    container: "#FFF8E1",
+    onContainer: "#3E2723",
+  },
+  weather: {
+    primary: "#00B0FF",
+    mineral: "cobalt",
+    primaryHover: "#40C4FF",
+    primaryMuted: "rgba(0,176,255,0.12)",
+    container: "#E3F2FD",
+    onContainer: "#002966",
+  },
+  health: {
+    primary: "#64FFDA",
+    mineral: "malachite",
+    primaryHover: "#80FFE4",
+    primaryMuted: "rgba(100,255,218,0.12)",
+    container: "#E0F2F1",
+    onContainer: "#00332B",
+  },
+  jobs: {
+    primary: "#FFD740",
+    mineral: "gold",
+    primaryHover: "#FFDF6B",
+    primaryMuted: "rgba(255,215,64,0.12)",
+    container: "#FFF8E1",
+    onContainer: "#3E2723",
+  },
+  wallet: {
+    primary: "#FFD740",
+    mineral: "gold",
+    primaryHover: "#FFDF6B",
+    primaryMuted: "rgba(255,215,64,0.12)",
+    container: "#FFF8E1",
+    onContainer: "#3E2723",
+  },
+}
+
+// ═══════════════════════════════════════════════════════════════
+// BRAND INDUSTRY CATEGORIES — Mineral associations by sector
+// Each brand (Nyuchi enterprise, Mukoko super app, Shamwari AI)
+// organises products into industry categories, each with a
+// mineral accent that reflects the industry's emotional tone.
+// ═══════════════════════════════════════════════════════════════
+
+export type IndustryCategory = {
+  mineral: string
+  label: string
+  products: string[]
+}
+
+export const brandIndustryCategories: Record<string, Record<string, IndustryCategory>> = {
+  nyuchi: {
+    services: {
+      mineral: "gold",
+      label: "Services",
+      products: ["Nyuchi Platform", "Tukmart", "Nyuchi Honey"],
+    },
+    travel: {
+      mineral: "malachite",
+      label: "Travel",
+      products: ["Zimbabwe Travel Information", "Iconic Expeditions"],
+    },
+    education: {
+      mineral: "cobalt",
+      label: "Education",
+      products: ["Nyuchi Learning", "Nyuchi Lingo"],
+    },
+    community: {
+      mineral: "terracotta",
+      label: "Community",
+      products: ["Nyuchi Foundation", "Technology Leaders of Africa"],
+    },
+  },
+  mukoko: {
+    id: { mineral: "tanzanite", label: "Identity", products: ["Mukoko ID", "Digital Twin"] },
+    news: { mineral: "cobalt", label: "News", products: ["Mukoko News"] },
+    social: {
+      mineral: "tanzanite",
+      label: "Social",
+      products: ["Campfire", "Bytes", "Novels", "Circles"],
+    },
+    events: { mineral: "malachite", label: "Events", products: ["Nhimbe"] },
+    commerce: { mineral: "gold", label: "Commerce", products: ["BushTrade", "Wallet"] },
+    places: { mineral: "gold", label: "Places", products: ["Places", "Transport"] },
+    productivity: {
+      mineral: "cobalt",
+      label: "Productivity",
+      products: ["Planner", "Weather", "Jobs"],
+    },
+    wellness: { mineral: "malachite", label: "Wellness", products: ["Health"] },
+    language: { mineral: "cobalt", label: "Language", products: ["Lingo"] },
+  },
+  shamwari: {
+    ai: { mineral: "tanzanite", label: "AI Companion", products: ["Shamwari AI", "Digital Twin"] },
+  },
+}
+
+// ═══════════════════════════════════════════════════════════════
+// TIER 3 — COMPONENT TOKENS
+// Scoped values for specific brand components.
+// ═══════════════════════════════════════════════════════════════
+
+export const componentTokens = {
+  header: { height: "56px", zIndex: "50" },
+  bottomNav: { height: "80px", fabSize: "52px", fabRise: "24px" },
+  sidebar: { width: "256px", collapsedWidth: "64px" },
+  avatar: { sm: "32px", md: "40px", lg: "64px", xl: "80px", xxl: "120px" },
+  badge: { height: "20px", padding: "0 8px", fontSize: "10px" },
+  input: { height: "48px" },
+  button: { height: "56px", heightSm: "48px", heightLg: "56px" },
+  card: { padding: "16px", gap: "14px" },
+  page: { maxWidth: "1280px", margin: "20px" },
+  focusRing: { width: "2px", offset: "2px", color: "var(--ring)" },
+  // GLOBAL CSS RULE (add to globals.css):
+  // :focus-visible { outline: 2px solid var(--ring); outline-offset: 2px; }
+  // button:focus-visible, a:focus-visible, [role="button"]:focus-visible,
+  // input:focus-visible, select:focus-visible, textarea:focus-visible {
+  //   outline: 2px solid var(--ring); outline-offset: 2px;
+  // }
+  mineralStrip: { width: "4px", position: "left", direction: "vertical" },
+  listingImage: {
+    aspectRatio: "1/1",
+    description: "Always square — events, products, articles, places",
+  },
+} as const
+
+// ═══════════════════════════════════════════════════════════════
+// CSS GENERATOR — Produces CSS custom properties for :root
+// ═══════════════════════════════════════════════════════════════
+
+export function generateCSSVariables(theme: ThemeMode = "dark", brand: BrandId = "mukoko"): string {
+  const semantic = semanticTokens[theme]
+  const brandColors = brandOverrides[brand]
+
+  const lines: string[] = [":root {"]
+
+  // Mineral colors (constant across themes)
+  const mineralKeys = ["cobalt", "tanzanite", "malachite", "gold", "terracotta"] as const
+  for (const mineral of mineralKeys) {
+    const val =
+      theme === "light"
+        ? primitives.color[`${mineral}Light` as keyof typeof primitives.color]
+        : primitives.color[mineral]
+    lines.push(`  --color-${mineral}: ${val.value};`)
+  }
+
+  // Heritage colors (constant across themes)
+  const heritageKeys = ["indigo", "savanna", "baobab", "sunset", "river"] as const
+  for (const heritage of heritageKeys) {
+    const val =
+      theme === "light"
+        ? primitives.color[`${heritage}Light` as keyof typeof primitives.color]
+        : primitives.color[heritage]
+    lines.push(`  --color-${heritage}: ${val.value};`)
+  }
+
+  // Radii
+  for (const [key, val] of Object.entries(primitives.radius)) {
+    lines.push(`  --radius-${key}: ${val.value};`)
+  }
+
+  // Spacing
+  for (const [key, val] of Object.entries(primitives.spacing)) {
+    lines.push(`  --space-${key}: ${val.value};`)
+  }
+
+  // Shadows
+  for (const [key, val] of Object.entries(primitives.shadow)) {
+    lines.push(`  --shadow-${key}: ${val.value};`)
+  }
+
+  // Touch targets
+  lines.push(`  --touch-target: ${primitives.touchTarget.default.value};`)
+  lines.push(`  --touch-target-sm: ${primitives.touchTarget.sm.value};`)
+
+  // Motion
+  for (const [key, val] of Object.entries(primitives.motion.duration)) {
+    lines.push(`  --motion-${key}: ${val.value};`)
+  }
+  for (const [key, val] of Object.entries(primitives.motion.easing)) {
+    lines.push(`  --easing-${key}: ${val.value};`)
+  }
+
+  // Semantic tokens (theme-dependent)
+  for (const [key, val] of Object.entries(semantic)) {
+    lines.push(`  --${key}: ${val.value};`)
+  }
+
+  // Brand overrides
+  lines.push(`  --color-primary: ${brandColors.primary};`)
+  lines.push(`  --color-primary-hover: ${brandColors.primaryHover};`)
+  lines.push(`  --color-primary-muted: ${brandColors.primaryMuted};`)
+
+  // Component tokens
+  for (const [comp, tokens] of Object.entries(componentTokens)) {
+    for (const [key, val] of Object.entries(tokens)) {
+      lines.push(`  --${comp}-${key}: ${val};`)
+    }
+  }
+
+  lines.push("}")
+  return lines.join("\n")
+}
+
+// ═══════════════════════════════════════════════════════════════
+// MULTI-PLATFORM TOKEN GENERATOR
+// Produces token files for every platform in the ecosystem.
+// ═══════════════════════════════════════════════════════════════
+
+export type PlatformFormat =
+  | "css"
+  | "swift"
+  | "kotlin"
+  | "arkts"
+  | "react-native"
+  | "rust"
+  | "python"
+  | "json"
+
+export function generateTokens(format: PlatformFormat): string {
+  switch (format) {
+    case "json":
+      return JSON.stringify(
+        { primitives, semanticTokens, brandOverrides, listingThemes, componentTokens },
+        null,
+        2
+      )
+
+    case "swift":
+      return generateSwiftTokens()
+
+    case "kotlin":
+      return generateKotlinTokens()
+
+    case "rust":
+      return generateRustTokens()
+
+    case "python":
+      return generatePythonTokens()
+
+    default:
+      return generateCSSVariables()
+  }
+}
+
+function generateSwiftTokens(): string {
+  const lines = [
+    "// MUKOKO DESIGN TOKENS — Auto-generated from tokens.ts",
+    "// Do not edit manually. Source: design.nyuchi.com",
+    "import SwiftUI",
+    "",
+    "extension Color {",
+  ]
+  const mineralKeys = ["cobalt", "tanzanite", "malachite", "gold", "terracotta"] as const
+  const heritageKeys = ["indigo", "savanna", "baobab", "sunset", "river"] as const
+  for (const key of [...mineralKeys, ...heritageKeys]) {
+    // Swift color values are baked at asset-catalog generation time; the
+    // emitted line just references the catalog key, so the dark/light
+    // values aren't used in this loop.
+    lines.push(
+      `    static let mukoko${key.charAt(0).toUpperCase() + key.slice(1)} = Color("nyuchi-${key}")`
+    )
+  }
+  lines.push("}")
+  return lines.join("\n")
+}
+
+function generateKotlinTokens(): string {
+  const lines = [
+    "// MUKOKO DESIGN TOKENS — Auto-generated from tokens.ts",
+    "// Do not edit manually. Source: design.nyuchi.com",
+    "package com.mukoko.design.tokens",
+    "",
+    "import androidx.compose.ui.graphics.Color",
+    "",
+    "object MukokoColors {",
+  ]
+  const allKeys = [
+    "cobalt",
+    "tanzanite",
+    "malachite",
+    "gold",
+    "terracotta",
+    "indigo",
+    "savanna",
+    "baobab",
+    "sunset",
+    "river",
+  ] as const
+  for (const key of allKeys) {
+    const val = primitives.color[key].value
+    const hex = val.replace("#", "")
+    lines.push(`    val ${key.charAt(0).toUpperCase() + key.slice(1)} = Color(0xFF${hex})`)
+  }
+  lines.push("}")
+  return lines.join("\n")
+}
+
+function generateRustTokens(): string {
+  const lines = [
+    "// MUKOKO DESIGN TOKENS — Auto-generated from tokens.ts",
+    "// Do not edit manually. Source: design.nyuchi.com",
+    "",
+  ]
+  const allKeys = [
+    "cobalt",
+    "tanzanite",
+    "malachite",
+    "gold",
+    "terracotta",
+    "indigo",
+    "savanna",
+    "baobab",
+    "sunset",
+    "river",
+  ] as const
+  for (const key of allKeys) {
+    const val = primitives.color[key].value
+    lines.push(`pub const MUKOKO_${key.toUpperCase()}: &str = "${val}";`)
+  }
+  return lines.join("\n")
+}
+
+function generatePythonTokens(): string {
+  const lines = [
+    "# MUKOKO DESIGN TOKENS — Auto-generated from tokens.ts",
+    "# Do not edit manually. Source: design.nyuchi.com",
+    "from dataclasses import dataclass",
+    "",
+    "@dataclass(frozen=True)",
+    "class MukokoColors:",
+  ]
+  const allKeys = [
+    "cobalt",
+    "tanzanite",
+    "malachite",
+    "gold",
+    "terracotta",
+    "indigo",
+    "savanna",
+    "baobab",
+    "sunset",
+    "river",
+  ] as const
+  for (const key of allKeys) {
+    const val = primitives.color[key].value
+    lines.push(`    ${key.toUpperCase()}: str = "${val}"`)
+  }
+  return lines.join("\n")
+}
+
+// ═══════════════════════════════════════════════════════════════
+// EXPORTS
+// ═══════════════════════════════════════════════════════════════
+
+// ═══════════════════════════════════════════════════════════════
+// ═══════════════════════════════════════════════════════════════
+// SEMANTIC STATUS & ALERT TOKEN SYSTEM
+//
+// IMPORTANT: These use GLOBALLY RECOGNIZED accessibility colors,
+// NOT the Five African Minerals. The minerals are brand identity
+// (links, CTAs, achievements, community). Status colors are a
+// SEPARATE universal system that works across all languages,
+// literacy levels, and cultures. Color is the first thing people
+// see — especially across Africa and different languages.
+//
+// WCAG AA compliant on both light and dark backgrounds.
+// Based on: Material Design, Apple HIG, W3C accessibility guidelines.
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * Universal status colors — WCAG AA compliant, globally recognized.
+ * These are NOT minerals. Red = error. Amber = warning. Green = success.
+ * People see color before text. This is critical for accessibility.
+ */
+export const universalStatus = {
+  success: "#22C55E", // Green-500 — universal "go/safe/done/complete"
+  warning: "#F59E0B", // Amber-500 — universal "caution/attention/pending"
+  error: "#EF4444", // Red-500 — universal "stop/danger/error/failed"
+  info: "#3B82F6", // Blue-500 — universal "notice/information/help"
+  neutral: "#6B7280", // Gray-500 — neutral/inactive/disabled/unknown
+} as const
+
+/**
+ * Status tokens — the universal 5-state status system.
+ * Every component that shows success/warning/error/info/neutral uses these.
+ */
+export const statusTokens = {
+  success: {
+    value: "var(--status-success, #22C55E)",
+    css: "--status-success",
+    hex: "#22C55E",
+    label: "Success",
+  },
+  warning: {
+    value: "var(--status-warning, #F59E0B)",
+    css: "--status-warning",
+    hex: "#F59E0B",
+    label: "Warning",
+  },
+  error: {
+    value: "var(--status-error, #EF4444)",
+    css: "--status-error",
+    hex: "#EF4444",
+    label: "Error",
+  },
+  info: {
+    value: "var(--status-info, #3B82F6)",
+    css: "--status-info",
+    hex: "#3B82F6",
+    label: "Info",
+  },
+  neutral: {
+    value: "var(--status-neutral, #6B7280)",
+    css: "--status-neutral",
+    hex: "#6B7280",
+    label: "Neutral",
+  },
+} as const
+
+/**
+ * Severity tokens — graduated urgency scale for alerts, weather, health.
+ * Uses universally recognized color escalation: green → amber → orange → red.
+ */
+export const severityTokens = {
+  low: {
+    value: "var(--severity-low, #22C55E)",
+    css: "--severity-low",
+    hex: "#22C55E",
+    label: "Low",
+  },
+  moderate: {
+    value: "var(--severity-moderate, #F59E0B)",
+    css: "--severity-moderate",
+    hex: "#F59E0B",
+    label: "Moderate",
+  },
+  high: {
+    value: "var(--severity-high, #F97316)",
+    css: "--severity-high",
+    hex: "#F97316",
+    label: "High",
+  },
+  severe: {
+    value: "var(--severity-severe, #EF4444)",
+    css: "--severity-severe",
+    hex: "#EF4444",
+    label: "Severe",
+  },
+  extreme: {
+    value: "var(--severity-extreme, #DC2626)",
+    css: "--severity-extreme",
+    hex: "#DC2626",
+    label: "Extreme",
+  },
+  cold: {
+    value: "var(--severity-cold, #3B82F6)",
+    css: "--severity-cold",
+    hex: "#3B82F6",
+    label: "Cold",
+  },
+} as const
+
+/**
+ * Notification tokens — for toast, banner, and notification components.
+ * Same universal colors as status — consistency across all notification types.
+ */
+export const notificationTokens = {
+  success: {
+    value: "var(--notification-success, #22C55E)",
+    css: "--notification-success",
+    hex: "#22C55E",
+  },
+  warning: {
+    value: "var(--notification-warning, #F59E0B)",
+    css: "--notification-warning",
+    hex: "#F59E0B",
+  },
+  error: {
+    value: "var(--notification-error, #EF4444)",
+    css: "--notification-error",
+    hex: "#EF4444",
+  },
+  info: { value: "var(--notification-info, #3B82F6)", css: "--notification-info", hex: "#3B82F6" },
+} as const
+
+/**
+ * Connection tokens — connectivity gradient for local-first architecture.
+ * Green = online, Blue = syncing, Amber = cached, Red/Orange = offline.
+ */
+export const connectionTokens = {
+  online: {
+    value: "var(--connection-online, #22C55E)",
+    css: "--connection-online",
+    hex: "#22C55E",
+    label: "Connected",
+  },
+  syncing: {
+    value: "var(--connection-syncing, #3B82F6)",
+    css: "--connection-syncing",
+    hex: "#3B82F6",
+    label: "Syncing",
+  },
+  cached: {
+    value: "var(--connection-cached, #F59E0B)",
+    css: "--connection-cached",
+    hex: "#F59E0B",
+    label: "Cached",
+  },
+  offline: {
+    value: "var(--connection-offline, #EF4444)",
+    css: "--connection-offline",
+    hex: "#EF4444",
+    label: "Offline",
+  },
+} as const
+
+/**
+ * Verification tier tokens — these DO use minerals because they are BRAND identity.
+ * Verification tiers are a Mukoko-specific concept, not a universal status.
+ * The minerals communicate prestige and progression within the ecosystem.
+ */
+export const verificationTokens = {
+  unverified: {
+    value: "var(--tier-unverified, #6B7280)",
+    css: "--tier-unverified",
+    hex: "#6B7280",
+    label: "Unverified",
+  },
+  community: {
+    value: "var(--tier-community, var(--color-malachite, #64FFDA))",
+    css: "--tier-community",
+    mineral: "malachite",
+    label: "Community",
+  },
+  otp: {
+    value: "var(--tier-otp, var(--color-cobalt, #00B0FF))",
+    css: "--tier-otp",
+    mineral: "cobalt",
+    label: "OTP Verified",
+  },
+  government: {
+    value: "var(--tier-government, var(--color-tanzanite, #B388FF))",
+    css: "--tier-government",
+    mineral: "tanzanite",
+    label: "Government ID",
+  },
+  licensed: {
+    value: "var(--tier-licensed, var(--color-gold, #FFD740))",
+    css: "--tier-licensed",
+    mineral: "gold",
+    label: "Licensed",
+  },
+} as const
+
+/**
+ * Crypto level tokens — universal color scale (green = safe, red = none).
+ * NOT minerals — these are security indicators that must be instantly readable.
+ */
+export const cryptoTokens = {
+  quantumSafe: {
+    value: "var(--crypto-quantum-safe, #22C55E)",
+    css: "--crypto-quantum-safe",
+    hex: "#22C55E",
+    label: "Quantum Safe",
+  },
+  classical: {
+    value: "var(--crypto-classical, #3B82F6)",
+    css: "--crypto-classical",
+    hex: "#3B82F6",
+    label: "Classical",
+  },
+  weak: {
+    value: "var(--crypto-weak, #F59E0B)",
+    css: "--crypto-weak",
+    hex: "#F59E0B",
+    label: "Weak",
+  },
+  none: {
+    value: "var(--crypto-none, #EF4444)",
+    css: "--crypto-none",
+    hex: "#EF4444",
+    label: "None",
+  },
+} as const
+
+/**
+ * Moderation tokens — universal colors (green = approved, red = rejected).
+ */
+export const moderationTokens = {
+  approved: {
+    value: "var(--moderation-approved, #22C55E)",
+    css: "--moderation-approved",
+    hex: "#22C55E",
+    label: "Approved",
+  },
+  pending: {
+    value: "var(--moderation-pending, #F59E0B)",
+    css: "--moderation-pending",
+    hex: "#F59E0B",
+    label: "Pending",
+  },
+  flagged: {
+    value: "var(--moderation-flagged, #F97316)",
+    css: "--moderation-flagged",
+    hex: "#F97316",
+    label: "Flagged",
+  },
+  rejected: {
+    value: "var(--moderation-rejected, #EF4444)",
+    css: "--moderation-rejected",
+    hex: "#EF4444",
+    label: "Rejected",
+  },
+} as const
+
+/**
+ * Service health tokens — universal colors (green = operational, red = outage).
+ */
+export const serviceHealthTokens = {
+  operational: {
+    value: "var(--health-operational, #22C55E)",
+    css: "--health-operational",
+    hex: "#22C55E",
+    label: "Operational",
+  },
+  degraded: {
+    value: "var(--health-degraded, #F59E0B)",
+    css: "--health-degraded",
+    hex: "#F59E0B",
+    label: "Degraded",
+  },
+  outage: {
+    value: "var(--health-outage, #EF4444)",
+    css: "--health-outage",
+    hex: "#EF4444",
+    label: "Outage",
+  },
+  maintenance: {
+    value: "var(--health-maintenance, #3B82F6)",
+    css: "--health-maintenance",
+    hex: "#3B82F6",
+    label: "Maintenance",
+  },
+} as const
+
+/**
+ * Generate CSS custom property declarations for all semantic tokens.
+ */
+export function generateStatusCSS(): string {
+  const lines = [":root {", "  /* Universal status colors — NOT minerals */"]
+  const groups = [
+    { name: "Status", tokens: statusTokens },
+    { name: "Severity", tokens: severityTokens },
+    { name: "Notification", tokens: notificationTokens },
+    { name: "Connection", tokens: connectionTokens },
+    { name: "Crypto", tokens: cryptoTokens },
+    { name: "Moderation", tokens: moderationTokens },
+    { name: "Health", tokens: serviceHealthTokens },
+  ]
+  for (const group of groups) {
+    lines.push(`  /* ${group.name} */`)
+    for (const [, token] of Object.entries(group.tokens)) {
+      if ("css" in token && "hex" in token) lines.push(`  ${token.css}: ${token.hex};`)
+    }
+  }
+  lines.push("  /* Verification tiers — these use minerals (brand identity) */")
+  lines.push("  --tier-unverified: #6B7280;")
+  lines.push("  --tier-community: var(--color-malachite, #64FFDA);")
+  lines.push("  --tier-otp: var(--color-cobalt, #00B0FF);")
+  lines.push("  --tier-government: var(--color-tanzanite, #B388FF);")
+  lines.push("  --tier-licensed: var(--color-gold, #FFD740);")
+  lines.push("}")
+  return lines.join("\n")
+}
+
+// CHART COLOR SYSTEM
+// Maps chart indices to Five African Minerals + Heritage colors.
+// Replaces shadcn default --chart-1..5 with Nyuchi mineral palette.
+// Import mineralChartConfig in any chart block for instant brand compliance.
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * CSS custom property definitions for globals.css:
+ *
+ * :root (light mode):
+ *   --chart-1: #0047AB;  (cobalt)
+ *   --chart-2: #4B0082;  (tanzanite)
+ *   --chart-3: #004D40;  (malachite)
+ *   --chart-4: #5D4037;  (gold)
+ *   --chart-5: #8B4513;  (terracotta)
+ *
+ * .dark:
+ *   --chart-1: #00B0FF;  (cobalt)
+ *   --chart-2: #B388FF;  (tanzanite)
+ *   --chart-3: #64FFDA;  (malachite)
+ *   --chart-4: #FFD740;  (gold)
+ *   --chart-5: #D4A574;  (terracotta)
+ */
+
+/** Pre-built chart configs mapping data keys to mineral colors */
+export const mineralChartConfig = {
+  /** Single-series chart — uses cobalt */
+  single: (label: string) => ({
+    value: { label, color: "var(--color-cobalt, #00B0FF)" },
+  }),
+  /** Two-series chart — cobalt + malachite */
+  dual: (label1: string, label2: string) => ({
+    [label1.toLowerCase().replace(/\\s/g, "_")]: {
+      label: label1,
+      color: "var(--color-cobalt, #00B0FF)",
+    },
+    [label2.toLowerCase().replace(/\\s/g, "_")]: {
+      label: label2,
+      color: "var(--color-malachite, #64FFDA)",
+    },
+  }),
+  /** Five-series chart — all five minerals */
+  fiveMinerals: (labels: [string, string, string, string, string]) => ({
+    [labels[0].toLowerCase().replace(/\\s/g, "_")]: {
+      label: labels[0],
+      color: "var(--color-cobalt, #00B0FF)",
+    },
+    [labels[1].toLowerCase().replace(/\\s/g, "_")]: {
+      label: labels[1],
+      color: "var(--color-tanzanite, #B388FF)",
+    },
+    [labels[2].toLowerCase().replace(/\\s/g, "_")]: {
+      label: labels[2],
+      color: "var(--color-malachite, #64FFDA)",
+    },
+    [labels[3].toLowerCase().replace(/\\s/g, "_")]: {
+      label: labels[3],
+      color: "var(--color-gold, #FFD740)",
+    },
+    [labels[4].toLowerCase().replace(/\\s/g, "_")]: {
+      label: labels[4],
+      color: "var(--color-terracotta, #D4A574)",
+    },
+  }),
+  /** Heritage colors for series 6-10 */
+  heritage: {
+    indigo: "var(--color-indigo, #8C9EFF)",
+    savanna: "var(--color-savanna, #FFCC80)",
+    baobab: "var(--color-baobab, #A5D6A7)",
+    sunset: "var(--color-sunset, #FF8A80)",
+    river: "var(--color-river, #80DEEA)",
+  },
+} as const
+
+/** Chart color array for recharts — mineral order */
+export const mineralChartColors = [
+  "var(--color-cobalt, #00B0FF)",
+  "var(--color-tanzanite, #B388FF)",
+  "var(--color-malachite, #64FFDA)",
+  "var(--color-gold, #FFD740)",
+  "var(--color-terracotta, #D4A574)",
+  "var(--color-indigo, #8C9EFF)",
+  "var(--color-savanna, #FFCC80)",
+  "var(--color-baobab, #A5D6A7)",
+  "var(--color-sunset, #FF8A80)",
+  "var(--color-river, #80DEEA)",
+] as const
+
+// ═══════════════════════════════════════════════════════════════
+// COLOR RESOLUTION UTILITIES
+// For Canvas-based charts and non-CSS-aware rendering contexts.
+// CSS var() references don't work in Canvas 2D — these resolve
+// them to concrete hex values at runtime.
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * Resolve a CSS custom property to its computed value.
+ * Returns the concrete color for Canvas 2D, WebGL, or native contexts.
+ * Falls back to the raw string if resolution fails (SSR, DOM not ready).
+ */
+export function resolveColor(color: string): string {
+  if (typeof window === "undefined") return color
+  if (!color.startsWith("var(")) return color
+  const prop = color
+    .replace(/^var\(/, "")
+    .replace(/\)$/, "")
+    .split(",")[0]
+    .trim()
+  try {
+    const resolved = getComputedStyle(document.documentElement).getPropertyValue(prop).trim()
+    return resolved || color
+  } catch {
+    return color
+  }
+}
+
+/**
+ * Apply alpha to a resolved color string.
+ * Handles hex (#RGB, #RRGGBB), rgb(), rgba(), hsl(), hsla(), oklch().
+ * Canvas 2D cannot use CSS opacity — must compute rgba directly.
+ */
+export function hexWithAlpha(color: string, alpha: number): string {
+  const a = Math.max(0, Math.min(1, alpha))
+  if (!color || color.startsWith("var(")) return `rgba(0,0,0,${a})`
+
+  const rgbMatch = color.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)/)
+  if (rgbMatch) return `rgba(${rgbMatch[1]},${rgbMatch[2]},${rgbMatch[3]},${a})`
+
+  const hslMatch = color.match(/^hsla?\(\s*([\d.]+),\s*([\d.]+)%,\s*([\d.]+)%/)
+  if (hslMatch) return `hsla(${hslMatch[1]},${hslMatch[2]}%,${hslMatch[3]}%,${a})`
+
+  const oklchMatch = color.match(/^oklch\(\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)/)
+  if (oklchMatch) return `oklch(${oklchMatch[1]} ${oklchMatch[2]} ${oklchMatch[3]} / ${a})`
+
+  if (color.startsWith("#")) {
+    const hex = color.replace("#", "")
+    const base =
+      hex.length === 3
+        ? hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2]
+        : hex.length >= 6
+          ? hex.slice(0, 6)
+          : hex
+    return `#${base}${Math.round(a * 255)
+      .toString(16)
+      .padStart(2, "0")}`
+  }
+
+  return `rgba(0,0,0,${a})`
+}
+
+/**
+ * Generate the canonical tokens.json — single source of truth for all platform generators.
+ * The architecture doc specifies: "The source of truth is a single tokens.json file
+ * that all platform generators read from."
+ */
+export function generateTokensJSON(): string {
+  // Upstream bug: the registry source of this function references
+  // `primitives.typography`, `primitives.typeScale`, and `primitives.touchTargets`
+  // which don't exist on the current primitives shape. Aligned to actual
+  // shape (`primitives.touchTarget`, no typography/typeScale) so the module
+  // type-checks. Tracking upstream — the intent is to fold typography into
+  // primitives or reference it from componentTokens.
+  return JSON.stringify(
+    {
+      $schema: "https://design.nyuchi.com/tokens/v1",
+      version: "4.0.2",
+      generated: new Date().toISOString(),
+      colors: { minerals: primitives.color, semantic: semanticTokens },
+      radii: primitives.radius,
+      spacing: primitives.spacing,
+      motion: primitives.motion,
+      touchTarget: primitives.touchTarget,
+      brandOverrides,
+      chartColors: mineralChartColors,
+      status: statusTokens,
+      severity: severityTokens,
+      notifications: notificationTokens,
+      connection: connectionTokens,
+      verification: verificationTokens,
+      crypto: cryptoTokens,
+      moderation: moderationTokens,
+      serviceHealth: serviceHealthTokens,
+    },
+    null,
+    2
+  )
+}
+
+/**
+ * Generate ArkTS/ArkUI tokens for HarmonyOS native shell.
+ * Maps minerals + semantics to ArkUI Resource files + theme tokens.
+ */
+export function generateArkTS(): string {
+  const lines: string[] = [
+    "// Auto-generated — Nyuchi Design Tokens for ArkUI",
+    "// Source: design.nyuchi.com",
+    "",
+  ]
+  lines.push("export const NyuchiColors = {")
+  const allKeys = [
+    "cobalt",
+    "tanzanite",
+    "malachite",
+    "gold",
+    "terracotta",
+    "indigo",
+    "savanna",
+    "baobab",
+    "sunset",
+    "river",
+  ] as const
+  for (const key of allKeys) {
+    const val = primitives.color[key]?.value ?? "#000000"
+    lines.push(`  ${key}: "${val}",`)
+  }
+  lines.push("}")
+  lines.push("")
+  lines.push("export const NyuchiRadii = {")
+  lines.push("  sm: 7, md: 12, lg: 14, xl: 17, full: 9999,")
+  lines.push("}")
+  return lines.join("\n")
+}


### PR DESCRIPTION
## Summary

Dogfoods the registry by vendoring the 33-item transitive dependency tree of `nyuchi-header` / `nyuchi-footer` / `nyuchi-user-menu`. Per the doctrine established in PR #52, **no code on the portal should be a hand-rolled variation of what's in the DB** — this lands the infrastructure so the portal can consume its own registry components.

## Three commits

### Commit 1 (`743d875`) — vendor the registry stack (20 files, +5,693 lines)

- **Infrastructure (`lib/`):** `harness/index.tsx` (NyuchiHarness + useNyuchiHarness), `resilience/index.tsx` (section error boundary + retry fetch + fallback), `tokens/index.ts` (900+ lines of L1 primitives + semantic tokens + ten listing themes + multi-platform generators), `motion/index.tsx` (presets + reduced-motion), `a11y/index.tsx` (focus-trap + live-region + skip-nav), plus the seven resilience building blocks (`circuit-breaker.ts`, `retry.ts`, `timeout.ts`, `fallback-chain.ts`, `bulkhead.ts`, `rate-limiter.ts`, `chaos.ts`), and the `icons.ts` shim that re-exports lucide-react so brand components can swap icon sets per consumer.
- **Brand components (`components/mukoko/`):** `mukoko-{header,footer,theme-provider,skeleton-set,error-set,verified-badge}.tsx`.
- **UI:** `components/ui/user-menu.tsx`.
- **11 upstream-bug fixes inline** — tracked in [issue #56](https://github.com/nyuchi/design-portal/issues/56): escape round-trip artefacts, broken/missing exports, `portalAttrs` missing from `ComponentHarnessResult`, trailing duplicate `export {}` in tokens, `generateTokensJSON` referencing non-existent primitive keys, JSX in `.ts` extensions, `thickness` prop mismatch on `MineralStrip`, undeclared `loading` in `NyuchiVerifiedBadge`, stale `react-hooks/exhaustive-deps` disable, `"use client"` below imports, unused harness destructures.
- **Import-path remaps:** `@/components/brand/*` → `@/components/layout/*` and `@/components/mukoko/nyuchi-theme-provider` → `@/components/mukoko/mukoko-theme-provider` (for the registry's item-name-vs-path drift — also tracked in #56).

### Commit 2 (`a8499f3`) — wire `NyuchiHeader` into the layout

- `components/landing/header.tsx` is now a **30-line composition** that configures `NyuchiHeader` with the portal's four top-level nav items (Components, Brand, Architecture, Docs) and the three-icon pill actions (Search, Fundi, Avatar) PR #52 established. Zero behaviour here — future header changes land on the registry source and propagate on the next vendor refresh.
- `app/layout.tsx` wraps `<Layout>` in `<SidebarProvider defaultOpen={false}>` so `NyuchiHeader`'s built-in `<SidebarTrigger className="md:hidden" />` has context. The actual `<Sidebar>` content is out of scope here — it lands in the follow-up `claude/nyuchi-dashboard-shell` branch. Until then the trigger toggles an empty provider (harmless no-op on desktop, stub sheet on mobile).
- **Footer intentionally not swapped.** `NyuchiFooter` doesn't currently support the four portal-chrome features PR #52 added (ecosystem brand grid, socials row, inline theme toggle, version badge). Rather than lose those, the portal footer stays as a composition over primitives (`Separator`, `NyuchiLogo`, `ThemeToggle`) — documented in CLAUDE.md §8.7. Extending `NyuchiFooter` upstream is a follow-up tracked in issue #56.

### Commit 3 (`31e1500`) — CLAUDE.md doctrine update

- **§5 Directory Structure** — adds `components/mukoko/`, `lib/harness/`, `lib/resilience/`, `lib/tokens/`, `lib/motion/`, `lib/a11y/`, resilience primitive files, `lib/icons.ts`, `components/ui/user-menu.tsx`. Notes that `components/landing/` now contains portal-specific *compositions* over registry components, not hand-rolled variations.
- **§8.7 (new) — "Vendored registry stack — path + naming drift".** Documents the `components/mukoko/*`-vs-`nyuchi-*` path-vs-item-name drift, the `@/components/brand/*` import remap, the 11 upstream-bug commitment to issue #56, and the footer-composition rationale so future contributors know why the portal's footer is deliberately richer than `NyuchiFooter`.
- `§8.7 registry.json Schema Reference` renumbered to `§8.8`.

## Verification

- `pnpm lint` — clean, zero warnings
- `pnpm typecheck` — clean
- `pnpm test` — 26/26 passing
- `pnpm build` — succeeds (Pagefind postbuild indexes 55 pages)

## Known limitations / follow-ups tracked elsewhere

- **PR #53** (workflow-only, into main) — draft-skip guard + `paths-ignore` + `concurrency`. The claude-review on this PR may 429 until #53 merges.
- **Issue #56** — the 11 registry-source bugs fixed inline, plus the four `NyuchiFooter` feature gaps.
- **Vercel main deployment** — production is still serving the pre-PR-#52 build (confirmed earlier this session). This PR may hit the same build issue on its preview deploy; will investigate if it does.
- **Follow-up branches in memory:** `claude/drop-nextra` (switch to `@next/mdx`), `claude/nyuchi-dashboard-shell` (sidebar + full user menu wired), `claude/migrate-docs-from-supabase-to-repo`, `claude/responsive-mdx-content`, `claude/skills-api-and-db` + `claude/publish-nyuchi-cli-and-skills` (issue #54).

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm audit --audit-level=moderate` — no known vulnerabilities
- [ ] Vercel preview deploy green (awaiting webhook)
- [ ] Manual visual check of the header against PR #52's design (no browser in this session — flagging)
- [ ] `claude-review` pass (may need #53 to land first for rate-limit breathing room)

https://claude.ai/code/session_01YPT39eiRaqW9RR9FVZcyhn