### PR TITLE
chore(release): v4.0.40 — doctrine + openapi audit + Mzizi transition release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ design-portal (this repo)
         │   (each Mzizi mini-app ships as the `mzizi-console-app` npm package
         │    and plugs into platform.nyuchi.com)
         ├── Sister brands (Zimbabwe Information Platform, Barstool by Nyuchi)
-        └── Any new bundu ecosystem app — via @nyuchi/design-cli init
+        └── Any new bundu ecosystem app — via the shadcn CLI against /api/v1/ui/<component>
 ```
 
 **Rule:** When building a new app, install components from this registry. Do not copy-paste component code or create parallel component libraries. Mzizi-side agentic tooling (the Fundi self-healing agent, MCP transport, console mini-app shell) lives in `nyuchi/mzizi-tools`; long-form product docs live in `nyuchi/bundu-docs`; engineering docs in `nyuchi/nyuchi-docs`. Do not reintroduce any of those into `design-portal`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,15 +8,15 @@
 
 ## 1. Project Identity
 
-**Mzizi** is an **independent open-architecture project of the Bundu Foundation** — governed by the Bundu Foundation, operated and developed by Nyuchi. It is **not** a Nyuchi product. Mzizi owns the open 3D frontend architecture, the component registry (`mzizi.dev/r/`), the Mzizi API (`mzizi.dev/api`), the components, the infrastructure harness, and architecture nodes N4/N5/N8.
+**Mzizi** is an **independent open-architecture project of the Bundu Foundation** — governed by the Bundu Foundation, operated and developed by Nyuchi. It is **not** a Nyuchi product. Mzizi owns the open 3D frontend architecture, the component registry (`mzizi.dev/r/`), the Mzizi API (`mzizi.dev/api`), the components, the infrastructure harness, and the architecture nodes it serves.
 
-It serves the full stable registry across a 3D frontend architecture — **ten layers across five axes**: X-axis (horizontal composition — L2 primitives → L3 brand → L6 pages → L7 shell), Y-axis (vertical infrastructure — L1 tokens, L4 safety, L5 resilience), Z-axis (depth observation — L8 assurance), Outside (L9 fundi — self-healing actors), and Documentation (L10). Built on the **Five African Minerals** design system, installable via the shadcn CLI:
+It serves the full stable registry across a 3D frontend architecture — **ten nodes across five axes**: X-axis (horizontal composition — N2 primitives → N3 brand → N6 pages → N7 shell), Y-axis (vertical infrastructure — N1 tokens, N4 safety, N5 resilience), Z-axis (depth observation — N8 assurance), Outside (N9 — self-healing actors, now owned by `mzizi-tools`), and Documentation (N10). Built on the **Five African Minerals** design system, installable via the shadcn CLI:
 
 ```
 npx shadcn@latest add https://mzizi.dev/api/v1/ui/<component>
 ```
 
-**Version:** 4.0.39
+**Version:** 4.0.40
 
 **Live at:** mzizi.dev
 
@@ -24,72 +24,88 @@ npx shadcn@latest add https://mzizi.dev/api/v1/ui/<component>
 
 **Governance:** Bundu Foundation. **Operated by:** Nyuchi — `github.com/nyuchi`
 
-**Ecosystem context:** Mzizi is consumed across the bundu ecosystem — mukoko (17 consumer mini-apps + 4 substrate components), nyuchi (7 enterprise products), and sister brands (Zimbabwe Information Platform, Barstool by Nyuchi). It is the single source of truth for the design system, brand documentation, and the open architecture.
+**Ecosystem context:** Mzizi is consumed across the bundu ecosystem — the Mukoko consumer family (mini-apps), Nyuchi enterprise products (delivered through the Console), and sister brands. It is the single source of truth for the design system, the component registry, the brand documentation, and the open 3D frontend architecture. Long-form product documentation lives at **docs.bundu.org** (bundu-docs); engineering / how-things-are-done content lives at **docs.nyuchi.com** (nyuchi-docs).
 
 ---
 
 ## 2. Ecosystem Overview
 
-Mzizi exists within a broader ecosystem. Understanding the relationships prevents duplicate work and ensures consistency.
+Mzizi exists within a broader ecosystem. Understanding the relationships prevents duplicate work and keeps the doctrinal split (Mzizi / Mukoko / Nyuchi / Bundu) clean.
 
-| Repository                    | Purpose                                | Stack                                            | Status            |
-| ----------------------------- | -------------------------------------- | ------------------------------------------------ | ----------------- |
-| **design-portal** (this repo) | Component registry + design system hub | Next.js 16, Tailwind 4, Radix UI                 | Canonical, active |
-| **mukoko-weather**            | AI weather intelligence platform       | Next.js 16, FastAPI, ScyllaDB, Claude AI         | Production        |
-| **mukoko-news**               | Pan-African news aggregator            | Next.js 15, Cloudflare Workers, Hono, D1         | Active            |
-| **mukoko**                    | Super app (17 mini-apps, 4 substrate)  | Next.js + Capacitor, Preact mini-apps, Turborepo | Active            |
-| **nhimbe**                    | Events platform                        | Next.js, TypeScript                              | Active            |
-| **shamwari-ai**               | Sovereign AI companion                 | Python, Claude AI                                | Active            |
-| **nyuchi-main**               | Core platform + API + marketing        | Next.js, Cloudflare Workers                      | Active            |
-| **learning**                  | Digital learning experiences           | Astro                                            | Active            |
+| Repository                    | Purpose                                                                                                                                    | Stack                                                   | Status                               |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- | ------------------------------------ |
+| **design-portal** (this repo) | Mzizi portal — component registry, brand, 3D architecture, document-route MCP                                                              | Next.js 16, Tailwind 4, Radix UI, Supabase              | Canonical, active                    |
+| **nyuchi/mzizi-tools**        | Mzizi tooling — `mzizi-mcp`, `mzizi-sdk` (contains the Fundi agent), `mzizi-skills`, `mzizi-console-app` (Svelte mini-app for the Console) | TypeScript, Cloudflare Workers, Svelte                  | Active (renamed from `nyuchi/fundi`) |
+| **nyuchi/mukoko-platform**    | Nyuchi Console — B2B platform at `platform.nyuchi.com` (will be renamed `nyuchi-console`)                                                  | SvelteKit, Rust workers, WorkOS via identity.nyuchi.com | Active                               |
+| **nyuchi/bundu-docs**         | Outward-facing product documentation — `docs.bundu.org`                                                                                    | Astro Starlight                                         | Active                               |
+| **nyuchi/nyuchi-docs**        | Engineering / how-things-are-done docs — `docs.nyuchi.com`                                                                                 | Astro Starlight                                         | Active (mid-Wave-3 build)            |
+| **nyuchi/mukoko-news**        | Pan-African news aggregator                                                                                                                | Next.js 15, Cloudflare Workers, Hono, D1                | Active                               |
+| **nyuchi/mukoko-weather**     | AI weather intelligence platform                                                                                                           | Next.js 16, FastAPI, ScyllaDB, Claude AI                | Production                           |
+| **nyuchi/mukoko**             | Super app (mini-apps + substrate components)                                                                                               | Next.js + Capacitor, Preact mini-apps, Turborepo        | Active                               |
+| **nyuchi/nhimbe**             | Events platform                                                                                                                            | Next.js, TypeScript                                     | Active                               |
+| **nyuchi/shamwari-ai**        | Sovereign AI companion                                                                                                                     | Python, Claude AI                                       | Active                               |
+| `mintlify-docs`               | Retired Mintlify docs site                                                                                                                 | —                                                       | Retired (README has a redirect)      |
 
-### Design System Flow
+### Design system flow
 
 ```
 design-portal (this repo)
     │
