### PR TITLE
feat(portal): /changelog and /tools pages, status + node badges (#85)

### DIFF
--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -1,0 +1,173 @@
+import type { Metadata } from "next"
+
+import { listChangelog, isSupabaseConfigured } from "@/lib/db"
+import { NodeBadgeList } from "@/components/ui/node-badge"
+
+// CHANGELOG — issue #85
+//
+// Server-rendered timeline of releases. Reads from the node-aware
+// `list_changelog()` RPC introduced by the `versioning_and_changelog_v2`
+// migration; renders each release with its version, title, release date,
+// description, and the ecosystem nodes (N1–N10) touched. The node
+// badges are axis-coloured per the live `nyuchi-changelog-renderer`
+// (registry v2.0.0).
+
+export const revalidate = 3600
+
+export const metadata: Metadata = {
+  title: "Changelog — Mzizi",
+  description:
+    "Release notes for the Mzizi component registry — each entry tagged with the ecosystem nodes (N1–N10) it touched.",
+}
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return ""
+  try {
+    return new Date(iso).toISOString().slice(0, 10)
+  } catch {
+    return ""
+  }
+}
+
+export default async function ChangelogPage() {
+  if (!isSupabaseConfigured()) {
+    return (
+      <article className="mx-auto w-full max-w-3xl space-y-6 py-8">
+        <header className="space-y-3">
+          <h1 className="font-serif text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            Changelog
+          </h1>
+          <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
+            Release notes for the Mzizi component registry.
+          </p>
+        </header>
+        <p className="rounded-xl border border-border bg-muted/30 p-6 text-sm text-muted-foreground">
+          Supabase is not configured. The changelog is served live from the{" "}
+          <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">changelog</code> table
+          via the{" "}
+          <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">list_changelog()</code>{" "}
+          RPC.
+        </p>
+      </article>
+    )
+  }
+
+  const entries = await listChangelog(100, 0).catch(() => [])
+
+  return (
+    <article className="mx-auto w-full max-w-3xl space-y-8 py-8">
+      <header className="space-y-3">
+        <p className="font-mono text-[11px] tracking-widest text-muted-foreground uppercase">
+          Releases
+        </p>
+        <h1 className="font-serif text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          Changelog
+        </h1>
+        <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
+          Every Mzizi release, newest first. Each entry is tagged with the ecosystem nodes (N1–N10)
+          it touched — colour-coded by axis (cobalt = horizontal, tanzanite = vertical, malachite =
+          depth, gold = outlier).
+        </p>
+      </header>
+
+      {entries.length === 0 ? (
+        <p className="rounded-xl border border-border bg-muted/30 p-6 text-sm text-muted-foreground">
+          No changelog entries available yet.
+        </p>
+      ) : (
+        <ol
+          className="flex flex-col gap-8"
+          role="feed"
+          aria-label="Changelog"
+          data-slot="changelog-timeline"
+        >
+          {entries.map((entry) => (
+            <li
+              key={entry.version}
+              className="relative space-y-3 border-l-2 border-border pb-4 pl-6 last:pb-0"
+            >
+              {/* Timeline dot */}
+              <div className="absolute top-1 -left-[5px] size-2 rounded-full bg-primary" />
+
+              <div className="flex flex-wrap items-baseline gap-3">
+                <span className="font-mono text-sm font-bold text-primary">v{entry.version}</span>
+                <time className="font-mono text-xs text-muted-foreground">
+                  {formatDate(entry.created_at)}
+                </time>
+                {entry.changed_by ? (
+                  <span className="font-mono text-[10px] text-muted-foreground">
+                    by {entry.changed_by}
+                  </span>
+                ) : null}
+              </div>
+
+              {entry.title ? (
+                <h2 className="text-lg font-semibold text-foreground">{entry.title}</h2>
+              ) : null}
+              {entry.description ? (
+                <p className="text-sm leading-relaxed text-muted-foreground">{entry.description}</p>
+              ) : null}
+
+              {entry.nodes_affected && entry.nodes_affected.length > 0 ? (
+                <NodeBadgeList nodes={entry.nodes_affected} label="Nodes affected" />
+              ) : null}
+
+              {/* Component deltas */}
+              {entry.components_added && entry.components_added.length > 0 ? (
+                <div className="flex flex-wrap gap-1" aria-label="Components added">
+                  {entry.components_added.map((c) => (
+                    <span
+                      key={`added-${c}`}
+                      className="inline-flex h-5 items-center rounded-full bg-[var(--color-malachite)]/10 px-2 py-0.5 font-mono text-[11px] text-[var(--color-malachite)]"
+                    >
+                      +{c}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+
+              {entry.components_modified && entry.components_modified.length > 0 ? (
+                <div className="flex flex-wrap gap-1" aria-label="Components modified">
+                  {entry.components_modified.map((c) => (
+                    <span
+                      key={`mod-${c}`}
+                      className="inline-flex h-5 items-center rounded-full bg-[var(--color-cobalt)]/10 px-2 py-0.5 font-mono text-[11px] text-[var(--color-cobalt)]"
+                    >
+                      ~{c}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+
+              {entry.components_deprecated && entry.components_deprecated.length > 0 ? (
+                <div className="flex flex-wrap gap-1" aria-label="Components deprecated">
+                  {entry.components_deprecated.map((c) => (
+                    <span
+                      key={`dep-${c}`}
+                      className="inline-flex h-5 items-center rounded-full bg-[var(--color-terracotta)]/10 px-2 py-0.5 font-mono text-[11px] text-[var(--color-terracotta)] line-through"
+                    >
+                      {c}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+
+              {entry.components_removed && entry.components_removed.length > 0 ? (
+                <div className="flex flex-wrap gap-1" aria-label="Components removed">
+                  {entry.components_removed.map((c) => (
+                    <span
+                      key={`rem-${c}`}
+                      className="inline-flex h-5 items-center rounded-full bg-destructive/10 px-2 py-0.5 font-mono text-[11px] text-destructive line-through"
+                    >
+                      −{c}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+            </li>
+          ))}
+        </ol>
+      )}
+    </article>
+  )
+}

--- a/app/tools/[name]/page.tsx
+++ b/app/tools/[name]/page.tsx
@@ -1,0 +1,224 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { ArrowLeft, ExternalLink, Package } from "lucide-react"
+
+import { getMcpTool, isSupabaseConfigured } from "@/lib/db"
+import { StatusBadge, type StatusBadgeStatus } from "@/components/ui/status-badge"
+
+// TOOL DETAIL — issue #85
+//
+// Server-rendered detail page for a single published Mzizi tool. For
+// known slugs (mzizi-mcp, mzizi-sdk, mzizi-skills, mzizi-cli) we render
+// the install command, npm + GitHub links, and the latest version
+// (pulled from `mcp_tool_registry` when available, otherwise from the
+// hardcoded fallback set). Unknown slugs return a 404.
+//
+// TODO(#83): when the registry-driven endpoints land, drop the hardcoded
+// fallback and surface every row in `mcp_tool_registry` via this page.
+
+export const revalidate = 3600
+
+const SLUG_PATTERN = /^[a-z][a-z0-9-]*$/
+
+interface KnownTool {
+  name: string
+  npm: string
+  github: string
+  install: string
+  binary: string | null
+  description: string
+  defaultStatus: StatusBadgeStatus
+}
+
+const KNOWN_TOOLS: Record<string, KnownTool> = {
+  "mzizi-mcp": {
+    name: "mzizi-mcp",
+    npm: "https://www.npmjs.com/package/@nyuchi/mzizi-mcp",
+    github: "https://github.com/nyuchi/fundi/tree/main/packages/mzizi-mcp",
+    install: "npx @nyuchi/mzizi-mcp",
+    binary: "mzizi-mcp",
+    description:
+      "Model Context Protocol server exposing the Mzizi registry, brand tokens, design tokens, and architecture data to AI assistants via Streamable HTTP. Mirrors the live /mcp endpoint.",
+    defaultStatus: "stable",
+  },
+  "mzizi-sdk": {
+    name: "mzizi-sdk",
+    npm: "https://www.npmjs.com/package/@nyuchi/mzizi-sdk",
+    github: "https://github.com/nyuchi/fundi/tree/main/packages/mzizi-sdk",
+    install: "npm install @nyuchi/mzizi-sdk",
+    binary: null,
+    description:
+      "TypeScript SDK for the Mzizi API. Fetch the component registry, brand tokens, agent skills, and changelog without hand-rolling HTTP plumbing.",
+    defaultStatus: "alpha",
+  },
+  "mzizi-skills": {
+    name: "mzizi-skills",
+    npm: "https://www.npmjs.com/package/@nyuchi/mzizi-skills",
+    github: "https://github.com/nyuchi/fundi/tree/main/packages/mzizi-skills",
+    install: "npx skills add @nyuchi/mzizi-skills",
+    binary: null,
+    description:
+      "Offline-friendly Markdown bundle of design-system skills, regenerated from the Supabase `skills` table on every release. Any AI assistant with a skills loader can ingest it.",
+    defaultStatus: "stable",
+  },
+  "mzizi-cli": {
+    name: "mzizi-cli",
+    npm: "https://www.npmjs.com/package/@nyuchi/mzizi-cli",
+    github: "https://github.com/nyuchi/fundi/tree/main/packages/mzizi-cli",
+    install: "npx @nyuchi/mzizi-cli init",
+    binary: "mzizi",
+    description:
+      "Command-line bootstrap and maintenance for Bundu ecosystem apps. Scaffolds a project, installs components, syncs agent skills, and exposes status / changelog subcommands.",
+    defaultStatus: "stable",
+  },
+}
+
+function statusFromStability(stability: string | null | undefined): StatusBadgeStatus | null {
+  switch (stability) {
+    case "stable":
+    case "frozen":
+      return "stable"
+    case "deprecated":
+      return "deprecated"
+    case "experimental":
+    case "evolving":
+      return "alpha"
+    default:
+      return null
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ name: string }>
+}): Promise<Metadata> {
+  const { name } = await params
+  if (!SLUG_PATTERN.test(name) || !KNOWN_TOOLS[name]) {
+    return { title: "Tool not found — Mzizi" }
+  }
+  const tool = KNOWN_TOOLS[name]
+  return {
+    title: `${tool.name} — Mzizi tools`,
+    description: tool.description,
+  }
+}
+
+export default async function ToolDetailPage({ params }: { params: Promise<{ name: string }> }) {
+  const { name } = await params
+  if (!SLUG_PATTERN.test(name)) notFound()
+
+  const known = KNOWN_TOOLS[name]
+  if (!known) notFound()
+
+  // Pull live version + DB-derived status when the registry has the row.
+  const registryRow = isSupabaseConfigured() ? await getMcpTool(name).catch(() => null) : null
+  const status: StatusBadgeStatus =
+    statusFromStability(registryRow?.stability) ?? known.defaultStatus
+  const version = registryRow?.current_version ?? null
+
+  return (
+    <article className="mx-auto w-full max-w-3xl space-y-8 py-8">
+      <Link
+        href="/tools"
+        className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="size-3" /> Back to tools
+      </Link>
+
+      <header className="space-y-3">
+        <p className="font-mono text-[11px] tracking-widest text-muted-foreground uppercase">
+          Tool
+        </p>
+        <div className="flex flex-wrap items-baseline gap-3">
+          <h1 className="font-serif text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            {known.name}
+          </h1>
+          <StatusBadge status={status} />
+          {version ? (
+            <span className="font-mono text-xs text-muted-foreground">v{version}</span>
+          ) : null}
+        </div>
+        <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
+          {known.description}
+        </p>
+      </header>
+
+      <section className="space-y-3" aria-label="Install command">
+        <h2 className="font-serif text-lg font-semibold text-foreground">Install</h2>
+        <pre className="overflow-x-auto rounded-lg border border-border bg-muted/40 p-3 font-mono text-xs">
+          <code>{known.install}</code>
+        </pre>
+        {known.binary ? (
+          <p className="text-xs text-muted-foreground">
+            Binary:{" "}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">
+              {known.binary}
+            </code>
+          </p>
+        ) : null}
+      </section>
+
+      <section className="space-y-3" aria-label="Links">
+        <h2 className="font-serif text-lg font-semibold text-foreground">Links</h2>
+        <ul className="flex flex-wrap gap-2">
+          <li>
+            <a
+              href={known.npm}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:border-foreground/20"
+            >
+              <Package className="size-3" aria-hidden="true" />
+              npm
+            </a>
+          </li>
+          <li>
+            <a
+              href={known.github}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:border-foreground/20"
+            >
+              <ExternalLink className="size-3" aria-hidden="true" />
+              GitHub
+            </a>
+          </li>
+        </ul>
+      </section>
+
+      {registryRow ? (
+        <section className="space-y-3" aria-label="Registry metadata">
+          <h2 className="font-serif text-lg font-semibold text-foreground">Registry metadata</h2>
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+            {registryRow.category ? (
+              <>
+                <dt className="font-mono text-muted-foreground uppercase">Category</dt>
+                <dd className="font-mono text-foreground">{registryRow.category}</dd>
+              </>
+            ) : null}
+            {registryRow.tool_kind ? (
+              <>
+                <dt className="font-mono text-muted-foreground uppercase">Kind</dt>
+                <dd className="font-mono text-foreground">{registryRow.tool_kind}</dd>
+              </>
+            ) : null}
+            {registryRow.added_in_version ? (
+              <>
+                <dt className="font-mono text-muted-foreground uppercase">Added in</dt>
+                <dd className="font-mono text-foreground">v{registryRow.added_in_version}</dd>
+              </>
+            ) : null}
+            {registryRow.version_count !== null && registryRow.version_count !== undefined ? (
+              <>
+                <dt className="font-mono text-muted-foreground uppercase">Versions</dt>
+                <dd className="font-mono text-foreground">{registryRow.version_count}</dd>
+              </>
+            ) : null}
+          </dl>
+        </section>
+      ) : null}
+    </article>
+  )
+}

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -1,0 +1,139 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+
+import { listMcpToolRegistry, isSupabaseConfigured } from "@/lib/db"
+import { StatusBadge, type StatusBadgeStatus } from "@/components/ui/status-badge"
+
+// TOOLS INDEX — issue #85
+//
+// Server-rendered index of the published Mzizi tools. Hydrated from the
+// Supabase `mcp_tool_registry` table when available, falling back to the
+// known set (mzizi-mcp, mzizi-sdk, mzizi-skills, mzizi-cli) when the
+// registry doesn't yet include them. The full registry-driven endpoints
+// are tracked in #83.
+
+export const revalidate = 3600
+
+export const metadata: Metadata = {
+  title: "Tools — Mzizi",
+  description:
+    "Published Mzizi tools — MCP server, SDK, skills bundle, and CLI. Install via npm or npx.",
+}
+
+interface ToolCardData {
+  name: string
+  description: string
+  category: string
+  status: StatusBadgeStatus
+  version: string | null
+}
+
+const KNOWN_TOOLS: ToolCardData[] = [
+  {
+    name: "mzizi-mcp",
+    description: "Model Context Protocol server exposing the Mzizi registry to AI assistants.",
+    category: "mcp",
+    status: "stable",
+    version: null,
+  },
+  {
+    name: "mzizi-sdk",
+    description: "TypeScript SDK for the Mzizi API — fetch components, brand tokens, and skills.",
+    category: "sdk",
+    status: "alpha",
+    version: null,
+  },
+  {
+    name: "mzizi-skills",
+    description: "Markdown bundle of design-system skills for any AI assistant.",
+    category: "skills",
+    status: "stable",
+    version: null,
+  },
+  {
+    name: "mzizi-cli",
+    description: "Bootstrap and maintain Bundu ecosystem apps from the registry.",
+    category: "cli",
+    status: "stable",
+    version: null,
+  },
+]
+
+function statusFromStability(stability: string | null | undefined): StatusBadgeStatus {
+  switch (stability) {
+    case "stable":
+    case "frozen":
+      return "stable"
+    case "deprecated":
+      return "deprecated"
+    default:
+      return "alpha"
+  }
+}
+
+export default async function ToolsPage() {
+  let tools: ToolCardData[] = KNOWN_TOOLS
+
+  if (isSupabaseConfigured()) {
+    const rows = await listMcpToolRegistry().catch(() => [])
+    const fromDb: ToolCardData[] = rows
+      .filter((r) => r.tool_name.startsWith("mzizi-"))
+      .map((r) => ({
+        name: r.tool_name,
+        description: r.description ?? "",
+        category: r.category ?? "tool",
+        status: statusFromStability(r.stability),
+        version: r.current_version,
+      }))
+    // Merge: prefer DB rows, fall back to known set for missing names.
+    const byName = new Map<string, ToolCardData>(KNOWN_TOOLS.map((t) => [t.name, t]))
+    for (const t of fromDb) byName.set(t.name, t)
+    tools = Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  return (
+    <article className="mx-auto w-full max-w-3xl space-y-8 py-8">
+      <header className="space-y-3">
+        <p className="font-mono text-[11px] tracking-widest text-muted-foreground uppercase">
+          Tools
+        </p>
+        <h1 className="font-serif text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          Published Mzizi tools
+        </h1>
+        <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
+          The Mzizi distribution surface — MCP server, SDK, skills bundle, and CLI. Each tool is
+          installable via npm or npx and lives in the bundu ecosystem GitHub org.
+        </p>
+      </header>
+
+      <ul className="grid gap-3 sm:grid-cols-2">
+        {tools.map((tool) => (
+          <li key={tool.name}>
+            <Link
+              href={`/tools/${tool.name}`}
+              className="group flex h-full flex-col gap-2 rounded-xl border border-border bg-card p-4 transition-colors hover:border-foreground/20"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="font-mono text-sm font-medium text-foreground">{tool.name}</span>
+                <StatusBadge status={tool.status} />
+              </div>
+              {tool.description ? (
+                <p className="text-xs leading-relaxed text-muted-foreground">{tool.description}</p>
+              ) : null}
+              <div className="mt-auto flex items-center justify-between gap-2 pt-2">
+                <span className="font-mono text-[10px] text-muted-foreground uppercase">
+                  {tool.category}
+                </span>
+                {tool.version ? (
+                  <span className="font-mono text-[10px] text-muted-foreground">
+                    v{tool.version}
+                  </span>
+                ) : null}
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </article>
+  )
+}

--- a/components/ui/node-badge.tsx
+++ b/components/ui/node-badge.tsx
@@ -1,0 +1,101 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+// NODE BADGE
+//
+// Renders a single ecosystem node (N1–N10) as a pill, axis-coloured per
+// the `nyuchi-changelog-renderer` (registry) v2.0.0 convention.
+//
+//   horizontal (N2, N3, N6, N7)            → Cobalt
+//   vertical   (N1, N4, N5)                → Tanzanite
+//   depth      (N8)                        → Malachite
+//   outlier    (N9, N10)                   → Gold
+//
+// The labels / axis mapping mirror CLAUDE.md §6.2.
+
+const NODE_LABELS: Record<number, string> = {
+  1: "Tokens",
+  2: "Primitives",
+  3: "Brand",
+  4: "Safety",
+  5: "Resilience",
+  6: "Pages",
+  7: "Shell",
+  8: "Assurance",
+  9: "Fundi",
+  10: "Documentation",
+}
+
+type NodeAxis = "horizontal" | "vertical" | "depth" | "outlier"
+
+const NODE_AXIS: Record<number, NodeAxis> = {
+  1: "vertical",
+  2: "horizontal",
+  3: "horizontal",
+  4: "vertical",
+  5: "vertical",
+  6: "horizontal",
+  7: "horizontal",
+  8: "depth",
+  9: "outlier",
+  10: "outlier",
+}
+
+const AXIS_COLOURS: Record<NodeAxis, string> = {
+  horizontal: "bg-[var(--color-cobalt)]/10 text-[var(--color-cobalt)]",
+  vertical: "bg-[var(--color-tanzanite)]/10 text-[var(--color-tanzanite)]",
+  depth: "bg-[var(--color-malachite)]/10 text-[var(--color-malachite)]",
+  outlier: "bg-[var(--color-gold)]/10 text-[var(--color-gold)]",
+}
+
+export interface NodeBadgeProps extends React.ComponentProps<"span"> {
+  node: number
+}
+
+export function NodeBadge({ node, className, ...props }: NodeBadgeProps) {
+  const axis = NODE_AXIS[node] ?? "horizontal"
+  const label = NODE_LABELS[node] ?? "Unknown"
+  return (
+    <span
+      data-slot="node-badge"
+      data-node={node}
+      data-axis={axis}
+      title={`N${node} — ${label} (${axis} axis)`}
+      className={cn(
+        "inline-flex h-5 items-center rounded-full px-2 py-0.5 text-xs font-medium",
+        AXIS_COLOURS[axis],
+        className
+      )}
+      {...props}
+    >
+      N{node}
+    </span>
+  )
+}
+
+export interface NodeBadgeListProps extends React.ComponentProps<"div"> {
+  nodes: number[]
+  label?: string
+}
+
+export function NodeBadgeList({
+  nodes,
+  label = "Nodes affected",
+  className,
+  ...props
+}: NodeBadgeListProps) {
+  if (!nodes || nodes.length === 0) return null
+  return (
+    <div
+      data-slot="node-badge-list"
+      aria-label={label}
+      className={cn("flex flex-wrap gap-1", className)}
+      {...props}
+    >
+      {nodes.map((n) => (
+        <NodeBadge key={n} node={n} />
+      ))}
+    </div>
+  )
+}

--- a/components/ui/status-badge.tsx
+++ b/components/ui/status-badge.tsx
@@ -1,0 +1,51 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+import { Badge } from "@/components/ui/badge"
+
+// STATUS BADGE
+//
+// Pill-shaped lifecycle indicator built on the shadcn `Badge` primitive.
+// Three statuses, each tinted with a Five-African-Minerals colour:
+//   - stable     → Malachite (cyan) — assurance, ready for production
+//   - alpha      → Gold (yellow)    — preview / unstable surface
+//   - deprecated → Terracotta (warm) — slated for removal
+//
+// CLAUDE.md §7.5 — buttons / badges are always pill-shaped (`rounded-full`).
+// CLAUDE.md §7.4 — colours come from CSS custom properties, not hex.
+
+export type StatusBadgeStatus = "stable" | "alpha" | "deprecated"
+
+const STATUS_STYLES: Record<StatusBadgeStatus, string> = {
+  stable: "bg-[var(--color-malachite)]/10 text-[var(--color-malachite)]",
+  alpha: "bg-[var(--color-gold)]/10 text-[var(--color-gold)]",
+  deprecated: "bg-[var(--color-terracotta)]/10 text-[var(--color-terracotta)] line-through",
+}
+
+const STATUS_LABELS: Record<StatusBadgeStatus, string> = {
+  stable: "stable",
+  alpha: "alpha",
+  deprecated: "deprecated",
+}
+
+export interface StatusBadgeProps extends React.ComponentProps<"span"> {
+  status: StatusBadgeStatus
+}
+
+export function StatusBadge({ status, className, children, ...props }: StatusBadgeProps) {
+  return (
+    <Badge
+      variant="outline"
+      data-slot="status-badge"
+      data-status={status}
+      className={cn(
+        "rounded-full border-transparent font-mono text-[10px] tracking-wide uppercase",
+        STATUS_STYLES[status],
+        className
+      )}
+      {...props}
+    >
+      {children ?? STATUS_LABELS[status]}
+    </Badge>
+  )
+}

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -66,7 +66,9 @@ import type {
   AiInstructionInsert,
   ChangelogRow,
   ChangelogInsert,
+  ChangelogListRow,
   ComponentVersionRow,
+  McpToolRegistryRow,
   DesignTokens,
   ArchitectureFrontendAxisRow,
   ArchitectureFrontendLayerRow,
@@ -1535,4 +1537,68 @@ export async function getNodeDistribution(): Promise<NodeDistributionRow[]> {
     ecosystem_axis: l.ecosystem_axis,
     component_count: counts.get(l.node_number) ?? 0,
   }))
+}
+
+// ── Changelog v2 — issue #85 (`versioning_and_changelog_v2`) ────────
+//
+// The node-aware changelog lives behind the `list_changelog(limit, offset)`
+// SQL helper. Each row carries `nodes_affected integer[]` (N1–N10) and
+// component / tool deltas. `/changelog` reads via this RPC; the older
+// `getChangelogEntries()` helper is kept for backwards compatibility
+// with `components/docs/db-changelog.tsx`.
+
+/**
+ * Live fetch of changelog entries via the `list_changelog()` RPC. Most
+ * recent first. Returns an empty array if Supabase isn't configured or
+ * the RPC errors. Bounded by `limit` (default 50) for the page render.
+ */
+export async function listChangelog(limit = 50, offset = 0): Promise<ChangelogListRow[]> {
+  if (!isSupabaseConfigured()) return []
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (getPublicClient() as any).rpc("list_changelog", {
+    p_limit: limit,
+    p_offset: offset,
+  })
+  if (error || !Array.isArray(data)) return []
+  return data as ChangelogListRow[]
+}
+
+// ── MCP tool registry — issue #85 / #83 (`mcp_tool_registry` table) ──
+//
+// The published Mzizi tools (mzizi-mcp, mzizi-sdk, mzizi-skills,
+// mzizi-cli) live in `mcp_tool_registry`. Thin read helpers backing
+// `/tools/[name]`. The full registry-driven endpoints land with #83.
+
+/**
+ * List all enabled rows from `mcp_tool_registry`. Empty array on
+ * configuration / query failure.
+ */
+export async function listMcpToolRegistry(): Promise<McpToolRegistryRow[]> {
+  if (!isSupabaseConfigured()) return []
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (getPublicClient() as any)
+    .from("mcp_tool_registry")
+    .select("*")
+    .eq("enabled", true)
+    .order("tool_name", { ascending: true })
+
+  if (error || !Array.isArray(data)) return []
+  return data as McpToolRegistryRow[]
+}
+
+/**
+ * Fetch a single tool row by `tool_name`. Returns null when missing or
+ * when Supabase isn't configured.
+ */
+export async function getMcpTool(toolName: string): Promise<McpToolRegistryRow | null> {
+  if (!isSupabaseConfigured()) return null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (getPublicClient() as any)
+    .from("mcp_tool_registry")
+    .select("*")
+    .eq("tool_name", toolName)
+    .maybeSingle()
+
+  if (error || !data) return null
+  return data as McpToolRegistryRow
 }

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -522,28 +522,107 @@ export interface SkillRow {
 export type SkillSummary = Omit<SkillRow, "body_mdx" | "id" | "created_at">
 
 // ── Changelog table types ───────────────────────────────────────────
+//
+// The `changelog` table was migrated by `versioning_and_changelog_v2`
+// to a node-aware shape. Each row tracks which ecosystem nodes (N1–N10)
+// and which components / tools moved in the release. The legacy
+// optional fields (`body`, `is_latest`, `categories`, `updated_at`)
+// are retained for backwards compatibility with the older
+// `getChangelogEntries` / `db-changelog.tsx` rendering path; they are
+// null/undefined on rows fetched via the new `list_changelog()` RPC.
 
 export interface ChangelogRow {
   id: number
   version: string
   title: string
   description: string | null
-  body: string | null
+  /**
+   * Ecosystem nodes (N1–N10) touched by this release. Rendered as
+   * axis-coloured pill badges via the nyuchi-changelog-renderer.
+   */
+  nodes_affected: number[] | null
+  axes_affected: string[] | null
+  components_added: string[] | null
+  components_modified: string[] | null
+  components_deprecated: string[] | null
+  components_removed: string[] | null
+  tools_added: string[] | null
+  tools_modified: string[] | null
+  tools_deprecated: string[] | null
+  tools_removed: string[] | null
+  total_stable: number | null
+  total_deprecated: number | null
+  total_alpha: number | null
+  changed_by: string | null
   released_at: string
-  is_latest: boolean
-  categories: Record<string, unknown> | null
+  linked_issues: string[] | null
   created_at: string
-  updated_at: string
+  // legacy fields (post-v2 migration leaves these absent)
+  body?: string | null
+  is_latest?: boolean
+  categories?: Record<string, unknown> | null
+  updated_at?: string
 }
 
 export interface ChangelogInsert {
   version: string
   title: string
   description?: string | null
-  body?: string | null
+  nodes_affected?: number[] | null
+  axes_affected?: string[] | null
+  components_added?: string[] | null
+  components_modified?: string[] | null
+  components_deprecated?: string[] | null
+  components_removed?: string[] | null
   released_at: string
-  is_latest?: boolean
-  categories?: Record<string, unknown> | null
+}
+
+/**
+ * Shape returned by the `list_changelog(p_limit, p_offset)` RPC. Mirrors
+ * the row shape minus the ID / archive columns. Used by `/changelog`.
+ */
+export interface ChangelogListRow {
+  version: string
+  title: string
+  description: string | null
+  nodes_affected: number[] | null
+  axes_affected: string[] | null
+  components_added: string[] | null
+  components_modified: string[] | null
+  components_deprecated: string[] | null
+  components_removed: string[] | null
+  total_stable: number | null
+  total_deprecated: number | null
+  total_alpha: number | null
+  changed_by: string | null
+  created_at: string
+}
+
+// ── mcp_tool_registry table types ───────────────────────────────────
+
+export type ToolStability = "experimental" | "evolving" | "stable" | "frozen" | "deprecated"
+
+export interface McpToolRegistryRow {
+  tool_name: string
+  category: string | null
+  description: string | null
+  sql_function: string | null
+  source_table: string | null
+  input_schema: Record<string, unknown> | null
+  output_shape: Record<string, unknown> | null
+  stability: ToolStability | null
+  tool_kind: string | null
+  requires_first_party: boolean | null
+  requires_domain_feature: string | null
+  cache_ttl_seconds: number | null
+  enabled: boolean | null
+  added_in_version: string | null
+  notes: string | null
+  created_at: string
+  updated_at: string
+  current_version: string | null
+  version_count: number | null
+  edge_function: string | null
 }
 
 // ── Component version table types ───────────────────────────────────

--- a/lib/nav.ts
+++ b/lib/nav.ts
@@ -1,12 +1,22 @@
-import { Activity, Box, BookOpen, Layers, Sparkles, type LucideIcon } from "lucide-react"
+import {
+  Activity,
+  Box,
+  BookOpen,
+  Layers,
+  ScrollText,
+  Sparkles,
+  Wrench,
+  type LucideIcon,
+} from "lucide-react"
 
 // Shared navigation structure for the Mzizi portal shell.
 // Curated (not auto-generated) — the portal hosts the functional
 // surfaces only; long-form guides live in the standalone Mintlify
 // docs site at docs.bundu.org/mzizi.
 //
-//   Explore       — the component gallery + the 3D architecture explorer
+//   Explore       — the component gallery, tools, and the 3D architecture explorer
 //   Playground    — interactive registry browser (live preview + API tester)
+//   Releases      — the node-aware changelog (issue #85)
 //   Observability — live registry / API / MCP usage metrics
 //   Documentation — external link to the Mintlify docs site
 //
@@ -34,6 +44,7 @@ export const SIDEBAR_NAV: NavGroup[] = [
     label: "Explore",
     items: [
       { label: "Components", href: "/components", icon: Layers },
+      { label: "Tools", href: "/tools", icon: Wrench },
       { label: "3D architecture", href: "/architecture", icon: Box },
       { label: "Observability", href: "/observability", icon: Activity },
     ],
@@ -41,6 +52,10 @@ export const SIDEBAR_NAV: NavGroup[] = [
   {
     label: "Playground",
     items: [{ label: "Playground", href: "/playground", icon: Sparkles }],
+  },
+  {
+    label: "Releases",
+    items: [{ label: "Changelog", href: "/changelog", icon: ScrollText }],
   },
   {
     label: "Documentation",
@@ -54,8 +69,10 @@ export const SIDEBAR_NAV: NavGroup[] = [
 // and sidebar tell the same story.
 export const HEADER_NAV: NavItem[] = [
   { label: "Components", href: "/components" },
+  { label: "Tools", href: "/tools" },
   { label: "Architecture", href: "/architecture" },
   { label: "Playground", href: "/playground" },
+  { label: "Changelog", href: "/changelog" },
   { label: "Observability", href: "/observability" },
   { label: "Docs", href: "https://docs.bundu.org/mzizi", external: true },
 ]
@@ -69,6 +86,7 @@ export const BREADCRUMB_LABELS: Record<string, string> = {
   observability: "Observability",
   playground: "Playground",
   changelog: "Changelog",
+  tools: "Tools",
   source: "Source",
   layers: "Layers",
 }


### PR DESCRIPTION
## Summary

Closes the portal half of #85 — wires the node-aware `versioning_and_changelog_v2` DB shape into two new server-rendered surfaces:

- **`/changelog`** — chronological timeline reading `list_changelog()` via a thin `listChangelog()` wrapper in `lib/db/index.ts`. Each entry renders version, release date, title, description, and the `nodes_affected integer[]` as axis-coloured N1–N10 pills (cobalt = horizontal, tanzanite = vertical, malachite = depth, gold = outlier — matches the live `nyuchi-changelog-renderer` v2.0.0 in the registry). Component deltas (added / modified / deprecated / removed) render as coloured `+ / ~ / strikethrough` pills.
- **`/tools` + `/tools/[name]`** — index + detail for the four published Mzizi tools (`mzizi-mcp`, `mzizi-sdk`, `mzizi-skills`, `mzizi-cli`). Hydrates from `mcp_tool_registry` when rows are present; falls back to a hardcoded known set otherwise (TODO referencing #83 for the full registry-driven endpoints). Detail page renders install command, npm + GitHub links, status badge, and live `current_version`.
- **`<StatusBadge>`** (`components/ui/status-badge.tsx`) — pill-shaped lifecycle indicator (`stable` malachite / `alpha` gold / `deprecated` terracotta), built on the shadcn `Badge` primitive. Per CLAUDE.md §7.5 (rounded-full) and §7.4 (CSS vars, no hex).
- **`<NodeBadge>` / `<NodeBadgeList>`** (`components/ui/node-badge.tsx`) — reusable N1–N10 axis-coloured pill mirroring the registry renderer's mapping.
- **`lib/nav.ts`** — adds `Tools` to Explore and a new `Releases` group containing `Changelog`; header nav mirrors the sidebar so the two never drift.
- **`lib/db/types.ts`** — `ChangelogRow` extended to the post-v2 shape (`nodes_affected`, `axes_affected`, `components_*`, `tools_*`, `total_*`, `changed_by`, `linked_issues`); legacy fields (`body`, `is_latest`, `categories`, `updated_at`) kept optional so the older `db-changelog.tsx` renderer still typechecks. New `ChangelogListRow` mirrors the RPC return; new `McpToolRegistryRow` + `ToolStability`.

Five commits per CLAUDE.md §14 (DB layer → UI primitives → /changelog → /tools → nav wiring).

## Deferred (not bugs)

- **Mzizi CLI commands (`mzizi changelog`, `mzizi status`).** These live in `mzizi-cli` inside `nyuchi/fundi`, not in this repo — out of scope for the design-portal PR. The /tools/mzizi-cli page links to the right package.
- **Full registry-driven `/tools` endpoints** are tracked by #83; the fallback set is annotated with a `TODO(#83)` so the cut-over is one PR away.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — zero warnings
- [x] `pnpm test` — 76 / 76 pass
- [x] `pnpm build` — `/changelog`, `/tools` static; `/tools/[name]` dynamic
- [ ] Smoke: `/changelog` renders the live `list_changelog()` rows with N-badges
- [ ] Smoke: `/tools` lists the four Mzizi packages; `/tools/mzizi-mcp` renders the install snippet and links

https://claude.ai/code/session_01RHdD3m5zeBYmYoUwxLwxKf

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHdD3m5zeBYmYoUwxLwxKf)_