-    ├── Defines: Five African Minerals palette, typography, component API
-    ├── Serves: the full stable registry across 10 architecture layers via shadcn CLI / API (live count: `GET /api/v1/stats`)
+    ├── Defines: Five African Minerals palette, typography, component API,
+    │            3D frontend architecture, Ubuntu doctrine
+    ├── Serves: the full stable registry across 10 architecture nodes via the
+    │           shadcn CLI / `/api/v1/*` (live count: GET /api/v1/stats)
+    │           and the document-route MCP at /mcp (mzizi://components, mzizi://nodes)
     │
     └── Consumed by:
-        ├── mukoko-weather  (weather.mukoko.com)
-        ├── mukoko-news     (news.mukoko.com)
-        ├── mukoko super app (*.mukoko.com)
-        ├── nhimbe          (events.mukoko.com)
-        ├── Sister brands   (Zimbabwe Information Platform, Barstool by Nyuchi)
-        └── Any new bundu ecosystem app
+        ├── Mukoko consumer apps  (weather, news, nhimbe, super app, …)
+        ├── Nyuchi enterprise products — surfaced inside the Console
+        │   (each Mzizi mini-app ships as the `mzizi-console-app` npm package
+        │    and plugs into platform.nyuchi.com)
+        ├── Sister brands (Zimbabwe Information Platform, Barstool by Nyuchi)
+        └── Any new bundu ecosystem app — via @nyuchi/design-cli init
 ```
 
-**Rule:** When building a new app, install components from this registry. Do not copy-paste component code or create parallel component libraries.
+**Rule:** When building a new app, install components from this registry. Do not copy-paste component code or create parallel component libraries. Mzizi-side agentic tooling (the Fundi self-healing agent, MCP transport, console mini-app shell) lives in `nyuchi/mzizi-tools`; long-form product docs live in `nyuchi/bundu-docs`; engineering docs in `nyuchi/nyuchi-docs`. Do not reintroduce any of those into `design-portal`.
 
 ---
 
 ## 3. Tech Stack
 
-| Layer                | Technology                                      | Version                                    |
-| -------------------- | ----------------------------------------------- | ------------------------------------------ |
-| Framework            | Next.js (App Router) + `@next/mdx`              | 16.2.4                                     |
-| Language             | TypeScript (strict mode)                        | 6.0.3                                      |
-| Package Manager      | pnpm                                            | 10.33.0                                    |
-| Styling              | Tailwind CSS + CSS custom properties            | 4.2.4                                      |
-| Component Primitives | Radix UI + Base UI                              | radix-ui 1.4.3, @base-ui/react 1.4.1       |
-| Variant Management   | class-variance-authority (CVA)                  | 0.7.1                                      |
-| Class Composition    | clsx + tailwind-merge                           | via `cn()` in `lib/utils.ts`               |
-| Icons                | Lucide React                                    | 1.8.0                                      |
-| Theming              | next-themes                                     | 0.4.6                                      |
-| Forms                | react-hook-form + zod                           | 7.73.1 / 4.3.6                             |
-| Charts               | Recharts                                        | 3.8.1                                      |
-| Testing              | Vitest + Testing Library                        | 4.1.5                                      |
-| Observability        | Structured logging (`lib/observability.ts`)     | Built-in                                   |
-| Metrics              | MCP usage tracking (`lib/metrics.ts`)           | Built-in                                   |
-| Site search          | Pagefind (built in `postbuild` step)            | 1.5.2, static index in `public/_pagefind/` |
-| Database             | Supabase (PostgreSQL) — single source of truth  | @supabase/supabase-js 2.104.0              |
-| MCP Server           | @modelcontextprotocol/sdk (Streamable HTTP)     | 1.29.0                                     |
-| CLI                  | @nyuchi/design-cli (workspace package)          | 0.1.0                                      |
-| Skills bundle        | @nyuchi/design-agent-skills (workspace package) | 1.0.0                                      |
-| Workspace            | pnpm workspace (`packages/*`)                   | pnpm 10.33                                 |
-| CI/CD                | GitHub Actions + Vercel                         | —                                          |
-| Deployment           | Vercel                                          | —                                          |
+| Layer                | Technology                                         | Version                                    |
+| -------------------- | -------------------------------------------------- | ------------------------------------------ |
+| Framework            | Next.js (App Router) + `@next/mdx`                 | 16.2.4                                     |
+| Language             | TypeScript (strict mode)                           | 6.0.3                                      |
+| Styling              | Tailwind CSS + CSS custom properties               | 4.2.4                                      |
+| Component Primitives | Radix UI + Base UI                                 | radix-ui 1.4.3, @base-ui/react 1.4.1       |
+| Variant Management   | class-variance-authority (CVA)                     | 0.7.1                                      |
+| Class Composition    | clsx + tailwind-merge                              | via `cn()` in `lib/utils.ts`               |
+| Icons                | Lucide React                                       | 1.8.0                                      |
+| Theming              | next-themes                                        | 0.4.6                                      |
+| Forms                | react-hook-form + zod                              | 7.73.1 / 4.3.6                             |
+| Charts               | Recharts                                           | 3.8.1                                      |
+| Testing              | Vitest + Testing Library                           | 4.1.5                                      |
+| Observability        | Structured logging (`lib/observability.ts`)        | Built-in                                   |
+| Metrics              | MCP usage tracking (`lib/metrics.ts`)              | Built-in                                   |
+| Site search          | Pagefind (built in `postbuild` step)               | 1.5.2, static index in `public/_pagefind/` |
+| Database             | Supabase (PostgreSQL) — single source of truth     | @supabase/supabase-js 2.104.0              |
+| Supabase request ctx | `@supabase/server` (`createSupabaseContext`, anon) | latest                                     |
+| MCP Server           | @modelcontextprotocol/sdk (Streamable HTTP)        | 1.29.0                                     |
+| CI/CD                | GitHub Actions + Vercel                            | —                                          |
+| Deployment           | Vercel                                             | —                                          |
+
+### Mzizi tooling — out-of-repo
+
+The Mzizi agent + MCP + SDK + console mini-app shell are **not** in this repo. They live in `nyuchi/mzizi-tools` and are consumed as published npm packages:
+
+| Package             | Purpose                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------- |
+| `mzizi-mcp`         | Standalone Cloudflare Worker MCP transport (mirrors `/mcp` for non-portal consumers)                    |
+| `mzizi-sdk`         | TypeScript SDK + the **Fundi self-healing agent** (Outside-axis actor)                                  |
+| `mzizi-skills`      | Published skill bundle (`.md` files) for AI assistants — successor to the in-repo `design-agent-skills` |
+| `mzizi-console-app` | Svelte mini-app that surfaces Mzizi inside the Nyuchi Console (platform.nyuchi.com)                     |
+
+The portal still owns the `/mcp` HTTP endpoint (this repo's `app/mcp/route.ts`) — the standalone `mzizi-mcp` Worker is a deployment variant for consumers that don't want to go through `mzizi.dev`. Both surfaces read the same `component_documents` Supabase table.
 
 ---
 
@@ -123,10 +139,7 @@ Sync flags (passed to `tsx scripts/sync-registry.ts`):
 design-portal/
 ├── .claude/
 │   ├── settings.json                 # MCP server configuration for Claude Code
-│   └── skills/
-│       ├── nyuchi-design-system.md   # Design system guidance skill
-│       ├── ecosystem-app-setup.md    # Bootstrapping a new bundu ecosystem app
-│       └── scaffold-component.md     # Pattern for adding a new registry component
+│   └── skills/                       # Author-time agent skills shipped with the repo
 ├── .github/
 │   └── workflows/
 │       ├── ci.yml                    # Lint, typecheck, test, build, audit
@@ -134,57 +147,71 @@ design-portal/
 │       └── release.yml               # Validate + create GitHub release on tags
 ├── .husky/
 │   └── pre-commit                    # lint-staged → typecheck → audit
-├── __tests__/                        # Vitest test suite (currently 3 files)
+├── __tests__/                        # Vitest test suite
+│   ├── playground-routes.test.ts     # /playground + /playground/[name] route surface
 │   └── api/
 │       ├── brand-route.test.ts       # /api/v1/brand response & headers
 │       ├── registry-route.test.ts    # /api/v1/ui registry integrity
 │       └── v1/
 │           └── architecture-routes.test.ts  # v1 route file existence
-├── app/                              # Next.js App Router (@next/mdx for .mdx routes)
+├── app/                              # Next.js App Router
 │   ├── globals.css                   # Theme tokens + Tailwind imports (token SOURCE OF TRUTH)
-│   ├── layout.tsx                    # Root layout (fonts, ThemeProvider)
-│   ├── page.mdx                      # Landing page
-│   ├── error.tsx, global-error.tsx, not-found.tsx
-│   ├── icon.svg, apple-icon.svg
+│   ├── layout.tsx                    # Root layout — Mzizi dashboard shell
+│   ├── page.tsx                      # Landing page (server component, no MDX)
+│   ├── error.tsx, global-error.tsx, not-found.tsx, loading.tsx
+│   ├── icon.svg, apple-icon.svg, opengraph-image.tsx
 │   ├── robots.ts                     # robots.txt generator
 │   ├── sitemap.ts                    # sitemap.xml generator
+│   ├── .well-known/security.txt/route.ts
 │   ├── api/
 │   │   ├── openapi/route.ts          # OpenAPI document
+│   │   ├── chaos/[name]/route.ts     # L5/N5 chaos-injection endpoint (out-of-v1)
+│   │   ├── health/[name]/route.ts    # Per-resource health probe (out-of-v1)
 │   │   └── v1/                       # Mzizi API v1 (see §9)
 │   │       ├── route.ts              # Discovery document
 │   │       ├── ai/instructions/      # AI instruction sets (mcp-server / claude / copilot)
+│   │       ├── architecture/         # /architecture, /architecture/axes, /architecture/layers/[n],
+│   │       │                         #   /architecture/frontend/{axes,layers}
 │   │       ├── brand/                # Brand system
 │   │       ├── changelog/            # Releases (root + [version])
-│   │       ├── data-layer/, ecosystem/, pipeline/, sovereignty/  # Architecture topics
-│   │       ├── docs/                 # HTTP 410 — docs moved to docs.bundu.org/mzizi (root + [slug])
+│   │       ├── data-layer/, ecosystem/, pipeline/, sovereignty/
+│   │       ├── docs/                 # HTTP 410 — docs moved to bundu-docs (root + [slug])
 │   │       ├── health/               # Health check
 │   │       ├── search/               # Cross-resource search
-│   │       ├── stats/                # Live counts + layer breakdown
+│   │       ├── skills/               # Skills index + summary + [name]
+│   │       ├── stats/                # Live counts + observability metrics
+│   │       ├── ubuntu/               # /ubuntu/pillars, /ubuntu/principles
 │   │       └── ui/                   # Registry: list, [name], [name]/docs, [name]/versions
-│   ├── mcp/route.ts                  # MCP server HTTP endpoint
+│   ├── mcp/route.ts                  # MCP server HTTP endpoint (document-route)
 │   ├── architecture/                 # 3D architecture explorer (page.tsx + layers/[n])
 │   ├── components/                   # Component gallery (page.tsx + [name])
-│   ├── design/, docs/, foundations/, observability/, patterns/, registry/   # MDX doc routes
+│   ├── source/[name]/                # Per-component source viewer
+│   ├── playground/                   # Interactive component gallery (page.tsx + [name]) — wired #106
+│   ├── tools/                        # Mzizi tools index + [name] detail — wired #107
+│   ├── changelog/                    # /changelog + /changelog/[name] (per-component changelog) — wired #107
+│   ├── observability/                # /observability open-data dashboard — wired #105
+│   └── (app/ubuntu/                  # /ubuntu portal page — landing on v4.0.41 from PR #108)
 ├── components/
-│   ├── docs/                         # DB-driven docs renderers (DEPRECATED — see §15.18)
+│   ├── docs/                         # `db-changelog.tsx` — DB-driven changelog renderer
 │   ├── landing/                      # Portal-specific compositions over registry components
 │   │                                 #   (header, footer, dashboard-sidebar, breadcrumbs, toc,
 │   │                                 #   hero, install-steps, ai-native, build-with, explore,
-│   │                                 #   resilient-by-design, architecture-canvas / explorer)
+│   │                                 #   resilient-by-design, architecture-canvas / explorer,
+│   │                                 #   copy-command)
 │   ├── layout/                       # mineral-strip.tsx, nyuchi-logo.tsx
-│   ├── mdx/                          # MDX-author-facing components (Callout, ...)
+│   ├── mdx/                          # MDX-author-facing components (Callout, …)
 │   ├── mukoko/                       # Vendored registry:ui brand components
 │   │                                 #   (mukoko-header, mukoko-footer, mukoko-theme-provider,
-│   │                                 #   mukoko-skeleton-set, mukoko-error-set,
-│   │                                 #   mukoko-verified-badge) — registry paths kept as-is
-│   │                                 #   for pnpm registry:sync parity, see §8.6 note
+│   │                                 #   mukoko-skeleton-set, mukoko-error-set, mukoko-verified-badge)
 │   ├── patterns/                     # Pattern demos (architecture, observability,
 │   │                                 #   error-boundary, lazy-loading, component-pattern, code-block)
 │   ├── playground/                   # Interactive component gallery + API tester
-│   ├── ui/                           # ~35 portal primitives (the only registry items committed
-│   │                                 #   to disk; the other ~510 live only in Supabase
-│   │                                 #   and are served via /api/v1/ui) — plus user-menu.tsx
-│   │                                 #   (vendored from nyuchi-user-menu)
+│   ├── ui/                           # Portal primitives — the only registry items committed
+│   │                                 #   to disk. Post-rebrand additions: `node-badge.tsx`,
+│   │                                 #   `status-badge.tsx`, `direction.tsx`, `typography.tsx`,
+│   │                                 #   `spinner.tsx`, `kbd.tsx`, `user-menu.tsx`
+│   ├── live-component-count.tsx      # Renders live count from /api/v1/stats
+│   ├── live-mcp-stats.tsx            # Renders MCP usage stats
 │   ├── error-boundary.tsx, lazy-section.tsx, section-error-boundary.tsx
 │   ├── theme-provider.tsx, theme-toggle.tsx
 │   └── example.tsx
@@ -194,12 +221,11 @@ design-portal/
 ├── lib/
 │   ├── utils.ts                      # cn() utility (clsx + tailwind-merge)
 │   ├── icons.ts                      # Re-export shim for @/lib/icons (lucide-react passthrough)
-│   ├── observability.ts              # Structured logging with [mukoko] prefix
+│   ├── observability.ts              # Structured logging with [mzizi] prefix
 │   ├── metrics.ts                    # MCP/API usage tracking
-│   ├── mcp-server.ts                 # MCP server factory (served at /mcp)
+│   ├── mcp-server.ts                 # MCP server factory — `createMziziMcpServer(supabase)`
 │   ├── nav.ts                        # Shared nav data for header + sidebar (curated, not auto-gen)
 │   ├── harness/                      # Vendored: NyuchiHarness + useNyuchiHarness hook
-│   │                                 #   (observability + motion + a11y + health wiring)
 │   ├── resilience/                   # Vendored: section error boundary + retry fetch + fallback
 │   ├── tokens/                       # Vendored: L1 design tokens + multi-platform generators
 │   ├── motion/                       # Vendored: motion presets + reduced-motion detection
@@ -217,29 +243,28 @@ design-portal/
 │   ├── _pagefind/                    # Static search index (built by postbuild)
 │   ├── icons/                        # Favicon assets
 │   └── llms.txt                      # LLM-readable registry summary
-├── packages/                         # pnpm workspace — published npm packages
-│   ├── design-cli/                   # @nyuchi/design-cli — bootstraps consumer
-│   │                                 #   apps (init / add / skills install/update)
-│   └── design-agent-skills/          # @nyuchi/design-agent-skills — published
-│                                     #   snapshot of the Supabase `skills` table;
-│                                     #   regenerated by `pnpm skills:sync`
-├── pnpm-workspace.yaml               # declares packages/* as workspace members
+├── supabase/
+│   ├── schema.sql                    # Single-file schema snapshot
+│   ├── config.toml
+│   ├── seeds/
+│   └── functions/
+│       ├── _shared/                  # CORS + supabase helpers
+│       └── analytics/                # Open-data analytics edge function
 ├── .claude-plugin/
 │   └── plugin.json                   # Claude Code plugin marketplace manifest
-│                                     #   (skills paths + MCP server + icons)
 ├── registry.json                     # Generated snapshot of Supabase `components` (CI verifies drift)
 ├── openapi.yaml                      # OpenAPI 3.1 specification for /api/v1/
 ├── vitest.config.ts, vitest.setup.ts
 ├── components.json                   # shadcn CLI configuration
 ├── next.config.mjs, tsconfig.json, postcss.config.mjs, eslint.config.mjs, .prettierrc
-└── package.json                      # v4.0.39 (private; the Next.js app at root)
+└── package.json                      # v4.0.40 (the Next.js app at root)
 ```
 
 > **Note on `registry.json`:** post-v4.0.26 the authoritative registry lives in the
 > Supabase `components` table. `registry.json` is a committed snapshot so PRs show
 > registry deltas clearly; `pnpm registry:verify` runs in CI to enforce the snapshot
-> stays in sync. Only the ~35 primitives the portal itself imports are written into
-> `components/ui/`; the rest of the stable registry is served only via `/api/v1/ui` (live count from `GET /api/v1/stats`).
+> stays in sync. Only the primitives the portal itself imports are written into
+> `components/ui/`; the rest of the stable registry is served only via `/api/v1/ui`.
 
 ---
 
@@ -247,18 +272,22 @@ design-portal/
 
 ### 6.1 Registry System
 
-**Single source of truth: the Supabase `components` table** — the stable registry across 10 architecture layers (live count: `GET /api/v1/stats` → `stable`), with metadata, dependencies, source code, docs, and version history split across:
+**Single source of truth: the Supabase `components` table** — the stable registry across 10 architecture nodes (live count: `GET /api/v1/stats`), with metadata, dependencies, source code, docs, and version history split across:
 
-| Table                 | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `components`          | Name, type, description, deps, files, source_code, architecture_layer, category, status                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| `component_docs`      | Use cases, variants, a11y notes (per component)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `component_versions`  | Per-component version history                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `documentation_pages` | **HISTORICAL — content migrated to repo MDX, renderers + API removed.** All 10 published rows shipped as repo MDX under `/docs/*`, `/architecture/*`, `/brand`, and `/foundations/tokens`. The DB-driven renderers (`components/docs/db-doc-page.tsx`, `db-doc-index.tsx`) and the dynamic `[slug]` route are deleted; `/api/v1/docs/*` returns HTTP 410 with a `migrated_to` map; the `get_documentation_page` MCP tool is removed. The table remains in Supabase as the historical source-of-record. Do not add new rows; author new docs as MDX. See §15.18. |
-| `changelog`           | Releases (currently 4.0.0 → 4.0.39)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| `ai_instructions`     | System prompts per target (mcp-server, claude, copilot)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| `brand_*`             | Minerals, semantic colors, typography, spacing, ecosystem brands                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| `architecture_*`      | Principles, data layer, pipeline, sovereignty assessments                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| Table                                                  | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `components`                                           | Name, type, description, deps, files, source_code, `node` / `architecture_layer`, category, status                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `component_documents`                                  | **Document-route staging table** (the spine of the new lean MCP). One self-contained JSON document per component (`{ owner, sources, legacy, files, … }`) keyed by node collection (`n1_tokens … n10_documentation`). The MCP at `/mcp` reads exclusively from here; the portal's `/api/v1/*` routes read from `components` and `component_docs`. The two surfaces are intentionally separate but stay in lock-step via a read-across pattern — `component_documents.legacy` mirrors the row in `components` so downstream consumers can pivot without duplicate fetches. |
+| `component_docs`                                       | Use cases, variants, a11y notes (per component) — served by `/api/v1/ui/{name}/docs`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `component_versions`                                   | Per-component version history — served by `/api/v1/ui/{name}/versions`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `documentation_pages`                                  | **HISTORICAL — content moved to bundu-docs and nyuchi-docs.** All published rows shipped as Astro Starlight pages on `docs.bundu.org` (product docs) and `docs.nyuchi.com` (engineering docs). The DB-driven renderers, the dynamic `[slug]` route, and the `get_documentation_page` MCP tool are all removed; `/api/v1/docs/*` returns HTTP 410 with a `migrated_to` map. The table remains in Supabase as the historical source-of-record. Do not add new rows; author new docs in the Starlight repos. See §15.18.                                                     |
+| `changelog`                                            | Releases — `nodes_affected` (1–10), `tools_added/modified/deprecated/removed`, `components_added/modified/deprecated/removed`, `linked_issues`, `released_at`. Served at `/api/v1/changelog` and `/api/v1/changelog/{version}`; rendered into `/changelog` (#107).                                                                                                                                                                                                                                                                                                        |
+| `ai_instructions`                                      | System prompts per target (mcp-server, claude, copilot)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `skills`                                               | Agent-skill MDX bodies (single source for `/api/v1/skills*` and the published `mzizi-skills` bundle in `nyuchi/mzizi-tools`)                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `brand_*`                                              | Minerals, semantic colors, typography, spacing, ecosystem brands                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `architecture_*`                                       | Principles, data layer, pipeline, sovereignty assessments, frontend axes/layers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `ubuntu_pillars/principles`                            | Doctrine rows served at `/api/v1/ubuntu/{pillars,principles}` (and consumed by `app/ubuntu` once #108 lands)                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `fundi_issues`, `observability_events`, `chaos_events` | Open-data event streams behind the `/observability` dashboard (#105) — public, schema.org `Dataset` JSON-LD                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 
 API responses follow the shadcn registry schema at `https://ui.shadcn.com/schema/registry.json`.
 
@@ -269,8 +298,11 @@ Supabase (source of truth)
      │
      ├── lib/db/index.ts (server-side queries)
      │     ├──► /api/v1/* (Next.js API routes — CORS + 1h cache)
-     │     ├──► /mcp      (MCP server — tools & resources)
-     │     └──► Server components (architecture / brand / docs MDX pages)
+     │     ├──► Server components (architecture / brand / changelog / observability pages)
+     │     └──► /observability dashboard (live charts from usage_events + fundi_issues + chaos_events)
+     │
+     ├── app/mcp/route.ts (document-route MCP)
+     │     └──► createMziziMcpServer(supabase) — reads `component_documents` only
      │
      ├── pnpm registry:sync ──► registry.json + components/ui/*  (committed snapshot)
      │                          (CI runs `pnpm registry:verify` to fail on drift)
@@ -280,61 +312,48 @@ Supabase (source of truth)
 
 **`registry.json`** must exist in the repo root, but it is **never hand-edited**. It is regenerated dynamically from Supabase by `pnpm registry:sync` whenever a component is added, modified, or removed in the database. The file is committed so that diffs are visible in PRs and CI can detect drift via `pnpm registry:verify`.
 
-**Registry item schema:**
-
-```json
-{
-  "name": "button",
-  "type": "registry:ui",
-  "description": "Displays a button or a component that looks like a button.",
-  "dependencies": ["radix-ui", "class-variance-authority"],
-  "registryDependencies": ["other-component-names"],
-  "files": [{ "path": "components/ui/button.tsx", "type": "registry:ui" }]
-}
-```
-
-**Item types:** `registry:ui` (components), `registry:hook` (hooks), `registry:lib` (utilities), `registry:block` (page blocks)
-
 **Required env vars:**
 
 ```
 NEXT_PUBLIC_SUPABASE_URL       — Supabase project URL
 NEXT_PUBLIC_SUPABASE_ANON_KEY  — public anon key (read-only via RLS)
 SUPABASE_SERVICE_ROLE_KEY      — write access; server-only, never expose
+SUPABASE_URL                   — (alias used by @supabase/server in /mcp)
+SUPABASE_PUBLISHABLE_KEY       — (alias used by @supabase/server in /mcp)
 ```
 
-Every route in the portal is public and anon-readable. There is no authenticated surface — the registry, brand, MCP, and API routes are all open. (The Fundi self-healing dashboard and its Stytch B2B auth were removed when Fundi moved to the Nyuchi platform.)
+Every route in the portal is public and anon-readable. There is no authenticated surface — the registry, brand, MCP, observability, and API routes are all open. The Fundi self-healing agent and its B2B auth surface live in `nyuchi/mzizi-tools` and the Nyuchi Console (`nyuchi/mukoko-platform`), not here.
 
 ### 6.2 Layered Component Architecture
 
 Every component follows a layered pattern. This is mandatory for all bundu ecosystem apps consuming this registry.
 
-The frontend architecture is a **3D model with ten layers across five axes**. Each component in `components.architecture_layer` (1-10) and `components.layer` (sub-label) sits at exactly one position. Issue #46 tracks moving this mapping into first-class Supabase tables (`architecture_frontend_layers`, `architecture_frontend_axes`); until then the mapping is also enumerated in `get_layer_counts()`.
+The frontend architecture is a **3D model with ten nodes across five axes**. Each component in `components.architecture_layer` (1–10) sits at exactly one position; per-node collections (`n1_tokens … n10_documentation`) are the canonical document-route keying.
 
-| #   | sub_label       | Axis          | Covenant                                                 |
-| --- | --------------- | ------------- | -------------------------------------------------------- |
-| 1   | `tokens`        | Y-axis        | Design decisions are data, not code.                     |
-| 2   | `primitive`     | X-axis        | A primitive does one thing well.                         |
-| 3   | `brand`         | X-axis        | A brand component is a primitive with Ubuntu in it.      |
-| 4   | `safety`        | Y-axis        | Nothing harmful reaches the user.                        |
-| 5   | `resilience`    | Y-axis        | Failure in one part never breaks the whole.              |
-| 6   | `pages`         | X-axis        | A page is a composition, not an implementation.          |
-| 7   | `shell`         | X-axis        | The shell holds the product.                             |
-| 8   | `assurance`     | Z-axis        | What breaks is seen before users feel it.                |
-| 9   | `fundi`         | Outside       | Failure is a learning event, not a user-facing incident. |
-| 10  | `documentation` | Documentation | The system documents itself in code — MDX in the repo.   |
+| #   | sub_label       | Axis          | Covenant                                                |
+| --- | --------------- | ------------- | ------------------------------------------------------- |
+| 1   | `tokens`        | Y-axis        | Design decisions are data, not code.                    |
+| 2   | `primitive`     | X-axis        | A primitive does one thing well.                        |
+| 3   | `brand`         | X-axis        | A brand component is a primitive with Ubuntu in it.     |
+| 4   | `safety`        | Y-axis        | Nothing harmful reaches the user.                       |
+| 5   | `resilience`    | Y-axis        | Failure in one part never breaks the whole.             |
+| 6   | `pages`         | X-axis        | A page is a composition, not an implementation.         |
+| 7   | `shell`         | X-axis        | The shell holds the product.                            |
+| 8   | `assurance`     | Z-axis        | What breaks is seen before users feel it.               |
+| 9   | `fundi`         | Outside       | Failure is a learning event — owned by `mzizi-tools`.   |
+| 10  | `documentation` | Documentation | The system documents itself — bundu-docs + nyuchi-docs. |
 
-**Axis meanings:** X = horizontal composition flow (primitives → brand → pages → shell, what the user sees); Y = vertical infrastructure (tokens, safety, resilience threading through every X-layer); Z = depth observation (assurance watching X and Y without being inside anything); Outside = actors beyond the build (fundi heals autonomously); Documentation = the system describing itself.
+**Axis meanings:** X = horizontal composition flow (primitives → brand → pages → shell, what the user sees); Y = vertical infrastructure (tokens, safety, resilience threading through every X-layer); Z = depth observation (assurance watching X and Y without being inside anything); Outside = actors beyond the build (Fundi heals autonomously); Documentation = the system describing itself.
 
 **Rules:**
 
 - Components import from the layer below on the same axis — never sideways or upward
 - Each component is a standalone file
-- L6 pages NEVER hardcode buttons/cards/SVGs — pure composition of L2/L3
-- L1 is the only layer allowed to define CSS values — every other layer consumes via `var()`
-- L3 always destructures `{ log, motion, LiveRegion }` from `useNyuchiHarness`; L2 never imports it
+- N6 pages NEVER hardcode buttons/cards/SVGs — pure composition of N2/N3
+- N1 is the only layer allowed to define CSS values — every other layer consumes via `var()`
+- N3 always destructures `{ log, motion, LiveRegion }` from `useNyuchiHarness`; N2 never imports it
 - All colors and styles come from CSS custom properties in `globals.css`
-- This 3D frontend model is **distinct** from the 7-layer data architecture at `/architecture` (Pod → Relational → Document → Orchestration → Edge → Device → Open Data). Never conflate the two numberings — a component can sit at frontend L3 and read from data L2 without contradiction.
+- This 3D frontend model is **distinct** from the 7-layer data architecture at `/architecture`. Never conflate the two numberings.
 
 ### 6.3 Component Patterns
 
@@ -350,12 +369,10 @@ const buttonVariants = cva(
       variant: {
         default: "bg-primary text-primary-foreground ...",
         outline: "border-border bg-input/30 ...",
-        // ...
       },
       size: {
         default: "h-9 gap-1.5 px-3",
         sm: "h-8 gap-1 px-3",
-        // ...
       },
     },
     defaultVariants: { variant: "default", size: "default" },
@@ -395,8 +412,8 @@ Three layers of error isolation:
 **API error handling:**
 
 - API routes return proper HTTP status codes (400, 404, 500, 503 when Supabase env vars are missing)
-- All errors logged via `createLogger("<scope>")` from `lib/observability.ts`, with `[mukoko]` prefix for grep-ability
-- Components and resilience patterns (circuit-breaker, retry, timeout, fallback-chain, ai-safety, chaos) are no longer kept as `lib/*` files in this repo — their canonical source lives in the Supabase `components` table as `registry:lib` items and is installed by consumer apps via the shadcn CLI
+- All errors logged via `createLogger("<scope>")` from `lib/observability.ts`, with `[mzizi]` prefix for grep-ability
+- Resilience patterns (circuit-breaker, retry, timeout, fallback-chain, ai-safety, chaos) are vendored in `lib/`; their canonical source lives in the Supabase `components` table as `registry:lib` items and is installed by consumer apps via the shadcn CLI
 
 ---
 
@@ -418,7 +435,7 @@ This is the canonical design system. All bundu ecosystem apps MUST use these tok
 
 **Semantic color tokens** (theme-adaptive via CSS custom properties):
 
-> **Values synced from the `nyuchi-tokens` registry (L1), April 2026 AAA-optimised swap.**
+> **Values synced from the `nyuchi-tokens` registry (N1), April 2026 AAA-optimised swap.**
 > Surfaces were re-arranged: `background` is now the ambient page base, `card` is the content surface, `muted` is the deepest fill. Border/input alpha tightened to 0.06. Two new tokens added: `overlay` (modal/sheet surface) and `scrim` (modal backdrop).
 
 | Token                  | Light                 | Dark                     | Usage                         |
@@ -465,7 +482,7 @@ This is the canonical design system. All bundu ecosystem apps MUST use these tok
 
 Noto Sans chosen for broad language support (African languages, diacritics).
 
-All brand wordmarks are **lowercase**: `mukoko`, `nyuchi`, `shamwari`.
+All brand wordmarks are **lowercase**: `mzizi`, `mukoko`, `nyuchi`, `shamwari`, `bundu`.
 
 ### 7.3 Theme Implementation
 
@@ -501,7 +518,7 @@ All radii derive from `--radius-unit: 7px`. The ecosystem numbers are 7, 12, 14,
 --radius-full: 9999px           — buttons, badges, pills, avatars
 ```
 
-**Buttons are always pill-shaped (`rounded-full`).** This is an executive brand identity decision — not a radius scale value. All buttons, tabs, and interactive pill-shaped controls use `rounded-full` (9999px). This applies across the entire ecosystem: every app, every API response, every MCP tool, every documentation reference.
+**Buttons are always pill-shaped (`rounded-full`).** This is an executive brand identity decision — not a radius scale value. All buttons, tabs, and interactive pill-shaped controls use `rounded-full` (9999px). This applies across the entire ecosystem.
 
 ---
 
@@ -513,14 +530,14 @@ All radii derive from `--radius-unit: 7px`. The ecosystem numbers are 7, 12, 14,
 - **shadcn style:** "new-york" with neutral base color
 - **Tailwind utility classes only** — no inline styles, no CSS modules (except embed widgets)
 - **TypeScript strict mode** — maintain type safety, no `any` without justification
-- **Exports:** Named exports for components (`export { Button, buttonVariants }`), not default exports
-- **File naming:** kebab-case for files (`button-group.tsx`), PascalCase for components (`ButtonGroup`)
+- **Exports:** Named exports for components, not default exports
+- **File naming:** kebab-case for files, PascalCase for components
 
 ### 8.2 Component Requirements
 
 Every component in `components/ui/` MUST have:
 
-1. **Touch targets** — 56px default height, 48px minimum for small variants. This is non-negotiable for the African mobile market (outdoor use, varied screen sizes, accessibility)
+1. **Touch targets** — 56px default height, 48px minimum for small variants. Non-negotiable for the African mobile market
 2. **Accessibility** — ARIA attributes where needed, semantic HTML, keyboard navigation via Radix primitives
 3. **Global styles only** — Tailwind classes backed by CSS custom properties from `globals.css`
 4. **`cn()` composition** — all className props composed through `cn()`
@@ -530,13 +547,14 @@ Every component in `components/ui/` MUST have:
 
 ### 8.3 Adding a New Component
 
-Components are authored **in the Supabase `components` table**, not as files in this repo. The committed `components/ui/*` files are a derived snapshot of the ~35 primitives the portal itself imports.
+Components are authored **in the Supabase `components` table**, not as files in this repo. The committed `components/ui/*` files are a derived snapshot of the primitives the portal itself imports.
 
 1. Insert the row into `components` (and `component_docs`) in Supabase, including `source_code`, `architecture_layer`, `category`, `dependencies`, `registry_dependencies`, and `status = 'stable'`
-2. Author the source following the CVA + Radix + cn() pattern (see `button.tsx` as reference)
-3. Run `pnpm registry:sync` locally to regenerate `registry.json` and (if the new component is portal-imported) `components/ui/<name>.tsx`
-4. Verify the API serves it: `curl http://localhost:11736/api/v1/ui/<component-name>`
-5. Commit the resulting `registry.json` (and `components/ui/*` if changed) — CI runs `pnpm registry:verify` to fail if the snapshot drifts
+2. If the new component should be reachable via the document-route MCP, also insert a row into `component_documents` keyed by the right `n{N}_*` collection
+3. Author the source following the CVA + Radix + cn() pattern (see `button.tsx`)
+4. Run `pnpm registry:sync` locally to regenerate `registry.json` and (if the new component is portal-imported) `components/ui/<name>.tsx`
+5. Verify the API serves it: `curl http://localhost:11736/api/v1/ui/<component-name>`
+6. Commit the resulting `registry.json` (and `components/ui/*` if changed) — CI runs `pnpm registry:verify` to fail if the snapshot drifts
 
 ### 8.4 Modifying Existing Components
 
@@ -545,84 +563,54 @@ Components are authored **in the Supabase `components` table**, not as files in 
 - Keep Radix UI accessibility primitives intact
 - Don't break the shadcn registry schema — `https://ui.shadcn.com/schema/registry.json`
 - Bump the row's `version` and append to `component_versions` so the changelog API reflects the change
+- If the component has a `component_documents` row, also update the document so the MCP stays in sync
 - Re-run `pnpm registry:sync` and commit the updated snapshot
 
 ### 8.5 When Building a New Bundu Ecosystem App
 
-One command:
+Install components via the shadcn CLI directly against the registry:
 
 ```bash
-npx @nyuchi/design-cli init
-```
-
-This scaffolds a fresh project with `app/globals.css` (the L1 token block — `:root` + `.dark` + `@theme inline`), `lib/utils.ts` (the `cn()` helper), `components/theme-provider.tsx` (next-themes wrapper), and `components.json` (shadcn CLI config). Pass `--force` to overwrite existing files.
-
-Then install components from the registry as needed:
-
-```bash
-npx @nyuchi/design-cli add button card data-table       # wraps shadcn CLI
-# or directly:
 npx shadcn@latest add https://mzizi.dev/api/v1/ui/button
+npx shadcn@latest add https://mzizi.dev/api/v1/ui/card
 ```
 
-And install agent skills so AI assistants in the project know the doctrine:
+Every new app inherits the canonical typography (Noto Sans / Noto Serif / JetBrains Mono), the Five African Minerals palette, the layered architecture, the pill-button identity, and the touch-target floor. Long-form product docs for any bundu app belong in `nyuchi/bundu-docs`; engineering docs belong in `nyuchi/nyuchi-docs`. Mzizi tooling (MCP, SDK, skills, console mini-app) is consumed from `nyuchi/mzizi-tools` as published npm packages.
 
-```bash
-npx @nyuchi/design-cli skills install                   # all skills, live from /api/v1/skills
-# or, equivalent, via the community skills CLI:
-npx skills add @nyuchi/design-agent-skills              # offline-friendly, ships .md files
-```
+### 8.6 Distribution surface
 
-Every new app inherits the canonical typography (Noto Sans / Noto Serif / JetBrains Mono), the Five African Minerals palette, the layered architecture, the pill-button identity, and the touch-target floor. The CLI is the single source of bootstrap truth.
-
-### 8.6 Distribution surface — shipped
-
-Three distribution surfaces, all live:
+Two live distribution paths from this repo:
 
 ```bash
 # 1. shadcn CLI — components from the registry
 npx shadcn@latest add https://mzizi.dev/api/v1/ui/<component>
 
-# 2. Nyuchi Design CLI — bootstrap + components + skills
-npx @nyuchi/design-cli init
-npx @nyuchi/design-cli add <component>
-npx @nyuchi/design-cli skills install
-npx @nyuchi/design-cli skills update
-
-# 3. Skills installer — markdown bundle for any AI assistant
-npx skills add @nyuchi/design-agent-skills
-
-# 4. Claude Code plugin marketplace (declared via .claude-plugin/plugin.json)
-/plugin marketplace add nyuchi/design-portal
-/plugin install nyuchi-design
-
-# 5. Direct HTTP — raw MDX for any consumer
-GET https://mzizi.dev/api/v1/skills           # list
-GET https://mzizi.dev/api/v1/skills/summary   # light list for version diff
-GET https://mzizi.dev/api/v1/skills/{name}    # full MDX body
+# 2. Direct HTTP — raw payloads for any consumer
+GET https://mzizi.dev/api/v1/ui            # list
+GET https://mzizi.dev/api/v1/ui/{name}     # source + metadata
+GET https://mzizi.dev/api/v1/skills        # list
+GET https://mzizi.dev/api/v1/skills/{name} # full MDX body
 ```
 
-Both npm packages live in this repo as workspace members under `packages/` and are published on every `v*` tag by `.github/workflows/release.yml` (uses `NPM_TOKEN`). Skills are source-of-truthed in the Supabase `skills` table; `pnpm skills:sync` regenerates `packages/design-agent-skills/skills/*.md` from the live DB before publish (CI verifies via `pnpm skills:verify`). The `@nyuchi/design-cli` `skills install` subcommand fetches live from the API on every run, so consumers always pull the latest doctrine without re-installing the npm package.
+Mzizi tooling (CLI, agent, MCP transport, skills bundle, console mini-app) is published from `nyuchi/mzizi-tools` — not from this repo. The MCP server at `mzizi.dev/mcp` is the canonical reference implementation; the `mzizi-mcp` worker in `mzizi-tools` mirrors it for consumers that want a self-hostable Cloudflare Worker copy.
 
-### 8.7 Vendored registry stack — path + naming drift
+### 8.7 Vendored brand stack — path + naming drift
 
-The portal dogfoods its own registry. The 33-item transitive closure of `nyuchi-header` / `nyuchi-footer` / `nyuchi-user-menu` is vendored into this repo — the harness, resilience, tokens, motion, a11y, theme-provider, skeleton/error sets, verified-badge, and the seven resilience primitives (circuit-breaker, retry, timeout, fallback-chain, bulkhead, rate-limiter, chaos).
+The portal dogfoods its own registry. The transitive closure of the brand components (`nyuchi-header`, `nyuchi-footer`, `nyuchi-user-menu`) is vendored into this repo under `components/mukoko/*` and `components/layout/*`.
 
 **Two divergences between the registry's declared paths and the portal's reality**:
 
-1. **`components/mukoko/*` paths, `nyuchi-*` item names.** The registry is mid-rename (CLAUDE.md §11 already reflects the `nyuchi-*` names, but the registry's `files[].path` still points at `components/mukoko/mukoko-header.tsx`, etc.). Vendored files keep the `components/mukoko/*` path so that future `pnpm registry:sync` sees them as unchanged and doesn't try to overwrite with reshaped paths. When the registry itself completes the rename to `components/nyuchi/*`, run `pnpm registry:sync` + rename locally in a single commit.
-2. **Brand component imports use `@/components/brand/*` paths** that don't exist in this repo. The portal keeps `nyuchi-logo.tsx` and `mineral-strip.tsx` under `@/components/layout/` instead. Vendored files are patched on install to target the portal's real paths. Next `pnpm registry:sync` will re-patch automatically via the sync script (issue to be filed against the registry to align paths).
+1. **`components/mukoko/*` paths, `nyuchi-*` item names.** The registry is mid-rename; vendored files keep the `components/mukoko/*` path so that `pnpm registry:sync` sees them as unchanged. When the registry itself completes the rename to `components/nyuchi/*`, run `pnpm registry:sync` + rename locally in a single commit.
+2. **Brand component imports use `@/components/brand/*` paths** that don't exist in this repo. The portal keeps `nyuchi-logo.tsx` and `mineral-strip.tsx` under `@/components/layout/` instead. Vendored files are patched on install to target the portal's real paths.
 
-**Upstream-bug tracking.** The vendor pass fixed 11 genuine bugs in the registry source code (template-literal escape artefacts, broken exports, missing prop definitions, type mismatches). They are listed in the commit message of the vendor commit and mirrored in a tracking GitHub issue. Re-running `pnpm registry:sync` before the upstream issues close will reintroduce the bugs — the sync script may need a patch-set overlay until the registry is clean.
-
-**Footer composition note.** `components/landing/footer.tsx` is deliberately NOT a one-line wrapper over `NyuchiFooter`. The portal footer has four portal-specific features NyuchiFooter doesn't currently expose: (1) the ecosystem brand grid (mukoko-consumer + nyuchi-enterprise columns), (2) a socials row (GitHub x2, X/Twitter), (3) an inline `ThemeToggle`, (4) a version line. The portal footer is a composition of primitives (`Separator`, `NyuchiLogo`, `ThemeToggle`) — not a hand-rolled variation of `NyuchiFooter`. Extending `NyuchiFooter` upstream with `ecosystem` / `socials` / `actions` / `version` props so the portal can fully dogfood it is a tracked follow-up.
+**Footer composition note.** `components/landing/footer.tsx` is deliberately NOT a one-line wrapper over `NyuchiFooter`. The portal footer has four portal-specific features: (1) the ecosystem brand grid, (2) a socials row, (3) an inline `ThemeToggle`, (4) a version line.
 
 ### 8.8 registry.json Schema Reference
 
 ```json
 {
   "$schema": "https://ui.shadcn.com/schema/registry.json",
-  "name": "mukoko",
+  "name": "mzizi",
   "homepage": "https://mzizi.dev",
   "items": [
     {
@@ -650,59 +638,62 @@ All endpoints are under `/api/v1/` and documented in `openapi.yaml` (OpenAPI 3.1
 
 All responses include schema.org JSON-LD metadata (`@context`, `@type`) where applicable.
 
-**Common headers:** `Cache-Control: public, max-age=3600, s-maxage=86400`, `Access-Control-Allow-Origin: *`
+**Common headers:** `Cache-Control: public, max-age=3600, s-maxage=86400`, `Access-Control-Allow-Origin: *` (except `/stats` which is `max-age=60, s-maxage=120` and `/health` which is `no-cache, no-store`).
 
-| Endpoint                                   | Description                                                | Supabase source                |
-| ------------------------------------------ | ---------------------------------------------------------- | ------------------------------ |
-| `GET /api/v1`                              | Discovery document — lists all resources                   | —                              |
-| `GET /api/v1/brand`                        | Brand system (minerals, typography, spacing, ecosystem)    | `brand_*` tables               |
-| `GET /api/v1/ui`                           | Component registry index                                   | `components`                   |
-| `GET /api/v1/ui/{name}`                    | Individual component (shadcn format, with source code)     | `components`                   |
-| `GET /api/v1/ui/{name}/docs`               | Component docs (use cases, variants, a11y)                 | `component_docs`               |
-| `GET /api/v1/ui/{name}/versions`           | Component version history                                  | `component_versions`           |
-| `GET /api/v1/ecosystem`                    | Architecture principles & framework decision               | `architecture_principles`      |
-| `GET /api/v1/data-layer`                   | Local-first + cloud layer specification                    | `architecture_data_layer`      |
-| `GET /api/v1/pipeline`                     | Open data pipeline (Redpanda → Flink → Doris)              | `architecture_pipeline`        |
-| `GET /api/v1/sovereignty`                  | Technology sovereignty assessments                         | `architecture_sovereignty`     |
-| `GET /api/v1/architecture/frontend/axes`   | 5 axes of the 3D frontend architecture                     | `architecture_frontend_axes`   |
-| `GET /api/v1/architecture/frontend/layers` | 10 layers of the 3D frontend architecture                  | `architecture_frontend_layers` |
-| `GET /api/v1/ubuntu/pillars`               | 5 Ubuntu Pillars                                           | `ubuntu_pillars`               |
-| `GET /api/v1/ubuntu/principles`            | 5 Ubuntu Principles                                        | `ubuntu_principles`            |
-| `GET /api/v1/docs`                         | **HTTP 410 Gone** — content moved to repo MDX (see §15.18) | —                              |
-| `GET /api/v1/docs/{slug}`                  | **HTTP 410 Gone** — content moved to repo MDX (see §15.18) | —                              |
-| `GET /api/v1/changelog`                    | All releases                                               | `changelog`                    |
-| `GET /api/v1/changelog/{version}`          | Single release                                             | `changelog`                    |
-| `GET /api/v1/ai/instructions`              | List AI instruction sets                                   | `ai_instructions`              |
-| `GET /api/v1/ai/instructions/{name}`       | Instruction set by target (mcp-server, claude, copilot)    | `ai_instructions`              |
-| `GET /api/v1/skills`                       | List published agent skills (lightweight, no body_mdx)     | `skills`                       |
-| `GET /api/v1/skills/summary`               | Same shape as `/skills`; reserved for the CLI update path  | `skills`                       |
-| `GET /api/v1/skills/{name}`                | Single skill with full `body_mdx`                          | `skills`                       |
-| `GET /api/v1/search?q=`                    | Cross-resource search (components + docs + changelog)      | multiple                       |
-| `GET /api/v1/stats`                        | Live counts (total stable, per layer, per category)        | `components`                   |
-| `GET /api/v1/health`                       | Service health check (`no-cache, no-store`)                | runtime checks                 |
+| Endpoint                                   | Description                                                  | Landed in |
+| ------------------------------------------ | ------------------------------------------------------------ | --------- |
+| `GET /api/v1`                              | Discovery document — lists all resources                     | —         |
+| `GET /api/v1/brand`                        | Brand system (minerals, typography, spacing, ecosystem)      | —         |
+| `GET /api/v1/ui`                           | Component registry index                                     | —         |
+| `GET /api/v1/ui/{name}`                    | Individual component (shadcn format, with source code)       | —         |
+| `GET /api/v1/ui/{name}/docs`               | Component docs (use cases, variants, a11y)                   | —         |
+| `GET /api/v1/ui/{name}/versions`           | Component version history                                    | —         |
+| `GET /api/v1/ecosystem`                    | Architecture principles & framework decision                 | —         |
+| `GET /api/v1/data-layer`                   | Local-first + cloud layer specification                      | —         |
+| `GET /api/v1/pipeline`                     | Open data pipeline (Redpanda → Flink → Doris)                | —         |
+| `GET /api/v1/sovereignty`                  | Technology sovereignty assessments                           | —         |
+| `GET /api/v1/architecture`                 | Full 3D architecture snapshot                                | —         |
+| `GET /api/v1/architecture/axes`            | Per-axis summary with live component counts                  | —         |
+| `GET /api/v1/architecture/layers/{n}`      | Per-layer detail (covenant, rules, breakdown)                | —         |
+| `GET /api/v1/architecture/frontend/axes`   | 5 axes of the 3D frontend architecture                       | —         |
+| `GET /api/v1/architecture/frontend/layers` | 10 layers of the 3D frontend architecture                    | —         |
+| `GET /api/v1/ubuntu/pillars`               | 5 Ubuntu Pillars                                             | —         |
+| `GET /api/v1/ubuntu/principles`            | 5 Ubuntu Principles                                          | —         |
+| `GET /api/v1/docs`                         | **HTTP 410 Gone** — content moved to bundu-docs              | —         |
+| `GET /api/v1/docs/{slug}`                  | **HTTP 410 Gone** — see `/api/v1/docs` for the slug map      | —         |
+| `GET /api/v1/changelog`                    | All releases (from `changelog` table)                        | #107      |
+| `GET /api/v1/changelog/{version}`          | Single release                                               | #107      |
+| `GET /api/v1/ai/instructions`              | List AI instruction sets                                     | —         |
+| `GET /api/v1/ai/instructions/{name}`       | Instruction set by target (mcp-server, claude, copilot)      | —         |
+| `GET /api/v1/skills`                       | List published agent skills (lightweight, no body_mdx)       | —         |
+| `GET /api/v1/skills/summary`               | Same shape as `/skills`; reserved for CLI update path        | —         |
+| `GET /api/v1/skills/{name}`                | Single skill with full `body_mdx`                            | —         |
+| `GET /api/v1/search?q=`                    | Cross-resource search (components + docs + changelog)        | —         |
+| `GET /api/v1/stats?days=`                  | Open-data usage metrics (CC BY 4.0) — backs `/observability` | #105      |
+| `GET /api/v1/health`                       | Service health check (`no-cache, no-store`)                  | —         |
 
-**Common response headers:** `Cache-Control: public, max-age=3600, s-maxage=86400`, `Access-Control-Allow-Origin: *` (except `/health` which is `no-cache, no-store`).
+Routes outside `/api/v1/` (intentionally not part of the public v1 contract): `GET /api/openapi` (serves `openapi.yaml`), `GET /api/chaos/{name}` (N5/Y-axis chaos-injection), `GET /api/health/{name}` (per-resource health probe).
 
-**Error responses:** 400 (invalid input), 404 (not found), 500 (server error), **503** (Supabase env vars missing — the API replies with a clear "Database not configured" message).
+**Error responses:** 400 (invalid input), 404 (not found), 410 (gone — `/docs*`), 500 (server error), **503** (Supabase env vars missing — clear "Database not configured" message).
 
 The OpenAPI document is also served at `GET /api/openapi`.
 
 ---
 
-## 10. MCP Server
+## 10. MCP Server (document-route)
 
-The registry includes a **Model Context Protocol (MCP) server** served at `/mcp` via Streamable HTTP transport. It exposes the registry, brand system, and design tokens to AI assistants.
+The portal runs the **Mzizi MCP server** at `/mcp` via Streamable HTTP transport — a **lean document-route MCP** that reads from `component_documents` and returns whole-document responses.
 
 ### Setup
 
-The MCP server is a Next.js API route at `app/mcp/route.ts`, powered by `lib/mcp-server.ts`.
+The MCP server is a Next.js API route at `app/mcp/route.ts`, powered by `lib/mcp-server.ts` (`createMziziMcpServer(supabase)`).
 
 Configured in `.claude/settings.json`:
 
 ```json
 {
   "mcpServers": {
-    "nyuchi-design": {
+    "mzizi": {
       "type": "url",
       "url": "https://mzizi.dev/mcp"
     }
@@ -712,80 +703,55 @@ Configured in `.claude/settings.json`:
 
 **Endpoint:** `POST /mcp` (JSON-RPC), `GET /mcp` (SSE), `DELETE /mcp` (cleanup), `OPTIONS /mcp` (CORS preflight)
 
+### Auth model — @supabase/server with `auth: 'none'`
+
+The route handler builds a per-request anon-scoped `SupabaseClient` via `createSupabaseContext` from `@supabase/server` with `auth: 'none'`. The resulting client is read-only under RLS — no service-role key in scope, no write APIs exposed. The factory in `lib/mcp-server.ts` just consumes that client.
+
+```typescript
+const { data: ctx, error } = await createSupabaseContext(request, {
+  auth: "none",
+  cors: false, // CORS handled by the route's own headers
+  env: { url: SUPABASE_URL, publishableKeys: { default: SUPABASE_PUBLISHABLE_KEY } },
+})
+const server = await createMziziMcpServer(ctx.supabase)
+```
+
 ### Resources (read-only data)
 
-| URI                      | Description                                                 |
-| ------------------------ | ----------------------------------------------------------- |
-| `mukoko://registry`      | Full component registry index                               |
-| `mukoko://brand`         | Complete brand system data                                  |
-| `mukoko://design-tokens` | Five African Minerals palette + semantic tokens             |
-| `mukoko://architecture`  | Ecosystem architecture (principles, framework, sovereignty) |
-| `mukoko://ubuntu`        | Ubuntu philosophy — community-first design doctrine         |
+| URI                  | Description                                                                    |
+| -------------------- | ------------------------------------------------------------------------------ |
+| `mzizi://components` | Mzizi component registry index — name / node / collection / owner per row      |
+| `mzizi://nodes`      | Per-node collection summary — counts + ownership breakdown across all 10 nodes |
 
 ### Tools (callable actions)
 
-| Tool                        | Description                                                                                       |
-| --------------------------- | ------------------------------------------------------------------------------------------------- |
-| `list_components`           | List all registry components, optionally filtered by type/layer                                   |
-| `get_component`             | Get a component's source code + metadata                                                          |
-| `get_component_docs`        | Get a component's structured documentation (use cases, variants, a11y notes)                      |
-| `get_component_links`       | Get all portal URLs for a component                                                               |
-| `get_component_versions`    | Get version history for a component                                                               |
-| `search_components`         | Search components by name / description / category                                                |
-| `get_design_tokens`         | Get color palette, typography, spacing tokens                                                     |
-| `scaffold_component`        | Generate a new component following the CVA + Radix + cn() pattern                                 |
-| `get_install_command`       | Get the shadcn CLI install command for one or more components                                     |
-| `get_brand_info`            | Get information about a specific ecosystem brand                                                  |
-| `get_architecture_info`     | Get architecture info by category (ecosystem, data-layer, pipeline, sovereignty)                  |
-| `get_ubuntu_doctrine`       | Read the static Ubuntu philosophy doctrine (philosophy, design, community, AI framing, languages) |
-| `get_ubuntu_pillars`        | Five Ubuntu Pillars — rows from `ubuntu_pillars`                                                  |
-| `get_ubuntu_principles`     | Five Ubuntu Principles — rows from `ubuntu_principles`                                            |
-| `get_architecture_frontend` | 3D frontend axes + layers — rows from `architecture_frontend_axes`/`_layers`                      |
-| `get_database_status`       | Health/diagnostic info about the Supabase connection                                              |
-| `get_usage_stats`           | MCP/API usage metrics                                                                             |
-| `get_layer_summary`         | Component count, categories, and names for a given architecture layer (1–10)                      |
-| `list_skills`               | List every published agent skill (summary; no body_mdx). Reads the Supabase `skills` table.       |
-| `get_skill`                 | Fetch a single skill (full body_mdx) by name. Reads via `get_skill(name)` SQL helper.             |
-| `get_ai_instructions`       | Read system prompts from `ai_instructions` by target                                              |
-| `get_changelog`             | Recent releases from the `changelog` table                                                        |
+| Tool                  | Description                                                                                                                                                                    |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `list_components`     | List components, optionally filtered by node (1–10) or owner (`bundu` / `nyuchi` / `mzizi` / `framework`). Returns the lean index — use `get_component` for the full document. |
+| `get_component`       | Fetch one component as its full JSON document — one read, everything (metadata, owner, sources/descriptors, legacy source code, files, docs)                                   |
+| `list_collections`    | List the per-node collections (`n1_tokens … n10_documentation`) with total counts and ownership breakdown                                                                      |
+| `get_database_status` | Supabase connection health + document-store row count                                                                                                                          |
 
-### Architecture
+### Legacy MCP — protected branch
 
-- **`lib/mcp-server.ts`** — Server factory (`createMukokoMcpServer()`) with all tools and resources
-- **`app/mcp/route.ts`** — HTTP endpoint using `WebStandardStreamableHTTPServerTransport` (stateless)
-- All data read from Supabase — zero hardcoded content
+The previous relational MCP (the wider tool surface that read from `components`, `component_docs`, `brand_*`, `architecture_*`, `ubuntu_*`) lives on the protected `legacy` branch and deploys to `design.nyuchi.com/mcp`. The two are split deliberately — the document-route MCP on `main` is the canonical Mzizi surface; the legacy MCP stays available for consumers that haven't migrated.
 
 ---
 
 ## 11. Component Categories
 
-The stable registry items live in the Supabase `components` table and are organised across 10 architecture layers and by function. Counts/items below are a snapshot — **query `GET /api/v1/stats` or the `get_layer_summary` MCP tool for live numbers, and never hardcode a component count anywhere in the repo** (user-facing docs render the live value via `<LiveComponentCount />` from `components/live-component-count.tsx`). Only the ~35 portal primitives are committed to `components/ui/`; the rest are served only via `/api/v1/ui` and installed by consumer apps via the shadcn CLI.
+The stable registry items live in the Supabase `components` table and are organised across 10 architecture nodes and by function.
 
-| Category                  | Count | Components                                                                                                                                                                                                                                                                                                                                                                 |
-| ------------------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Forms & Input**         | 28    | calendar, checkbox, combobox, command, date-picker, date-range-picker, field, file-upload, form, input, input-group, input-otp, label, native-select, radio-group, search-bar, select, slider, switch, textarea, phone-input, tag-input, time-picker, rich-text-editor, code-editor, color-picker, address-input, transfer-list, number-input, autocomplete, mention-input |
-| **Chat & Messaging**      | 8     | chat-bubble, chat-list, chat-input, chat-layout, typing-indicator, message-thread, reaction-picker                                                                                                                                                                                                                                                                         |
-| **AI & Chatbot**          | 8     | ai-chat, prompt-input, streaming-text, ai-feedback, ai-response-card, source-citation, suggested-prompts                                                                                                                                                                                                                                                                   |
-| **Data Display**          | 14    | avatar, badge, chart, data-table, kbd, pricing-card, stats-card, status-indicator, table, timeline, typography, tree-view, kanban-board, virtual-list, property-list, json-viewer, schema-viewer, description-list                                                                                                                                                         |
-| **User & Profile**        | 8     | avatar-group, user-card, profile-header, activity-feed, notification-list                                                                                                                                                                                                                                                                                                  |
-| **E-commerce**            | 7     | product-card, price-display, cart-item, order-summary, payment-method-card, subscription-card, invoice-row                                                                                                                                                                                                                                                                 |
-| **Calendar & Scheduling** | 7     | calendar-week-view, calendar-day-view, event-card, time-slot-picker, agenda-view                                                                                                                                                                                                                                                                                           |
-| **Productivity**          | 6     | todo-item, checklist, note-card, comment-thread, drag-handle                                                                                                                                                                                                                                                                                                               |
-| **Developer Tools**       | 7     | api-key-display, webhook-card, env-editor, code-tabs, code-block, endpoint-card, log-viewer                                                                                                                                                                                                                                                                                |
-| **Security & Auth**       | 5     | permission-badge, role-selector, mfa-setup, session-list, audit-log-entry                                                                                                                                                                                                                                                                                                  |
-| **Content & Media**       | 6     | markdown-renderer, lightbox, video-player, audio-player, file-preview                                                                                                                                                                                                                                                                                                      |
-| **Action**                | 6     | button, button-group, copy-button, rating, toggle, toggle-group                                                                                                                                                                                                                                                                                                            |
-| **Feedback**              | 10    | alert, empty, progress, skeleton, sonner, spinner, toast, toaster, announcement-bar, cookie-consent, password-strength, onboarding-tour, changelog-entry, maintenance-page                                                                                                                                                                                                 |
-| **Navigation**            | 8     | breadcrumb, menubar, navigation-menu, pagination, tabs, stepper, app-switcher, bottom-sheet, mega-menu                                                                                                                                                                                                                                                                     |
-| **Layout**                | 10    | accordion, aspect-ratio, card, carousel, collapsible, drawer, resizable, scroll-area, separator, sheet, sidebar, page-header, section-header, settings-layout, split-view, masonry-grid, sticky-bar, infinite-scroll, pull-to-refresh                                                                                                                                      |
-| **Overlay**               | 11    | alert-dialog, context-menu, dialog, dropdown-menu, filter-bar, hover-card, notification-bell, popover, share-dialog, tooltip, user-menu                                                                                                                                                                                                                                    |
-| **Directory & Listings**  | 6     | listing-card, category-browser, review-card, contact-card, featured-card, map-placeholder                                                                                                                                                                                                                                                                                  |
-| **Nyuchi Ecosystem**      | 4     | nyuchi-bottom-nav, nyuchi-footer, nyuchi-header, nyuchi-sidebar                                                                                                                                                                                                                                                                                                            |
-| **Infrastructure**        | 3     | error-boundary, lazy-section, section-error-boundary                                                                                                                                                                                                                                                                                                                       |
-| **Hooks**                 | 3     | use-memory-pressure, use-mobile, use-toast                                                                                                                                                                                                                                                                                                                                 |
-| **Resilience (lib)**      | 9     | ai-safety, chaos, circuit-breaker, fallback-chain, observability, retry, timeout, utils, architecture (served only via the registry — no longer files in this repo)                                                                                                                                                                                                        |
-| **Chart Blocks**          | 70    | area (10), bar (10), line (10), pie (11), radar (14), radial (6), tooltip (9)                                                                                                                                                                                                                                                                                              |
-| **Page Blocks**           | 35    | dashboard-01, login-01–05, signup-01–05, sidebar-01–16, profile-page, profile-settings, onboarding-flow, error-page, empty-state, notification-center, search-results, command-center                                                                                                                                                                                      |
+**Do not hardcode component counts anywhere in the repo.** Counts change with every registry sync; baking a number into MDX, into doctrine, or into a card guarantees doctrine drift.
+
+The live source of truth is one of:
+
+- `GET /api/v1/stats` (HTTP)
+- `get_system_counts()` (SQL helper in Supabase)
+- `<LiveComponentCount />` (renderer in `components/live-component-count.tsx`, used in MDX + page bodies)
+- MCP `list_collections` (per-node breakdown)
+
+If you genuinely need a category-level list for navigation or doc grouping, derive it at request time (server component or ISR) — never as a hand-edited table.
 
 ---
 
@@ -818,20 +784,18 @@ The stable registry items live in the Supabase `components` table and are organi
 
 ```
 __tests__/
+├── playground-routes.test.ts                    # /playground + /playground/[name] route surface
 └── api/
-    ├── brand-route.test.ts                  # /api/v1/brand response, headers, data
-    ├── registry-route.test.ts               # /api/v1/ui registry integrity
+    ├── brand-route.test.ts                      # /api/v1/brand response, headers, data
+    ├── registry-route.test.ts                   # /api/v1/ui registry integrity
     └── v1/
-        └── architecture-routes.test.ts      # v1 route file existence; legacy routes removed
+        └── architecture-routes.test.ts          # v1 route file existence; legacy routes removed
 ```
 
 ### What Tests Cover
 
 - **API routes:** Brand API returns the correct headers/status/payload shape; the registry response matches the shadcn schema; all expected v1 route files exist on disk; removed legacy routes are confirmed gone.
-
-### Tests removed in the Supabase migration
-
-The earlier file-based brand / architecture / component-rendering tests (against `lib/brand.ts`, `lib/architecture.ts`, `components/brand/*`) have been deleted along with the modules they covered. New tests should target the Supabase-backed data flow, the API-route contracts, and the playground / docs renderers that read from the API.
+- **Portal pages:** `/playground` + `/playground/[name]` exist and render through the playground demo registry.
 
 ### Running Tests
 
@@ -848,18 +812,16 @@ pnpm test:watch       # Watch mode for development
 
 **One PR = many commits. Not one-to-one.**
 
-A PR is a logical unit of work — "add mobile responsiveness", "drop Nextra and wire the dashboard shell", "publish the CLI and skills". Commits inside the PR are the incremental steps that get there. The PR is what reviewers review, what CI gates, what merges to main. The commits are the paper trail of how we got there.
+A PR is a logical unit of work. Commits inside the PR are the incremental steps that get there. The PR is what reviewers review, what CI gates, what merges to main. The commits are the paper trail.
 
 **Hard rules:**
 
-- Never split a logical unit of work across multiple PRs just to keep each PR small. A cohesive change ships as one PR with as many commits as it takes to reach a merge-ready state.
-- Never collapse a PR's history into a single commit. Multiple commits show the incremental steps, make `git bisect` useful, and make review tractable when the reader wants to follow the reasoning.
-- Commit messages are part of the documentation. Each commit's subject + body explains the step it represents and why; reviewers can read the commit graph as a timeline of the PR's reasoning.
-- Target the ratio at roughly **~10 commits per PR**, ~100 PRs to ~1000 commits in a year. That means PRs are substantial, not trivial; commits are incremental, not speculative.
-- A PR does not ship until it is **100% right end-to-end** — no half-measures, no "we'll clean that up in the follow-up". If the app doesn't hold together, the PR doesn't merge. Add more commits to the same PR until it does.
-- Exceptions to bundle-per-PR: security fixes, CI unblocks, and genuinely orthogonal infrastructure changes (see `claude/publish-cli-and-skills` as a parallel-track example) get their own PRs because their merge order is independent.
-
-**Why not one PR per commit?** Because PR overhead (branch protection, CI token spend, human review attention, merge-order sequencing) scales per-PR, not per-commit. A thousand tiny PRs burn a thousand tokens of review attention and produce a thousand merge conflicts. A hundred substantive PRs with ten commits each produce the same code volume with a tenth of the ceremony.
+- Never split a logical unit of work across multiple PRs just to keep each PR small.
+- Never collapse a PR's history into a single commit (no squash-merge).
+- Commit messages are part of the documentation.
+- Target the ratio at roughly **~10 commits per PR**.
+- A PR does not ship until it is **100% right end-to-end**.
+- Exceptions to bundle-per-PR: security fixes, CI unblocks, and genuinely orthogonal infrastructure changes get their own PRs because their merge order is independent.
 
 ### GitHub Actions
 
@@ -867,7 +829,7 @@ Three workflows in `.github/workflows/`:
 
 **`ci.yml`** — Runs on every push to `main` and all PRs:
 
-1. **Lint** — `pnpm lint` (ESLint with typescript-eslint, flat config in `eslint.config.mjs`)
+1. **Lint** — `pnpm lint`
 2. **Type Check** — `pnpm typecheck`
 3. **Test** — `pnpm test`
 4. **Build** — `pnpm build` (runs after lint, typecheck, test pass)
@@ -875,10 +837,9 @@ Three workflows in `.github/workflows/`:
 **`claude-review.yml`** — AI code review on every PR and `@claude` mentions:
 
 - Triggers on PR open/sync, issue comments, review comments, and reviews
-- Uses `anthropics/claude-code-action@v1` preceded by an explicit `actions/checkout@v6` step with `fetch-depth: 0` (the action itself does not check out the repo — it expects a populated `.git` directory so it can `git fetch origin main` to build the review diff)
-- Reviews for: code quality, design system adherence, accessibility (APCA 3.0 AAA, 56px default / 48px minimum touch targets), security, registry compatibility
-- Permissions: `contents: write`, `pull-requests: write`, `issues: write`, `id-token: write`, `actions: read`
-- Secret required: `CLAUDE_CODE_OAUTH_TOKEN` (generated via `claude setup-token`). Routes review runs through the Claude Code subscription quota instead of API-key billing — bypasses the org-level TPM cap on the API path. Trade-off: shares the personal 5-hour rolling subscription bucket with interactive Claude Code use, so heavy CI days compete with IDE work.
+- Uses `anthropics/claude-code-action@v1` preceded by `actions/checkout@v6` with `fetch-depth: 0`
+- Reviews for: code quality, design system adherence, accessibility, security, registry compatibility
+- Secret required: `CLAUDE_CODE_OAUTH_TOKEN`
 
 **`release.yml`** — Runs on version tags (`v*`):
 
@@ -886,77 +847,33 @@ Three workflows in `.github/workflows/`:
 2. Verifies tag version matches `package.json` version
 3. Creates a GitHub release with auto-generated release notes
 
-### Org-wide required checks — naming conventions per workflow
-
-Every bundu ecosystem repo's branch-protection rule on `main` requires the following check names, exactly. **The convention is asymmetric across workflows** — the CI workflow uses bare job names, the lint workflow uses prefixed names. Not stylistic — both must match the org rule literally.
-
-| Reported check name    | Source workflow / job                          | Required by branch protection |
-| ---------------------- | ---------------------------------------------- | ----------------------------- |
-| `Build`                | `.github/workflows/ci.yml` → `build`           | Yes                           |
-| `Lint`                 | `.github/workflows/ci.yml` → `lint`            | Yes                           |
-| `Type Check`           | `.github/workflows/ci.yml` → `typecheck`       | Yes                           |
-| `Security Audit`       | `.github/workflows/ci.yml` → `audit`           | Yes                           |
-| `Test`                 | `.github/workflows/ci.yml` → `test`            | No (informational)            |
-| `Registry Snapshot`    | `.github/workflows/ci.yml` → `registry`        | No (informational)            |
-| `lint / actionlint`    | `.github/workflows/lint.yml` → `actionlint`    | Yes                           |
-| `lint / JSON validity` | `.github/workflows/lint.yml` → `json-validity` | Yes                           |
-| `lint / prettier`      | `.github/workflows/lint.yml` → `prettier`      | Yes                           |
-| `lint / markdownlint`  | `.github/workflows/lint.yml` → `markdownlint`  | Yes                           |
-| `lint / yamllint`      | `.github/workflows/lint.yml` → `yamllint`      | Yes                           |
-
-**Critical implementation detail.** GitHub Actions reports the bare job `name:` field to the Checks API — the `<workflow> /` prefix that the PR UI shows is a visual grouping label, NOT part of the reported check name. So the job's `name:` field must literally match the required check name:
-
-```yaml
-# ci.yml — CI required checks are bare names
-jobs:
-  build:
-    name: Build           # not "CI / Build"
-  lint:
-    name: Lint            # not "CI / Lint"
-
-# lint.yml — lint required checks include the "lint / " prefix
-jobs:
-  actionlint:
-    name: lint / actionlint   # not just "actionlint"
-```
-
-The two conventions are inconsistent at the org level (history, not design), but both need to match what branch protection has configured. If you rename a job, update the org-level branch-protection rule in the same change. Both `ci.yml` and `lint.yml` in this repo are the canonical templates; copy the `name:` pattern when bootstrapping a new ecosystem repo.
-
 ### Versioning
 
-- **Current version:** 4.0.39 (must match in `package.json`, `lib/mcp-server.ts`, the `changelog` table in Supabase, `components/landing/footer.tsx`, `components/landing/dashboard-sidebar.tsx`, `app/layout.tsx` (`softwareVersion`), `README.md`, and CLAUDE.md §1)
+- **Current version:** 4.0.40 (must match in `package.json`, `lib/mcp-server.ts` (`VERSION` const), the `changelog` table in Supabase, `components/landing/footer.tsx`, `components/landing/dashboard-sidebar.tsx`, `app/layout.tsx` (`softwareVersion`), `README.md`, and CLAUDE.md §1)
 - **Scheme:** `4.0.x` is the internal pre-1.0-public iteration; `4.1.0` is reserved for the first community-contributed release
 - **Release process:**
   1. Update version in `package.json`
-  2. Update the version constant in `lib/mcp-server.ts`
-  3. Update the footer version in `components/landing/footer.tsx`
-  4. Insert a row into the `changelog` Supabase table for the new version
-  5. Commit: `git commit -m "Release v4.0.x"`
-  6. Tag: `git tag v4.0.x`
-  7. Push: `git push && git push --tags`
-  8. GitHub Actions (`release.yml`) verifies the tag matches `package.json` and creates the GitHub release
+  2. Update the `VERSION` constant in `lib/mcp-server.ts`
+  3. Update the footer version in `components/landing/footer.tsx` and the sidebar version in `components/landing/dashboard-sidebar.tsx`
+  4. Update `softwareVersion` in `app/layout.tsx`
+  5. Update the version line in `README.md` and CLAUDE.md §1
+  6. Insert a row into the `changelog` Supabase table for the new version (via `apply_migration`)
+  7. Commit, push, open PR; merge with `merge_method=merge` (never squash)
+  8. Tag and push the tag; GitHub Actions verifies and creates the release
 
 ### Dependency Management — Upgrade-First Policy
 
-**This registry is the testing ground for major version upgrades.** All dependency upgrades happen here FIRST, before touching any production app. The workflow:
+**This registry is the testing ground for major version upgrades.** All dependency upgrades happen here FIRST, before touching any production app.
 
-1. **Upgrade here first** — always update to the latest version, including major versions
-2. **Run all CI gates** — lint, typecheck, test, build must all pass
-3. **If breaking changes exist** — fix them here in the registry components
-4. **If unfixable** — roll back here before it ever touches production
-5. **Once passing** — production apps (weather, news, events, super app) can safely upgrade
-
-**Why:** This registry defines the component API surface for the entire ecosystem. If a major version upgrade (e.g., Recharts 2→3, Zod 3→4) changes how components work, that change propagates to every app that installs from the registry. Better to catch and fix it here than discover it in production.
-
-**Rule:** Never leave packages outdated "because it's a major version." Upgrade, test, fix. If it breaks and can't be fixed, document why and pin the version with a comment explaining the blocker.
-
-**Current known pins:**
-
-- `@vitejs/plugin-react@5` — v6 requires vite@8; vitest@4 peer-requires vite@7. `vite` is pinned as a direct devDependency at `^7.3.2` to ensure the patched version is used. Upgrade `@vitejs/plugin-react` to v6 together with vitest@5 when vitest@5 ships.
+1. Upgrade here first — always update to the latest version, including major versions
+2. Run all CI gates — lint, typecheck, test, build must all pass
+3. If breaking changes exist — fix them here in the registry components
+4. If unfixable — roll back here before it ever touches production
+5. Once passing — production apps can safely upgrade
 
 ### Pre-commit Gates
 
-Every commit must pass all gates before pushing. `.husky/pre-commit` enforces this automatically and runs three steps:
+`.husky/pre-commit` runs three steps:
 
 | Gate                       | Command                                                              | Failure means                                               |
 | -------------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------- |
@@ -964,29 +881,11 @@ Every commit must pass all gates before pushing. `.husky/pre-commit` enforces th
 | **Type check (project)**   | `pnpm typecheck`                                                     | TypeScript error                                            |
 | **Security audit**         | `pnpm audit --audit-level=moderate --ignore-registry-errors`         | Unresolved vulnerability — update deps or add pnpm override |
 
-CI additionally runs `pnpm test` and `pnpm build` (and `pnpm registry:verify` to guard against `registry.json` drifting from Supabase).
-
-`--ignore-registry-errors` is required because the npm "quick" audit endpoint that pnpm 10.x calls was retired in April 2026; remove the flag once pnpm ships a fix.
-
-**Hard rules:**
-
-- Zero ESLint warnings allowed — `--max-warnings=0` is enforced
-- All packages must be at latest, or pinned with a documented reason in this file
-- `pnpm audit --audit-level=moderate` must return clean — use `pnpm.overrides` in `package.json` for transitive vulnerabilities that can't be fixed by upgrading direct deps
-- Prettier formats everything — `.prettierrc` is the canonical style config
-- The CI `audit` job runs the same check — PRs with vulnerabilities will not be merged
-
-**Adding a pnpm override for a transitive vulnerability:**
-
-```json
-// In package.json → "pnpm" → "overrides":
-"vulnerable-package": "^safe-version",
-"parent-package>vulnerable-package": "^safe-version"  // scoped override for version conflicts
-```
+CI additionally runs `pnpm test`, `pnpm build`, and `pnpm registry:verify`.
 
 ### Deployment
 
-- **Platform:** Vercel (Vercel project `mukoko-registry`, domains `mzizi.dev`, `registry.mukoko.com`); automatic deploys from `main`
+- **Platform:** Vercel (`mzizi.dev`); automatic deploys from `main`
 - **CI gates:** Security audit, lint (zero warnings), typecheck, tests, build, and `registry:verify` must all pass before merge
 - **Search index:** the `postbuild` step runs Pagefind against `.next/server/app` and writes the static index into `public/_pagefind/`
 
@@ -996,53 +895,59 @@ CI additionally runs `pnpm test` and `pnpm build` (and `pnpm registry:verify` to
 
 When working on this codebase as an AI assistant:
 
-1. **Supabase is the source of truth.** Component source code, docs, brand data, architecture data, AI instructions, changelog — all live in Supabase. Do not reintroduce hardcoded JSON/TS files for any of these.
-2. **`registry.json` is generated, not authored.** It must exist in the repo root, but it is regenerated dynamically from the Supabase `components` table by `pnpm registry:sync`. Never hand-edit it. CI runs `pnpm registry:verify` to catch drift.
+1. **Supabase is the source of truth.** Component source code, docs, brand data, architecture data, AI instructions, changelog, document-route docs — all live in Supabase. Do not reintroduce hardcoded JSON/TS files for any of these.
+2. **`registry.json` is generated, not authored.** Never hand-edit it. CI runs `pnpm registry:verify` to catch drift.
 3. **Never break the shadcn registry schema** — downstream apps depend on it.
 4. **Use the Five African Minerals palette** — never introduce colors outside the token system.
 5. **Follow the CVA + Radix + cn() pattern** — every component uses this stack.
 6. **Keep components self-contained** — each file is independently installable via the registry.
 7. **Preserve accessibility** — APCA 3.0 AAA contrast, 56px default / 48px minimum touch targets, Radix primitives for keyboard/screen reader behaviour.
 8. **Test API output** — after modifying a component, verify it serves correctly via `/api/v1/ui/[name]`.
-9. **Respect the layered architecture** — primitives don't import page-level code. The 3D frontend model has five axes: X-axis (L2 primitives / L3 brand / L6 pages / L7 shell — horizontal composition), Y-axis (L1 tokens / L4 safety / L5 resilience — vertical infrastructure), Z-axis (L8 assurance — depth observation), Outside (L9 fundi — self-healing actors), Documentation (L10). This is distinct from the 7-layer data architecture served at `/architecture` — never conflate the two numberings. See issue #46 for the table-backed doctrine (`architecture_frontend_layers`, `architecture_frontend_axes`).
-10. **All brand wordmarks lowercase** — `mukoko`, `nyuchi`, `shamwari`, `bundu`, `nhimbe`.
+9. **Respect the layered architecture** — primitives don't import page-level code. The 3D frontend model has five axes (X horizontal, Y vertical, Z depth, Outside, Documentation). This is distinct from the 7-layer data architecture served at `/architecture` — never conflate the two numberings.
+10. **All brand wordmarks lowercase** — `mzizi`, `mukoko`, `nyuchi`, `shamwari`, `bundu`, `nhimbe`.
 11. **This is the canonical design system** — changes here propagate to all bundu ecosystem apps.
-12. **Run tests before committing** — `pnpm test` must pass; add tests for new behaviour, especially around API routes and DB-driven renderers.
-13. **Keep versions in sync** — `package.json`, `lib/mcp-server.ts`, the `changelog` Supabase row, and `components/landing/footer.tsx` must all match.
-14. **The mineral strip uses 5 mineral colors** — not flag colors; it's the brand identity element.
-15. **The mineral strip is always vertical** — used only as a left-edge accent (cards, sidebars, page borders); never horizontal.
-16. **Use the MCP server** — served at `/mcp` via `lib/mcp-server.ts`; all reads go through `lib/db/`.
-17. **Resilience patterns (circuit-breaker, retry, timeout, fallback-chain, ai-safety, chaos)** are registry items in Supabase, not files in this repo. Consumer apps install them via the shadcn CLI.
-18. **Long-form documentation lives in the repo as `.mdx` files** — _not_ in Supabase. The portal is a documentation site, not a blog. Guides (`/docs/*`) and architecture/foundations/brand pages (`/architecture`, `/foundations`, `/brand`, …) are authored as `.mdx` in `app/` and compiled via `@next/mdx`. The `documentation_pages` Supabase table is HISTORICAL — content was migrated to repo MDX, the DB-driven renderers (`components/docs/db-doc-page.tsx`, `db-doc-index.tsx`) and `app/docs/[slug]` dynamic route are deleted, `/api/v1/docs/*` returns HTTP 410, and the `get_documentation_page` MCP tool is gone. Do not add new rows to `documentation_pages`; author new docs as MDX. The `changelog` Supabase table is unaffected — it remains the source-of-truth for the release-bump workflow (§14) and is read by `components/docs/db-changelog.tsx`.
-19. **The playground (`components/playground/`) reads from the API**, not from local files. If you find a `registry.json` import there, refactor it to fetch `/api/v1/ui` (tracked in issue #26).
-20. **API is versioned under `/api/v1/`** — `openapi.yaml` is the contract; update it whenever a route changes.
-21. **Buttons are always pill-shaped (`rounded-full`)** across the entire ecosystem.
-22. **Security findings are never deferred.** Any vulnerability surfaced during a `/security-review`, a manual audit, a CodeQL alert, a Dependabot advisory, or `pnpm audit` must be fixed inside the current PR — even if the original PR scope is "docs only" or "feature X". Do not file a follow-up issue and merge the unfixed code. The only acceptable exception is when the fix concretely requires infrastructure that isn't available on the PR's branch (e.g. a Supabase migration the developer must run); in that case, document the gap in `SECURITY.md`, open a tracking issue, AND still ship every code-level mitigation that doesn't require the missing infrastructure. This rule applies even when the finding is downgraded to "lack of hardening" during false-positive filtering — if a reviewer flagged it, the patch goes in this PR.
+12. **Run tests before committing** — `pnpm test` must pass; add tests for new behaviour, especially around API routes.
+13. **Keep versions in sync** — `package.json`, `lib/mcp-server.ts` (`VERSION`), the `changelog` Supabase row, `components/landing/footer.tsx`, `components/landing/dashboard-sidebar.tsx`, `app/layout.tsx` (`softwareVersion`), `README.md`, and CLAUDE.md §1.
+14. **The mineral strip uses 5 mineral colors** and is always vertical (left-edge accent only).
+15. **Use the MCP server** — served at `/mcp` via `lib/mcp-server.ts` (`createMziziMcpServer`); reads `component_documents` only. The legacy relational MCP lives on the `legacy` branch.
+16. **Resilience patterns** (circuit-breaker, retry, timeout, fallback-chain, ai-safety, chaos) are vendored in `lib/` and also published as `registry:lib` items in Supabase. Consumer apps install them via the shadcn CLI.
+17. **Long-form documentation lives outside this repo** — product docs in `nyuchi/bundu-docs` (Astro Starlight → `docs.bundu.org`), engineering docs in `nyuchi/nyuchi-docs` (Astro Starlight → `docs.nyuchi.com`). The portal is a registry + brand + architecture surface, not a docs site. The `documentation_pages` Supabase table is HISTORICAL — content was migrated to the Starlight repos; `/api/v1/docs/*` returns HTTP 410 with a `migrated_to` map; the `get_documentation_page` MCP tool is gone. The `changelog` Supabase table is unaffected — it remains the source of truth for the release-bump workflow.
+18. **The playground (`components/playground/`) reads from the API**, not from local files.
+19. **API is versioned under `/api/v1/`** — `openapi.yaml` is the contract; update it whenever a route or schema changes.
+20. **Buttons are always pill-shaped (`rounded-full`)** across the entire ecosystem.
+21. **Security findings are never deferred.** Any vulnerability surfaced during a `/security-review`, a manual audit, a CodeQL alert, a Dependabot advisory, or `pnpm audit` must be fixed inside the current PR — even if the original PR scope is "docs only". The only acceptable exception is when the fix concretely requires infrastructure that isn't available on the PR's branch; in that case, document the gap in `SECURITY.md`, open a tracking issue, AND still ship every code-level mitigation that doesn't require the missing infrastructure.
 
-23. **No known bugs are ever deferred to a follow-up PR.** This is the canonical design system for the bundu ecosystem — every consumer app (mukoko's 17 mini-apps, nyuchi's 7 enterprise products, sister brands) inherits whatever ships from `main`. Deferring a known bug to "next PR" exposes every downstream consumer to risk we already know about. That is unacceptable on critical infrastructure.
+22. **No known bugs are ever deferred to a follow-up PR.** This is the canonical design system for the bundu ecosystem — every consumer app inherits whatever ships from `main`.
 
-    **A known bug means:** any verified-broken behaviour, any documented contract the code does not honour (e.g. a URL pattern documented in MDX that returns 404, a type/interface name promised in doctrine that doesn't exist), any dependency-version drift that breaks links/state in production, any runtime error path that has been reproduced. If it has been seen and confirmed, it is not deferred.
+    **A known bug means:** any verified-broken behaviour, any documented contract the code does not honour (e.g. a URL pattern documented in MDX that returns 404, a type/interface name promised in doctrine that doesn't exist), any dependency-version drift that breaks links/state in production, any runtime error path that has been reproduced.
 
-    **In contrast, the following are NOT bugs and can ship as separate PRs:**
-    - Unbuilt features documented as `(planned)` (a doc that explicitly says "not yet wired" is honest, not a bug)
-    - Quality work without a runtime symptom (missing tests on portal-internal components covered by manual sweep, undeclared `revalidate` defaults that Next.js handles silently, redundant directives that don't break anything)
-    - Enhancements to surfaces that already function (e.g. consuming a new live-data source on a page that already renders)
-    - Parallel-track work explicitly carved out by another doctrine section (e.g. §8.6 CLI publishing)
+    **NOT bugs (can ship as separate PRs):** unbuilt features documented as `(planned)`; quality work without a runtime symptom; enhancements to surfaces that already function; parallel-track work explicitly carved out by another doctrine section.
 
-    **The audit gate before merge.** Every PR runs through (1) `/security-review`, (2) a gap analysis against this CLAUDE.md, and (3) a sweep of open GitHub issues. Anything matching the bug definition above lands in the same PR — re-scope rather than defer. Anything that is genuinely feature/enhancement gets a tracking issue and a one-line note in the PR body explaining why it is not a bug.
+    **The audit gate before merge.** Every PR runs through (1) `/security-review`, (2) a gap analysis against this CLAUDE.md, and (3) a sweep of open GitHub issues. Anything matching the bug definition above lands in the same PR — re-scope rather than defer.
 
-    **No exceptions for "PR scope".** A PR titled "drop Nextra" still fixes a 22-link `nyuchitech → nyuchi` rename if that surfaces during the audit, because the linked URLs 404 in production. The doctrine of one-PR-many-commits (§14) exists precisely so we can re-scope without splitting work across PRs that ship serially over weeks.
+23. **Skills are MDX bodies authored once in Supabase.** The `skills` table is the SINGLE source of truth; content flows to `/api/v1/skills*` (HTTP), MCP (when bridged), and the published `mzizi-skills` bundle in `nyuchi/mzizi-tools`. Never duplicate skill content — edit the Supabase row, never the published bundle.
 
-24. **Skills are MDX bodies authored once, served four ways.** The Supabase `skills` table is the SINGLE source of truth. From there, content flows to:
-    1. **`/api/v1/skills/{name}`** — the HTTP endpoint that any consumer can `curl` or fetch.
-    2. **MCP `get_skill(name)`** — the same content via the Model Context Protocol; AI assistants connected to `/mcp` can load skills without HTTP plumbing.
-    3. **`@nyuchi/design-agent-skills`** — a published npm-package snapshot of the table; offline-friendly, regenerated by `pnpm skills:sync` before each publish (CI verifies via `pnpm skills:verify`).
-    4. **`@nyuchi/design-cli skills install`** — the CLI subcommand that fetches live from the API and writes `.claude/skills/*.md` into a consumer project; tracks versions in `.nyuchi-design.json` for `update`.
-
-    All four paths converge on the same `skills.body_mdx` column. **Never duplicate skill content.** If you find yourself editing a `.md` file directly under `packages/design-agent-skills/skills/` or `.claude/skills/` (in any consumer repo), stop — the change won't survive the next sync. Edit the Supabase row, then run `pnpm skills:sync` to refresh the published snapshot.
-
-    The `packages/design-agent-skills/skills/` directory is added to `.prettierignore` so prettier never reformats the canonical content (escaped underscores, JSX reflows) and silently breaks the bit-identity contract `pnpm skills:verify` enforces.
+24. **Mzizi vs Mukoko vs Nyuchi vs Bundu — keep the split clean.**
+    - **Bundu Foundation** owns Mzizi (governance); Mzizi serves the open 3D architecture, the component registry, and the brand system.
+    - **Mukoko** is the consumer family (super app + mini-apps); apps consume Mzizi but live in their own repos.
+    - **Nyuchi** is the enterprise operator; the Nyuchi Console (`nyuchi/mukoko-platform`, future `nyuchi-console`) surfaces Mzizi via the `mzizi-console-app` package.
+    - **Mzizi tooling** (Fundi agent, MCP transport, SDK, skills bundle, console mini-app) lives in `nyuchi/mzizi-tools` — not in this repo. The portal owns the **canonical** `/mcp` HTTP endpoint and the `/api/v1/*` surface; everything else is downstream.
 
 ### Open work to be aware of
 
-The repo is mid-migration to a Supabase-first model. Several issues track outstanding cleanup — see #25 (remove redundant files), #26 (Portal UI off `registry.json`), #27 (REST API expansion), #28 (MCP server fixes), #29 (DB-driven docs), #30 (this CLAUDE.md update), and #31 (dependabot deployment errors). When in doubt about whether something is canonical, prefer the Supabase row over any file in the repo.
+Active issues to keep on the radar (live from the `nyuchi/design-portal` issue tracker):
+
+- **#99** — Sovereignty rule: explicit per-technology assessment in doctrine
+- **#98** — Tri-mode architecture: Musha / Basa / Nhaka as a doctrine rule
+- **#97** — Open data framework: four-category model as doctrine spine + Nhaka
+- **#86** — Hyperdrive for Supabase (perf optimisation, not a prerequisite)
+- **#83** — Registry-driven API endpoints + CLI auto-update from `mcp_tool_registry`
+- **#82** — mukoko-edge: `/v1/design/*` and `/v1/mcp/design` routes + wire Supabase design project
+- **#81** — `@nyuchi/mzizi-cli` first-party CLI (login/logout/whoami/add/search/list)
+- **#80** — `components.requires_auth` opt-in flag with first-party bypass + 401 reason contract
+- **#79** — First-party tenant middleware + `whoami` MCP tool — auth moves to WorkOS
+- **#78** — `first_party_clients` allow-list table + `is_first_party_caller()` helper
+- **#58** — Repo sync: v4.0.33–v4.0.44 — nodes, plug design into mukoko-edge gateway
+- **#45** — Build: Ubuntu Five Pillars & Five Principles structural doctrine (parts landed via #108)
+
+When in doubt about whether something is canonical, prefer the Supabase row over any file in the repo.

--- a/README.md
+++ b/README.md
@@ -1,52 +1,31 @@
 # Mzizi
 
-> An open-architecture project of the Bundu Foundation — an open 3D frontend architecture, component registry, brand documentation, AI-native tooling, and developer portal. Operated and developed by Nyuchi.
+> An open-architecture project of the Bundu Foundation — the canonical component registry, brand system, 3D frontend architecture, and AI-native developer portal for the bundu ecosystem. Operated and developed by Nyuchi.
 
 [![CI](https://github.com/nyuchi/design-portal/actions/workflows/ci.yml/badge.svg)](https://github.com/nyuchi/design-portal/actions/workflows/ci.yml)
 [![Release](https://github.com/nyuchi/design-portal/actions/workflows/release.yml/badge.svg)](https://github.com/nyuchi/design-portal/actions/workflows/release.yml)
 [![CodeQL](https://github.com/nyuchi/design-portal/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/nyuchi/design-portal/security/code-scanning)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
-**Version:** 4.0.39 | **Live:** [mzizi.dev](https://mzizi.dev) | **Docs:** [docs.bundu.org/mzizi](https://docs.bundu.org/mzizi) | **Observability:** [mzizi.dev/observability](https://mzizi.dev/observability)
+**Version:** 4.0.40 | **Live:** [mzizi.dev](https://mzizi.dev) | **Product docs:** [docs.bundu.org](https://docs.bundu.org) | **Engineering docs:** [docs.nyuchi.com](https://docs.nyuchi.com) | **Observability:** [mzizi.dev/observability](https://mzizi.dev/observability)
+
+> The previous Mintlify docs site is retired — long-form docs now live at [docs.bundu.org](https://docs.bundu.org) (product) and [docs.nyuchi.com](https://docs.nyuchi.com) (engineering).
 
 ---
 
-## What is this?
+## What is Mzizi?
 
-Mzizi is an **independent open-architecture project of the Bundu Foundation** — operated and developed by Nyuchi, governed by the Bundu Foundation. It owns the open 3D frontend architecture, the component registry (`mzizi.dev/r/`), the Mzizi API (`mzizi.dev/api`), the components, and the infrastructure harness. Consumed across the bundu ecosystem — mukoko (Africa's super app — 17 mini-apps), nyuchi (7 enterprise products), and every app in the bundu family.
-
-The registry is backed by a **DB-first architecture** (Supabase) and served as a shadcn-compatible API — every component is installable directly into any project with one command. It is also **AI-native**: a full Model Context Protocol (MCP) server at `/mcp` gives Claude Code and other AI assistants direct access to the registry, brand tokens, and design system documentation. Long-form guides live in the standalone Mintlify docs site at [docs.bundu.org/mzizi](https://docs.bundu.org/mzizi).
+**Mzizi** (Swahili for _root_) is an independent open-architecture project of the **Bundu Foundation**, operated and developed by **Nyuchi**. It owns the open 3D frontend architecture, the component registry served at `mzizi.dev/r/`, the Mzizi API at `mzizi.dev/api`, the Five African Minerals design system, and the document-route Model Context Protocol (MCP) server at `mzizi.dev/mcp`. It is **not** a Nyuchi product — it is a Bundu-governed standard the whole bundu ecosystem (Mukoko consumer mini-apps, Nyuchi enterprise products, sister brands) installs from. Backed by a DB-first architecture (Supabase) and served as a shadcn-compatible API, every component is installable into any project with one command.
 
 ---
 
 ## Quick install
 
-Bootstrap a fresh project:
-
-```bash
-npx @nyuchi/design-cli init
-```
-
-This writes `app/globals.css` (the Five African Minerals tokens), `lib/utils.ts` (the `cn()` helper), `components/theme-provider.tsx`, and `components.json` — everything a new Nyuchi-branded app needs to start.
-
-Install components (wraps the shadcn CLI under the hood):
-
-```bash
-npx @nyuchi/design-cli add button card data-table
-```
-
-Install agent skills so AI tools in your project know the doctrine:
-
-```bash
-npx @nyuchi/design-cli skills install
-```
-
-Or use the shadcn CLI directly:
-
 ```bash
 npx shadcn@latest add https://mzizi.dev/api/v1/ui/button
 ```
 
-Install multiple via shadcn:
+Install several at once:
 
 ```bash
 npx shadcn@latest add \
@@ -55,13 +34,13 @@ npx shadcn@latest add \
   https://mzizi.dev/api/v1/ui/data-table
 ```
 
+Every install carries the canonical typography (Noto Sans / Noto Serif / JetBrains Mono), the Five African Minerals palette, the layered architecture, the pill-button identity, and the 56px touch-target floor.
+
 ---
 
-## AI-Native: MCP Server + Claude Code Skill
+## AI-Native: MCP server
 
-### Connect Claude Code (or any MCP client)
-
-Add to your `.claude/settings.json`:
+The portal exposes a **document-route MCP server** at `https://mzizi.dev/mcp` (Streamable HTTP transport). Each tool returns a whole self-contained JSON document per component — one fetch, no joins. Configure it in `.claude/settings.json`:
 
 ```json
 {
@@ -74,46 +53,19 @@ Add to your `.claude/settings.json`:
 }
 ```
 
-Your AI assistant can now call the full tool surface — live at `https://mzizi.dev/mcp` via `tools/list`:
+Resources:
 
-| Tool                        | What it does                                                                 |
-| --------------------------- | ---------------------------------------------------------------------------- |
-| `list_components`           | Browse all registry items, filter by type/layer/category                     |
-| `get_component`             | Fetch full source code + metadata for any component                          |
-| `get_component_docs`        | Structured docs (use cases, variants, a11y notes)                            |
-| `get_component_versions`    | Version history for a component                                              |
-| `get_component_links`       | All portal URLs for a component                                              |
-| `search_components`         | Search by name, description, or category                                     |
-| `scaffold_component`        | Generate a new component following CVA + Radix + cn() patterns               |
-| `get_design_tokens`         | Fetch the Five African Minerals palette + semantic tokens                    |
-| `get_install_command`       | Get the shadcn CLI install command for one or more components                |
-| `get_brand_info`            | Brand system — ecosystem brands, typography, spacing                         |
-| `get_architecture_info`     | Data architecture (principles, data layer, pipeline, sovereignty)            |
-| `get_ubuntu_doctrine`       | Static Ubuntu philosophy doctrine (philosophy, design, community, languages) |
-| `get_ubuntu_pillars`        | Five Ubuntu Pillars — rows from `ubuntu_pillars`                             |
-| `get_ubuntu_principles`     | Five Ubuntu Principles — rows from `ubuntu_principles`                       |
-| `get_architecture_frontend` | 3D frontend axes + layers                                                    |
-| `get_layer_summary`         | Component count / categories / names for a given frontend layer (1–10)       |
-| `get_ai_instructions`       | System prompts from `ai_instructions` by target (mcp-server/claude/copilot)  |
-| `get_changelog`             | Recent releases from the `changelog` table                                   |
-| `list_skills`               | List every published agent skill (summary only; no body_mdx)                 |
-| `get_skill`                 | Fetch a single skill (full MDX body) by name                                 |
-| `get_usage_stats`           | Public API and MCP usage metrics (open data, CC BY 4.0)                      |
-| `get_database_status`       | Registry database status and row counts                                      |
+- `mzizi://components` — component index (name / node / collection / owner)
+- `mzizi://nodes` — per-node collection summary
 
-**Endpoint:** `POST /mcp` (JSON-RPC) | `GET /mcp` (SSE) | `DELETE /mcp` (cleanup) | `OPTIONS /mcp` (CORS preflight)
+Tools:
 
-### Claude Code Skill
+- `list_components` — filter by node (1–10) or owner
+- `get_component` — full document for one component
+- `list_collections` — counts + ownership across all 10 nodes
+- `get_database_status` — connection health
 
-The `nyuchi-design-system` skill (`/.claude/skills/nyuchi-design-system.md`) is a pre-built Claude Code skill that teaches AI assistants the Five African Minerals design system:
-
-- Full color palette with APCA contrast values
-- CVA + Radix + `cn()` component patterns
-- Ubuntu design checklist (touch targets, connectivity, shared devices)
-- APCA Lc 90+ accessibility quick reference
-- Registry install commands
-
-Activate in any session: `/nyuchi-design-system`
+The standalone Cloudflare Worker variant (for consumers that don't want to go through `mzizi.dev`), the Fundi self-healing agent, the TypeScript SDK, the published `mzizi-skills` bundle, and the `mzizi-console-app` (Svelte mini-app that surfaces Mzizi inside the Nyuchi Console at `platform.nyuchi.com`) all live in **[`nyuchi/mzizi-tools`](https://github.com/nyuchi/mzizi-tools)** — not in this repo.
 
 ---
 
@@ -135,170 +87,98 @@ The design system is built on five colors named after African minerals — const
 
 ## Registry
 
-The registry is live at [mzizi.dev/components](https://mzizi.dev/components). Component counts are always live from the database — see [/observability](https://mzizi.dev/observability) for real-time totals.
+The registry is live at [mzizi.dev/components](https://mzizi.dev/components). Component counts are always live from the database — see [`/observability`](https://mzizi.dev/observability) for real-time totals and [`GET /api/v1/stats`](https://mzizi.dev/api/v1/stats) for the raw open-data feed (CC BY 4.0).
 
-| Category             | Examples                                                                                                                                   |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Forms & Input**    | input, phone-input, date-range-picker, tag-input, rich-text-editor, combobox                                                               |
-| **Chat & Messaging** | chat-bubble, chat-list, chat-input, chat-layout, typing-indicator                                                                          |
-| **AI & Chatbot**     | ai-chat, prompt-input, streaming-text, ai-feedback, suggested-prompts                                                                      |
-| **Data Display**     | data-table, kanban-board, tree-view, virtual-list, json-viewer, timeline                                                                   |
-| **User & Profile**   | avatar-group, user-card, profile-header, activity-feed                                                                                     |
-| **E-commerce**       | product-card, cart-item, order-summary, subscription-card                                                                                  |
-| **Calendar**         | calendar, calendar-week-view, event-card, time-slot-picker                                                                                 |
-| **Developer Tools**  | api-key-display, code-tabs, log-viewer, endpoint-card                                                                                      |
-| **Navigation**       | tabs, stepper, app-switcher, bottom-sheet, mega-menu                                                                                       |
-| **Layout**           | split-view, masonry-grid, infinite-scroll, page-header                                                                                     |
-| **Feedback**         | announcement-bar, cookie-consent, onboarding-tour, toast                                                                                   |
-| **Chart Blocks**     | area (10), bar (10), line (10), pie (11), radar (14), radial (6), tooltip (9)                                                              |
-| **Page Blocks**      | dashboard, login (5), signup (5), sidebar (16), profile, settings                                                                          |
-| **Mukoko Ecosystem** | mukoko-header, mukoko-footer, mukoko-sidebar, mukoko-bottom-nav                                                                            |
-| **Infrastructure**   | error-boundary, lazy-section, section-error-boundary                                                                                       |
-| **Hooks**            | use-toast, use-mobile, use-memory-pressure                                                                                                 |
-| **Lib Utilities**    | utils, observability, circuit-breaker, retry, timeout, fallback-chain, ai-safety, chaos (installed via shadcn; not committed in this repo) |
+Browse categories at [mzizi.dev/components](https://mzizi.dev/components) — they are derived live from `components.category`, never hardcoded in this README.
 
 ---
 
 ## API
 
-All endpoints under `/api/v1/`. Full spec in [`openapi.yaml`](openapi.yaml).
+All endpoints under `/api/v1/`. Full spec in [`openapi.yaml`](openapi.yaml) (also served at `GET /api/openapi`).
 
-| Endpoint                         | Method   | Description                                                      |
-| -------------------------------- | -------- | ---------------------------------------------------------------- |
-| `/api/v1`                        | GET      | Discovery document                                               |
-| `/api/v1/ui`                     | GET      | Component registry index                                         |
-| `/api/v1/ui/{name}`              | GET      | Component source + metadata (shadcn format)                      |
-| `/api/v1/ui/{name}/docs`         | GET      | Structured docs (use cases, variants, a11y)                      |
-| `/api/v1/ui/{name}/versions`     | GET      | Component version history                                        |
-| `/api/v1/brand`                  | GET      | Brand system (minerals, typography, spacing)                     |
-| `/api/v1/docs`                   | GET      | **HTTP 410 Gone** — long-form docs moved to docs.bundu.org/mzizi |
-| `/api/v1/docs/{slug}`            | GET      | **HTTP 410 Gone** — see `/api/v1/docs` for slug map              |
-| `/api/v1/changelog`              | GET      | Release history                                                  |
-| `/api/v1/changelog/{version}`    | GET      | Single release                                                   |
-| `/api/v1/ai/instructions`        | GET      | List AI instruction sets                                         |
-| `/api/v1/ai/instructions/{name}` | GET      | Instructions by target (mcp-server/claude/copilot)               |
-| `/api/v1/search?q=`              | GET      | Cross-resource search (components + docs + changelog)            |
-| `/api/v1/ecosystem`              | GET      | Architecture principles + framework decision                     |
-| `/api/v1/data-layer`             | GET      | Local-first + cloud layer specification                          |
-| `/api/v1/pipeline`               | GET      | Open data pipeline (Redpanda, Flink, Doris)                      |
-| `/api/v1/sovereignty`            | GET      | Technology sovereignty assessments                               |
-| `/api/v1/stats`                  | GET      | Public usage metrics (CC BY 4.0, `?days=7\|30\|90`)              |
-| `/api/v1/health`                 | GET      | Service health check                                             |
-| `/api/openapi`                   | GET      | OpenAPI 3.1 specification (YAML)                                 |
-| `/mcp`                           | POST/GET | MCP server (Streamable HTTP)                                     |
+| Endpoint                                       | Method   | Description                                                |
+| ---------------------------------------------- | -------- | ---------------------------------------------------------- |
+| `/api/v1`                                      | GET      | Discovery document                                         |
+| `/api/v1/ui`                                   | GET      | Component registry index                                   |
+| `/api/v1/ui/{name}`                            | GET      | Component source + metadata (shadcn format)                |
+| `/api/v1/ui/{name}/docs`                       | GET      | Structured docs (use cases, variants, a11y)                |
+| `/api/v1/ui/{name}/versions`                   | GET      | Component version history                                  |
+| `/api/v1/brand`                                | GET      | Brand system (minerals, typography, spacing)               |
+| `/api/v1/architecture`                         | GET      | Full 3D architecture snapshot                              |
+| `/api/v1/architecture/axes`                    | GET      | Per-axis summary with live counts                          |
+| `/api/v1/architecture/layers/{n}`              | GET      | Per-layer detail (covenant, rules, breakdown)              |
+| `/api/v1/architecture/frontend/{axes\|layers}` | GET      | 3D frontend axes / layers                                  |
+| `/api/v1/ubuntu/pillars`                       | GET      | Five Ubuntu Pillars                                        |
+| `/api/v1/ubuntu/principles`                    | GET      | Five Ubuntu Principles                                     |
+| `/api/v1/docs`                                 | GET      | **HTTP 410 Gone** — long-form docs moved to docs.bundu.org |
+| `/api/v1/docs/{slug}`                          | GET      | **HTTP 410 Gone** — see `/api/v1/docs` for slug map        |
+| `/api/v1/changelog`                            | GET      | Release history                                            |
+| `/api/v1/changelog/{version}`                  | GET      | Single release                                             |
+| `/api/v1/ai/instructions{,/{name}}`            | GET      | AI instruction sets (mcp-server / claude / copilot)        |
+| `/api/v1/skills{,/{name},/summary}`            | GET      | Published agent skills                                     |
+| `/api/v1/search?q=`                            | GET      | Cross-resource search (components + docs + changelog)      |
+| `/api/v1/ecosystem`                            | GET      | Architecture principles + framework decision               |
+| `/api/v1/data-layer`                           | GET      | Local-first + cloud layer specification                    |
+| `/api/v1/pipeline`                             | GET      | Open data pipeline (Redpanda, Flink, Doris)                |
+| `/api/v1/sovereignty`                          | GET      | Technology sovereignty assessments                         |
+| `/api/v1/stats?days=`                          | GET      | Open-data usage metrics (CC BY 4.0, `?days=7\|30\|90`)     |
+| `/api/v1/health`                               | GET      | Service health check                                       |
+| `/api/openapi`                                 | GET      | OpenAPI 3.1 specification (YAML)                           |
+| `/mcp`                                         | POST/GET | MCP server (Streamable HTTP)                               |
 
 ---
 
 ## Open Data & Observability
 
-Usage metrics are public by design — aligned with the bundu open data philosophy. The [/observability](https://mzizi.dev/observability) dashboard shows:
-
-- API call volumes, error rates, and p95 latency per endpoint
-- Most requested components (live install popularity ranking)
-- MCP tool usage breakdown
-- 30-day traffic trends
+Usage metrics are public by design — aligned with the bundu open data philosophy. The [`/observability`](https://mzizi.dev/observability) dashboard shows API call volumes, error rates, p95 latency per endpoint, most-requested components, MCP tool usage breakdown, and 30-day traffic trends (live from `usage_events`, `fundi_issues`, `chaos_events`).
 
 Raw data: `GET https://mzizi.dev/api/v1/stats` — licensed CC BY 4.0.
 
 ---
 
-## Architecture
-
-### DB-First
-
-All data flows through Supabase. API routes read from the database with no hardcoded fallbacks:
-
-```
-Supabase (PostgreSQL)
-  components, component_docs, component_demos
-  brand_minerals, brand_semantic_colors, brand_typography
-  brand_spacing, brand_ecosystem, brand_meta
-  architecture_principles, architecture_framework
-  architecture_data_layer, architecture_pipeline
-  architecture_sovereignty, architecture_removed
-  usage_events          ← API + MCP observability
-        │
-        ▼
-Next.js API Routes (/api/v1/)
-        │
-   ┌────┼────┐
-   ▼    ▼    ▼
-shadcn  MCP  Portal
-  CLI server  pages
-```
-
-### Layered Component Architecture
-
-```
-Layer 1: Primitives    (Button, Input, Card, Badge)
-    ↓
-Layer 2: Composites    (ChatLayout, DataTable)
-    ↓
-Layer 3: Orchestrators (Page sections)
-    ↓
-Layer 4: Error boundaries + loading states
-    ↓
-Layer 5: Server page wrappers (page.tsx)
-```
-
-### Three Sources of Truth
-
-| Source         | Database              | Role                                                       |
-| -------------- | --------------------- | ---------------------------------------------------------- |
-| Relational     | Supabase / PostgreSQL | Identity, places, events, commerce, wallet                 |
-| Non-relational | ScyllaDB              | Content and streams — messages, articles, AI conversations |
-| Personal       | Web3 Pod (TBD)        | Digital Twin memory, preferences, AI context               |
-
-**Speed is rented. Truth is owned.**
-
----
-
 ## Tech Stack
 
-| Layer                | Technology                             | Version        |
-| -------------------- | -------------------------------------- | -------------- |
-| Framework            | Next.js (App Router)                   | 16.2.2         |
-| Language             | TypeScript (strict mode)               | 6.0.2          |
-| Package Manager      | pnpm                                   | —              |
-| Styling              | Tailwind CSS 4 + CSS custom properties | 4.2.2          |
-| Component Primitives | Radix UI + Base UI                     | radix-ui 1.4.3 |
-| Variant Management   | class-variance-authority (CVA)         | 0.7.1          |
-| HTML Sanitization    | sanitize-html                          | 2.17.2         |
-| Charts               | Recharts                               | 3.8.1          |
-| Forms                | react-hook-form + zod                  | 7.73.1 / 4.3.6 |
-| Database             | Supabase                               | 2.104.0        |
-| Documentation (MDX)  | @next/mdx + rehype-slug + autolink     | 16.2.4         |
-| Icons                | Lucide React                           | 1.8.0          |
-| MCP                  | @modelcontextprotocol/sdk              | 1.29.0         |
-| Testing              | Vitest + Testing Library               | 4.1.5          |
-| CI/CD                | GitHub Actions + Vercel                | —              |
+| Layer                | Technology                                         | Version        |
+| -------------------- | -------------------------------------------------- | -------------- |
+| Framework            | Next.js (App Router)                               | 16.2.4         |
+| Language             | TypeScript (strict mode)                           | 6.0.3          |
+| Styling              | Tailwind CSS 4 + CSS custom properties             | 4.2.4          |
+| Component Primitives | Radix UI + Base UI                                 | radix-ui 1.4.3 |
+| Variant Management   | class-variance-authority (CVA)                     | 0.7.1          |
+| Charts               | Recharts                                           | 3.8.1          |
+| Forms                | react-hook-form + zod                              | 7.73.1 / 4.3.6 |
+| Database             | Supabase (PostgreSQL)                              | 2.104.0        |
+| MCP request context  | `@supabase/server` (`createSupabaseContext`, anon) | latest         |
+| MCP SDK              | @modelcontextprotocol/sdk                          | 1.29.0         |
+| Icons                | Lucide React                                       | 1.8.0          |
+| Testing              | Vitest + Testing Library                           | 4.1.5          |
+| CI/CD                | GitHub Actions + Vercel                            | —              |
 
 ---
 
 ## Commands
 
-| Command                | Description                                                                          |
-| ---------------------- | ------------------------------------------------------------------------------------ |
-| `pnpm dev`             | Start development server (port 11736)                                                |
-| `pnpm build`           | Production build (postbuild runs Pagefind to index `.next/server/app`)               |
-| `pnpm check`           | **Run every CI gate locally** — same set CI runs on a PR. Use this before pushing.   |
-| `pnpm format`          | Auto-fix formatting (prettier) across the whole tree                                 |
-| `pnpm format:check`    | Check formatting without writing — fails if anything would change                    |
-| `pnpm lint`            | ESLint (zero warnings enforced)                                                      |
-| `pnpm lint:fix`        | ESLint with `--fix`                                                                  |
-| `pnpm lint:md`         | markdownlint-cli2 across all `*.md` (config: `.markdownlint-cli2.jsonc`)             |
-| `pnpm lint:json`       | Parse every tracked `*.json` to ensure validity                                      |
-| `pnpm lint:yaml`       | yamllint (requires `pip install yamllint`)                                           |
-| `pnpm typecheck`       | TypeScript type check (`tsc --noEmit`)                                               |
-| `pnpm test`            | Vitest, single run                                                                   |
-| `pnpm test:watch`      | Vitest watch mode                                                                    |
-| `pnpm audit:check`     | `pnpm audit --audit-level=moderate` — same gate CI runs                              |
-| `pnpm registry:sync`   | Regenerate `registry.json` + committed primitives from Supabase                      |
-| `pnpm registry:verify` | Non-mutating; CI-safe drift check (run this before pushing if you've touched the DB) |
+| Command                | Description                                                                        |
+| ---------------------- | ---------------------------------------------------------------------------------- |
+| `pnpm dev`             | Start development server (port 11736)                                              |
+| `pnpm build`           | Production build (postbuild runs Pagefind to index `.next/server/app`)             |
+| `pnpm check`           | **Run every CI gate locally** — same set CI runs on a PR. Use this before pushing. |
+| `pnpm format`          | Auto-fix formatting (prettier) across the whole tree                               |
+| `pnpm format:check`    | Check formatting without writing — fails if anything would change                  |
+| `pnpm lint`            | ESLint (zero warnings enforced)                                                    |
+| `pnpm lint:fix`        | ESLint with `--fix`                                                                |
+| `pnpm lint:md`         | markdownlint-cli2 across all `*.md`                                                |
+| `pnpm lint:json`       | Parse every tracked `*.json` to ensure validity                                    |
+| `pnpm lint:yaml`       | yamllint (requires `pip install yamllint`)                                         |
+| `pnpm typecheck`       | TypeScript type check (`tsc --noEmit`)                                             |
+| `pnpm test`            | Vitest, single run                                                                 |
+| `pnpm test:watch`      | Vitest watch mode                                                                  |
+| `pnpm audit:check`     | `pnpm audit --audit-level=moderate` — same gate CI runs                            |
+| `pnpm registry:sync`   | Regenerate `registry.json` + committed primitives from Supabase                    |
+| `pnpm registry:verify` | Non-mutating drift check (run this if you've touched the DB)                       |
 
 ### Run every CI gate before pushing
-
-`pnpm check` chains all of the above (except dev/build watch modes) into one command. **It is the local mirror of CI** — if `pnpm check` is green, CI will be too:
 
 ```bash
 pnpm check
@@ -306,38 +186,18 @@ pnpm check
 #   && typecheck && test && audit:check && registry:verify && build
 ```
 
-Run it before every push. It's also the recommended pre-PR check; the husky pre-commit hook is the safety net (`lint-staged → typecheck → audit`), not a substitute.
+If `pnpm check` is green, CI will be too.
 
 ---
 
 ## CI workflows
 
-Three workflows enforce the gates that block a merge to `main`. All are in `.github/workflows/`. The full required-check matrix lives in [`CLAUDE.md`](CLAUDE.md) §14.
-
-| Workflow                                                   | Trigger                             | Jobs / required checks                                                                                   |
+| Workflow                                                   | Trigger                             | Required checks                                                                                          |
 | ---------------------------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------- |
 | [`ci.yml`](.github/workflows/ci.yml)                       | push to `main`, PR to `main`        | `Lint`, `Type Check`, `Test`, `Build`, `Security Audit`, `Registry Snapshot`                             |
 | [`lint.yml`](.github/workflows/lint.yml)                   | push to `main`, PR to `main`        | `lint / actionlint`, `lint / JSON validity`, `lint / prettier`, `lint / markdownlint`, `lint / yamllint` |
 | [`claude-review.yml`](.github/workflows/claude-review.yml) | PR open/sync, PR comment, PR review | AI code review on every human comment (advisory, not a merge gate)                                       |
-| [`release.yml`](.github/workflows/release.yml)             | push to `main`                      | Auto-creates a GitHub release when `package.json` version bumps                                          |
-
-Dependency tree inside `ci.yml`:
-
-```text
-Tier 1 (parallel, fast)
-├── Security Audit
-├── Lint
-├── Type Check
-└── Registry Snapshot
-
-Tier 2
-└── Test                   (waits on Lint, Type Check)
-
-Tier 3 — terminal gate
-└── Build                  (waits on Audit, Lint, Type Check, Test, Registry)
-```
-
-`Build` is the slowest — it never starts unless every cheaper signal is green.
+| [`release.yml`](.github/workflows/release.yml)             | tag push (`v*`)                     | Validates `package.json` version matches the tag, then creates a GitHub release                          |
 
 ---
 
@@ -348,13 +208,33 @@ git clone https://github.com/nyuchi/design-portal.git
 cd design-portal
 pnpm install
 
-# DB-first API + MCP server
 cp .env.example .env.local
 # NEXT_PUBLIC_SUPABASE_URL=...
 # NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+# SUPABASE_URL=...                # alias used by @supabase/server (/mcp)
+# SUPABASE_PUBLISHABLE_KEY=...    # alias used by @supabase/server (/mcp)
 
 pnpm dev
 ```
+
+---
+
+## Ecosystem
+
+| Repository                                                               | URL                                                | Role                                                                                                        |
+| ------------------------------------------------------------------------ | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **[design-portal](https://github.com/nyuchi/design-portal)** (this repo) | [mzizi.dev](https://mzizi.dev)                     | Mzizi portal — registry, brand, 3D architecture, document-route MCP                                         |
+| **[nyuchi/mzizi-tools](https://github.com/nyuchi/mzizi-tools)**          | npm packages                                       | Mzizi tooling — `mzizi-mcp` worker, `mzizi-sdk` (with the Fundi agent), `mzizi-skills`, `mzizi-console-app` |
+| **[nyuchi/mukoko-platform](https://github.com/nyuchi/mukoko-platform)**  | [platform.nyuchi.com](https://platform.nyuchi.com) | Nyuchi Console — B2B platform (will be renamed `nyuchi-console`)                                            |
+| **[nyuchi/bundu-docs](https://github.com/nyuchi/bundu-docs)**            | [docs.bundu.org](https://docs.bundu.org)           | Outward-facing product documentation (Astro Starlight)                                                      |
+| **[nyuchi/nyuchi-docs](https://github.com/nyuchi/nyuchi-docs)**          | [docs.nyuchi.com](https://docs.nyuchi.com)         | Engineering / how-things-are-done docs (Astro Starlight)                                                    |
+| mukoko                                                                   | [mukoko.com](https://mukoko.com)                   | Africa's super app                                                                                          |
+| mukoko weather                                                           | [weather.mukoko.com](https://weather.mukoko.com)   | Hyperlocal forecasts, farming intelligence                                                                  |
+| mukoko news                                                              | [news.mukoko.com](https://news.mukoko.com)         | Pan-African news aggregation                                                                                |
+| nhimbe                                                                   | [nhimbe.com](https://nhimbe.com)                   | Events and cultural gatherings                                                                              |
+| shamwari                                                                 | [shamwari.ai](https://shamwari.ai)                 | Sovereign AI companion                                                                                      |
+| nyuchi                                                                   | [nyuchi.com](https://nyuchi.com)                   | Enterprise layer                                                                                            |
+| bundu                                                                    | [bundu.family](https://bundu.family)               | The ecosystem                                                                                               |
 
 ---
 
@@ -362,38 +242,13 @@ pnpm dev
 
 Every merge to `main` that bumps `package.json` version triggers an automatic GitHub release. The release workflow validates all CI gates (lint, typecheck, tests, build) before tagging.
 
-To release a new version:
-
-1. Update `version` in `package.json`
-2. Update `BRAND_SYSTEM.version` in `lib/brand.ts`
-3. Update the version in `components/landing/footer.tsx`
-4. Open a PR — the merge creates the release automatically
-
-See [CHANGELOG.md](CHANGELOG.md) for release history.
-
----
-
-## Ecosystem
-
-| App            | URL                                              | Role                                       |
-| -------------- | ------------------------------------------------ | ------------------------------------------ |
-| mukoko         | [mukoko.com](https://mukoko.com)                 | Africa's super app — 17 mini-apps          |
-| mukoko weather | [weather.mukoko.com](https://weather.mukoko.com) | Hyperlocal forecasts, farming intelligence |
-| mukoko news    | [news.mukoko.com](https://news.mukoko.com)       | Pan-African news aggregation               |
-| nhimbe         | [nhimbe.com](https://nhimbe.com)                 | Events and cultural gatherings             |
-| lingo          | [lingo.mukoko.com](https://lingo.mukoko.com)     | African language learning                  |
-| shamwari       | [shamwari.ai](https://shamwari.ai)               | Sovereign AI companion                     |
-| bushtrade      | [bushtrade.co.zw](https://bushtrade.co.zw)       | Rentals-first marketplace                  |
-| nyuchi         | [nyuchi.com](https://nyuchi.com)                 | Enterprise layer — 7 products              |
-| bundu          | [bundu.family](https://bundu.family)             | The ecosystem                              |
+The version-bump propagation surfaces are listed in [`CLAUDE.md`](CLAUDE.md) §14. See [`CHANGELOG.md`](CHANGELOG.md) for release history.
 
 ---
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines, code standards, and the PR process.
-
-For questions and ideas, use [GitHub Discussions](https://github.com/nyuchi/design-portal/discussions).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines, code standards, and the PR process. For questions and ideas, use [GitHub Discussions](https://github.com/nyuchi/design-portal/discussions).
 
 ## Code of Conduct
 
@@ -403,6 +258,8 @@ See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). Built on Ubuntu: _umuntu ngumuntu 
 
 See [SECURITY.md](SECURITY.md) or report privately via [GitHub Security Advisories](https://github.com/nyuchi/design-portal/security/advisories/new).
 
-## License
+## Governance & License
 
-Copyright Nyuchi Africa (PVT) Ltd. All rights reserved.
+Mzizi is an **independent open-architecture project of the [Bundu Foundation](https://bundu.family)**, operated and developed by [Nyuchi Africa (PVT) Ltd](https://nyuchi.com). It is **not** a Nyuchi product — Nyuchi is the operator, the Bundu Foundation is the governance body. Anyone in the bundu ecosystem can consume the registry; contribution and direction-setting flow through the Bundu Foundation.
+
+Licensed under the [Apache License 2.0](LICENSE). © Bundu Foundation, operated by Nyuchi Africa (PVT) Ltd. See [NOTICE](NOTICE) for attribution.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -130,7 +130,7 @@ const jsonLd = {
       },
       description: SITE_DESCRIPTION,
       creator: { "@id": `${SITE_URL}/#organization` },
-      softwareVersion: "4.0.39",
+      softwareVersion: "4.0.40",
       downloadUrl: "https://mzizi.dev/api/v1/ui",
     },
   ],

--- a/components/landing/dashboard-sidebar.tsx
+++ b/components/landing/dashboard-sidebar.tsx
@@ -77,7 +77,7 @@ export function DashboardSidebar() {
       </SidebarContent>
 
       <SidebarFooter className="text-xs text-muted-foreground">
-        <span className="px-2 font-mono">v4.0.39</span>
+        <span className="px-2 font-mono">v4.0.40</span>
       </SidebarFooter>
 
       <SidebarRail />

--- a/components/landing/footer.tsx
+++ b/components/landing/footer.tsx
@@ -219,7 +219,7 @@ export function Footer() {
               </a>
             </span>
             <span aria-hidden="true">·</span>
-            <span className="font-mono text-[10px]">v4.0.39</span>
+            <span className="font-mono text-[10px]">v4.0.40</span>
           </div>
         </div>
       </div>

--- a/components/playground/demos.tsx
+++ b/components/playground/demos.tsx
@@ -553,7 +553,7 @@ export const COMPONENT_DEMOS: Record<string, React.ReactNode> = {
         <div className="rounded-md px-3 py-1.5 text-xs text-muted-foreground">API</div>
       </div>
       <div className="mt-3 border-t border-border pt-2 text-[10px] text-muted-foreground">
-        v4.0.39
+        v4.0.40
       </div>
     </div>
   ),
@@ -604,7 +604,7 @@ export const COMPONENT_DEMOS: Record<string, React.ReactNode> = {
         </div>
       </div>
       <div className="mt-3 border-t border-border pt-2 text-[10px] text-muted-foreground">
-        Built by Nyuchi — v4.0.39
+        Built by Nyuchi — v4.0.40
       </div>
     </div>
   ),

--- a/lib/mcp-server.ts
+++ b/lib/mcp-server.ts
@@ -19,7 +19,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import type { SupabaseClient } from "@supabase/supabase-js"
 import { z } from "zod"
 
-const VERSION = "4.0.39"
+const VERSION = "4.0.40"
 
 // ─── Result helpers ─────────────────────────────────────────────────────────
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -617,7 +617,7 @@ paths:
         - name: version
           in: path
           required: true
-          schema: { type: string, example: "4.0.39" }
+          schema: { type: string, example: "4.0.40" }
       responses:
         "200":
           description: Release
@@ -1121,7 +1121,7 @@ components:
           const: "Brand"
         version:
           type: string
-          example: "4.0.39"
+          example: "4.0.40"
         name:
           type: string
           example: "Nyuchi Brand System"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -851,36 +851,53 @@ paths:
 
   /stats:
     get:
-      summary: Live registry stats
-      description: Live counts across the registry — total stable components, per-layer and per-category breakdown, token counts. Never hardcoded.
+      summary: Public usage statistics (open data — CC BY 4.0)
+      description: |
+        Live API + MCP usage metrics for the public observability dashboard
+        (`/observability`) — aligned with the bundu open data philosophy.
+        Returns aggregate counts (calls, errors, p95 latency, top components,
+        top tools) over the lookback window plus a `layers` breakdown sourced
+        live from the `components` table. Carries schema.org `Dataset` JSON-LD
+        + CC BY 4.0 license. Never hardcoded.
       operationId: getStats
       tags: [Discovery]
+      parameters:
+        - name: days
+          in: query
+          required: false
+          description: "Lookback period in days. Clamped to [1, 90]."
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 90
+            default: 30
       responses:
         "200":
           description: Stats
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+                example: "public, max-age=60, s-maxage=120"
+            Access-Control-Allow-Origin:
+              $ref: "#/components/headers/CorsWildcard"
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  components:
-                    type: object
-                    properties:
-                      total: { type: integer }
-                      stable: { type: integer }
-                      alpha: { type: integer }
-                      deprecated: { type: integer }
+                  "@context": { type: string, const: "https://schema.org" }
+                  "@type": { type: string, const: "Dataset" }
+                  name: { type: string }
+                  description: { type: string }
+                  license: { type: string, format: uri }
+                  total_api_calls: { type: integer }
+                  total_mcp_calls: { type: integer }
                   layers:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        layer: { type: integer }
-                        axis: { type: string }
-                        count: { type: integer }
-                  tokens:
                     type: object
                     additionalProperties: { type: integer }
+        "500":
+          $ref: "#/components/responses/InternalError"
 
   /ui/{name}/docs:
     get:
@@ -1884,28 +1901,53 @@ components:
 
     ChangelogEntry:
       type: object
-      required: [version, title, createdAt]
+      required: [version, title, description, changed_by, created_at, released_at]
       properties:
-        version: { type: string, example: "4.0.39" }
+        version: { type: string, example: "4.0.40" }
         title: { type: string }
         description: { type: string }
-        layersAffected:
+        nodes_affected:
           type: array
+          description: "Architecture nodes (1–10) touched by this release."
+          items: { type: integer, minimum: 1, maximum: 10 }
+        axes_affected:
+          type: array
+          items: { type: string }
+        components_added:
+          type: array
+          items: { type: string }
+        components_modified:
+          type: array
+          items: { type: string }
+        components_deprecated:
+          type: array
+          items: { type: string }
+        components_removed:
+          type: array
+          items: { type: string }
+        tools_added:
+          type: array
+          description: "Mzizi tools — MCP tools, SDK helpers — added in this release."
+          items: { type: string }
+        tools_modified:
+          type: array
+          items: { type: string }
+        tools_deprecated:
+          type: array
+          items: { type: string }
+        tools_removed:
+          type: array
+          items: { type: string }
+        linked_issues:
+          type: array
+          description: "GitHub issue / PR numbers referenced by this release."
           items: { type: integer }
-        axesAffected:
-          type: array
-          items: { type: string }
-        componentsAdded:
-          type: array
-          items: { type: string }
-        componentsModified:
-          type: array
-          items: { type: string }
-        componentsDeprecated:
-          type: array
-          items: { type: string }
-        changedBy: { type: string }
-        createdAt: { type: string, format: date-time }
+        total_stable: { type: integer, nullable: true }
+        total_deprecated: { type: integer, nullable: true }
+        total_alpha: { type: integer, nullable: true }
+        changed_by: { type: string }
+        created_at: { type: string, format: date-time }
+        released_at: { type: string, format: date-time }
 
   responses:
     InternalError:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mzizi",
-  "version": "4.0.39",
+  "version": "4.0.40",
   "private": true,
   "description": "Mzizi — an open-architecture project of the Bundu Foundation. Open 3D frontend architecture, component registry, and MCP server, operated and developed by Nyuchi.",
   "homepage": "https://mzizi.dev",

--- a/supabase/seeds/changelog_v4_0_40.sql
+++ b/supabase/seeds/changelog_v4_0_40.sql
@@ -1,0 +1,59 @@
+-- Changelog row for v4.0.40 — Mzizi transition + node-aware portal surfaces.
+--
+-- Applied to the live Supabase project (grjsboqkaywpwatvrzmy) via the
+-- design-portal MCP at PR time using `apply_migration`. Tracked here as a
+-- text record so the PR shows the exact row that landed.
+--
+-- The migration was named: `changelog_v4_0_40_mzizi_transition_release`.
+--
+-- Idempotent: guarded by `WHERE NOT EXISTS` so re-running is safe. Note that
+-- the `changelog` table does NOT enforce a unique constraint on `version`,
+-- so historically a row already existed for version 4.0.40 (id 47, dated
+-- 2026-04-29, "Infrastructure topology declaration"). This row sits next
+-- to it; if a uniqueness constraint is added later, the older row should
+-- be merged or migrated forward — flagged in CLAUDE.md §14.
+
+BEGIN;
+
+INSERT INTO public.changelog (
+  version,
+  title,
+  description,
+  nodes_affected,
+  axes_affected,
+  components_added,
+  components_modified,
+  components_deprecated,
+  components_removed,
+  tools_added,
+  tools_modified,
+  tools_deprecated,
+  tools_removed,
+  linked_issues,
+  changed_by,
+  released_at
+)
+SELECT
+  '4.0.40',
+  'v4.0.40 — Mzizi transition + node-aware portal surfaces',
+  $$Doctrine + release cleanup landing the Mzizi transition (#104) and the node-aware portal surfaces wired by #103–#107. PR #103 renamed layers to nodes across the registry and shipped the database migration. PR #104 stripped the Fundi edge function from the portal (it moved to nyuchi/mzizi-tools), retired the in-repo MDX renderers in favour of bundu-docs / nyuchi-docs (Astro Starlight), removed the Stytch B2B auth surface (the portal is anon-only now), rebranded everything from Nyuchi Design Portal to Mzizi, relicensed to Apache-2.0, swapped the document-route MCP to @supabase/server with auth:'none', fixed the MDX styling regression on native markdown elements, and pinned qs via pnpm overrides. PR #105 wired the /observability open-data dashboard with live charts from usage_events, fundi_issues, and chaos_events. PR #106 wired /playground and /playground/[name]. PR #107 wired /changelog, /tools, /tools/[name], the per-component /changelog/[name] route, and the <NodeBadge> + <StatusBadge> registry primitives. Also bundled: CLAUDE.md rewritten for post-#104 reality (node language, four-repo ecosystem split — Mzizi/Mukoko/Nyuchi/Bundu, document-route MCP doctrine, count-as-data rule); openapi.yaml audited against the live route tree and its ChangelogEntry + /stats schemas brought in line with the post-#107 DB shape; README refreshed for the Mzizi identity and Bundu Foundation governance footer.$$,
+  ARRAY[1,2,3,4,5,6,7,8,10]::int[],
+  ARRAY['X','Y','Z','Outside','Documentation']::text[],
+  ARRAY['node-badge','status-badge']::text[],
+  ARRAY['mukoko-header','mukoko-footer','mukoko-theme-provider','mukoko-skeleton-set','mukoko-error-set','mukoko-verified-badge']::text[],
+  ARRAY[]::text[],
+  ARRAY[]::text[],
+  ARRAY['createMziziMcpServer','mzizi://components','mzizi://nodes','list_collections']::text[],
+  ARRAY['list_components','get_component','get_database_status']::text[],
+  ARRAY[]::text[],
+  ARRAY['get_component_docs','get_component_links','get_component_versions','search_components','get_design_tokens','scaffold_component','get_install_command','get_brand_info','get_architecture_info','get_ubuntu_doctrine','get_ubuntu_pillars','get_ubuntu_principles','get_architecture_frontend','get_usage_stats','get_layer_summary','list_skills','get_skill','get_ai_instructions','get_changelog']::text[],
+  ARRAY[103,104,105,106,107]::int[],
+  'mzizi-release-bot',
+  now()
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.changelog
+  WHERE version = '4.0.40'
+    AND title = 'v4.0.40 — Mzizi transition + node-aware portal surfaces'
+);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Doctrine + release cleanup landing the Mzizi transition (#104) and the node-aware portal surfaces wired by #103–#107.

- **CLAUDE.md rewritten** for post-#104 reality — node language, four-repo ecosystem split (Mzizi / Mukoko / Nyuchi / Bundu), document-route MCP doctrine (`createMziziMcpServer`, `mzizi://components`, `mzizi://nodes`, 4 tools), `@supabase/server` `auth: 'none'` pattern, legacy MCP on the protected `legacy` branch, count-as-data rule replacing the hardcoded category tables, refreshed open-work section against the live issue tracker.
- **openapi.yaml audited** against the actual `app/api/v1/` route tree — every live route was already documented, so the diff is schema-level: `ChangelogEntry` brought in line with the post-#103/#107 table shape (`nodes_affected`, full `tools_*` / `linked_issues` / `released_at` / `total_*` columns); `/stats` rewritten for the open-data dashboard that landed in #105 (documented `?days=` param, Dataset JSON-LD + CC BY 4.0 license, live `layers` breakdown, `max-age=60, s-maxage=120`).
- **README refreshed** for the Mzizi identity — Bundu Foundation governance / Nyuchi operations, Apache-2.0 license badge, retired-Mintlify redirect, full ecosystem table including `nyuchi/mzizi-tools`, `nyuchi/mukoko-platform`, `nyuchi/bundu-docs`, `nyuchi/nyuchi-docs`. MCP section rewritten for the lean document-route surface. Quick install simplified to the shadcn CLI direct-add path.
- **Version bumped to 4.0.40** across `package.json`, `lib/mcp-server.ts` (`VERSION` const), `components/landing/footer.tsx`, `components/landing/dashboard-sidebar.tsx`, `app/layout.tsx` (`softwareVersion`), `openapi.yaml` examples, the two footer/sidebar mirrors in `components/playground/demos.tsx`, README, and CLAUDE.md §1.
- **Supabase changelog row** for v4.0.40 inserted via `apply_migration` (`changelog_v4_0_40_mzizi_transition_release`, id 54) — `nodes_affected = ARRAY[1,2,3,4,5,6,7,8,10]`, `linked_issues = ARRAY[103,104,105,106,107]`. Text-tracked mirror in `supabase/seeds/changelog_v4_0_40.sql`.

## Commits (5)

1. `docs(openapi):` audit against post-#107 route tree — refresh stats + changelog schemas
2. `docs(claude):` rewrite CLAUDE.md for post-#104 reality
3. `chore(release):` bump to v4.0.40 + propagate version everywhere
4. `docs(readme):` refresh for Mzizi identity + new ecosystem split
5. `db(changelog):` seed v4.0.40 — Mzizi transition + node-aware portal surfaces

## Doctrine compliance

- Multi-commit history (5 commits, ~one per logical step) — never squash.
- `merge_method=merge` on merge.
- No new code surface introduced — docs + version-bump + Supabase row only.
- Signing kept; no `--no-verify`.
- Open-issues sweep folded into CLAUDE.md "Open work" section.

## Flagged ambiguities

- The changelog table has **no unique constraint on `version`**, so a historical row for `4.0.40` already exists (id 47, dated 2026-04-29, "Infrastructure topology declaration"). My new row (id 54) sits next to it — both coexist. Flagged in `supabase/seeds/changelog_v4_0_40.sql` and CLAUDE.md.
- `pnpm-workspace.yaml`, `packages/design-cli`, and `packages/design-agent-skills` are still on main as orphaned remnants even though the task brief states they were stripped. I followed the brief and removed their references from CLAUDE.md and README; the directories themselves were not touched (would need a separate cleanup PR to delete safely, since they may still be referenced by `release.yml` npm publish).
- PR #108 (`app/ubuntu/`) is still open + dirty; CLAUDE.md §5 marks `app/ubuntu/` as "(landing on v4.0.41)" and §15.18 / Open Work flag #45 (Ubuntu doctrine build) accordingly.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (zero warnings)
- [x] `pnpm test` — 85 passed across 10 files
- [x] `pnpm build` — clean (Next.js + Pagefind both green)
- [x] CI green (waiting on merge)
- [x] Supabase row landed (id 54)

https://claude.ai/code/session_01RHdD3m5zeBYmYoUwxLwxKf

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHdD3m5zeBYmYoUwxLwxKf)_