### PR TITLE
docs: update colour-system doctrine to Seven Minerals + heritage/status/experimental

### DIFF
--- a/.claude/skills/ecosystem-app-setup.md
+++ b/.claude/skills/ecosystem-app-setup.md
@@ -20,7 +20,7 @@ npx @nyuchi/design-cli init
 
 This scaffolds a Next.js 16 project (Turbopack, pnpm, Node 24) with:
 
-- globals.css pre-populated with the five African minerals tokens
+- globals.css pre-populated with the seven African minerals tokens
 - components.json pointing at https://mzizi.dev/api/v1/ui
 - lib/utils.ts with the cn() helper
 - app/layout.tsx wired with the nyuchi-theme-provider
@@ -47,19 +47,21 @@ pnpm add -D @tailwindcss/typography
 
 ### 3. Scaffold globals.css
 
-Add the five African minerals tokens at the top of `app/globals.css`:
+Add the seven African minerals tokens at the top of `app/globals.css`:
 
 ```css
 @layer base {
   :root {
-    /* Minerals — query brand_minerals for canonical values */
-    --color-cobalt: 0 176 255; /* DRC */
-    --color-tanzanite: 179 136 255; /* Tanzania */
-    --color-malachite: 100 255 218; /* Congo */
-    --color-gold: 255 215 64; /* Ghana/SA */
-    --color-terracotta: 212 165 116; /* Pan-African Sahel */
+    /* Minerals — use the styling-minerals collection / /api/v1/brand for canonical values */
+    --color-cobalt: 0 176 255; /* Knowledge · deep-earth */
+    --color-tanzanite: 179 136 255; /* Identity · deep-earth */
+    --color-malachite: 100 255 218; /* Growth · deep-earth */
+    --color-sodalite: 61 90 254; /* Intelligence · deep-earth */
+    --color-gold: 255 215 64; /* Value · hand */
+    --color-terracotta: 225 176 126; /* Community · hand */
+    --color-copper: 255 138 101; /* Stewardship · hand */
 
-    /* Semantic — query brand_semantic_colors */
+    /* Semantic — use the styling-semantic collection / /api/v1/brand */
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
     --primary: var(--color-cobalt);

--- a/.claude/skills/nyuchi-design-system.md
+++ b/.claude/skills/nyuchi-design-system.md
@@ -38,17 +38,19 @@ Production source for every stable component is stored in the components.source_
 
 When you add or modify a component: write the source directly to components.source_code via SQL, and flip its status from alpha to stable.
 
-## The five African minerals
+## The seven African minerals
 
-Our colour palette draws from the continent's mineral wealth. For canonical hex values and container colours, query brand_minerals — the database is the source of truth.
+Our colour palette draws from the continent's mineral wealth. Colour is a **role contract**, not decoration. For canonical hex values (dark + light) and container colours, use the `styling-minerals` collection / `GET /api/v1/brand` / `/tokens` — the database is the source of truth. The seven minerals split into two families: `deep-earth` (cobalt, tanzanite, malachite, sodalite) and `hand` (gold, terracotta, copper).
 
-- Cobalt — primary actions, links, active states (DRC)
-- Tanzanite — brand identity, premium features, purple accents (Tanzania)
-- Malachite — success states, positive indicators, growth (Congo)
-- Gold — achievements, warmth, premium badges (Ghana, South Africa)
-- Terracotta — community features, grounding, heritage (Pan-African)
+- Cobalt — Knowledge; primary actions, links, active states (Katanga/Copperbelt) · deep-earth
+- Tanzanite — Identity; brand identity, premium features (Merelani Hills, Tanzania) · deep-earth
+- Malachite — Growth; success states, positive indicators (Congo Copper Belt) · deep-earth
+- Sodalite — Intelligence; depth, focus, analytical surfaces (pan-African) · deep-earth
+- Gold — Value; achievements, warmth, premium badges (Ghana, South Africa, Mali) · hand
+- Terracotta — Community; grounding, heritage (Kunene River) · hand
+- Copper — Stewardship; craft, care, custodianship (Central African Copperbelt) · hand
 
-Never hardcode hex values for these colours. Reference them via CSS variables or query brand_minerals.
+Alongside the minerals: **seven heritage tones** (indigo, savanna, baobab, sunset, river, hematite, kalahari), the **status** set, and the computed **Experimental Seven** (ember, acacia, fern, lagoon, storm, dusk, protea). Never hardcode hex values — reference the CSS variables (`--color-<mineral>`) or the design database.
 
 ## Implementation rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 
 **Mzizi** is an **independent open-architecture project of the Bundu Foundation** — governed by the Bundu Foundation, operated and developed by Nyuchi. It is **not** a Nyuchi product. Mzizi owns the open 3D frontend architecture, the component registry (`mzizi.dev/r/`), the Mzizi API (`mzizi.dev/api`), the components, the infrastructure harness, and the architecture nodes it serves.
 
-It serves the full stable registry across a 3D frontend architecture — **ten nodes across five axes**: X-axis (horizontal composition — N2 primitives → N3 brand → N6 pages → N7 shell), Y-axis (vertical infrastructure — N1 tokens, N4 safety, N5 resilience), Z-axis (depth observation — N8 assurance), Outside (N9 — self-healing actors, now owned by `mzizi-tools`), and Documentation (N10). Built on the **Five African Minerals** design system, installable via the shadcn CLI:
+It serves the full stable registry across a 3D frontend architecture — **ten nodes across five axes**: X-axis (horizontal composition — N2 primitives → N3 brand → N6 pages → N7 shell), Y-axis (vertical infrastructure — N1 tokens, N4 safety, N5 resilience), Z-axis (depth observation — N8 assurance), Outside (N9 — self-healing actors, now owned by `mzizi-tools`), and Documentation (N10). Built on the **Seven African Minerals** design system (seven minerals + seven heritage tones + status + the Experimental Seven — see §7), installable via the shadcn CLI:
 
 ```
 npx shadcn@latest add https://mzizi.dev/api/v1/ui/<component>
@@ -51,7 +51,7 @@ Mzizi exists within a broader ecosystem. Understanding the relationships prevent
 ```
 design-portal (this repo)
     │
-    ├── Defines: Five African Minerals palette, typography, component API,
+    ├── Defines: Seven African Minerals palette, typography, component API,
     │            3D frontend architecture, Ubuntu doctrine
     ├── Serves: the full stable registry across 10 architecture nodes via the
     │           shadcn CLI / `/api/v1/*` (live count: GET /api/v1/stats)
@@ -417,23 +417,52 @@ Three layers of error isolation:
 
 ---
 
-## 7. Five African Minerals Design System
+## 7. Colour System — Seven Minerals, Seven Heritage, Status & Experimental
 
 This is the canonical design system. All bundu ecosystem apps MUST use these tokens.
 
+The palette layers four families:
+
+1. **Seven minerals** — the brand accents, each carrying a semantic **role**, grouped in two **families** (`deep-earth`, `hand`).
+2. **Seven heritage** — atmospheric anchors for surfaces, moods and mini-app theming (no role/family).
+3. **Status** — semantic state colours (success/warning/info/error/neutral/offline/syncing), separate from the brand accent.
+4. **The Experimental Seven** — a computed proving-ground palette (candidate accents + data series).
+
+Minerals + heritage are **DB-generated**: `pnpm tokens:sync` projects the Supabase collections `styling-minerals` and `styling-heritage-colors` into `lib/tokens/palette.generated.ts` and the `tokens:generated` block of `app/globals.css`; `pnpm tokens:verify` is the CI drift gate. The live, theme-adaptive values render at `/tokens`. **Never hand-edit `palette.generated.ts` or the generated globals.css block** — edit the DB collection and re-sync.
+
 ### 7.1 Color Palette
 
-**Mineral accent colors** (constant across light/dark):
+**Seven minerals** — brand accents, each with a role + family (sourced from `styling-minerals`; hexes shown are the current dark/light snapshot — `/tokens` is the live source):
 
-| Mineral    | Hex       | CSS Variable         | Usage                             |
-| ---------- | --------- | -------------------- | --------------------------------- |
-| Cobalt     | `#0047AB` | `--color-cobalt`     | Primary blue, links, CTAs         |
-| Tanzanite  | `#B388FF` | `--color-tanzanite`  | Purple accent, brand/logo         |
-| Malachite  | `#64FFDA` | `--color-malachite`  | Cyan accent, success states       |
-| Gold       | `#FFD740` | `--color-gold`       | Yellow accent, rewards/highlights |
-| Terracotta | `#D4A574` | `--color-terracotta` | Warm accent, community            |
+| Mineral    | Role         | Family     | Dark      | Light     | CSS Variable         |
+| ---------- | ------------ | ---------- | --------- | --------- | -------------------- |
+| Cobalt     | Knowledge    | deep-earth | `#00B0FF` | `#0047AB` | `--color-cobalt`     |
+| Tanzanite  | Identity     | deep-earth | `#B388FF` | `#4B0082` | `--color-tanzanite`  |
+| Malachite  | Growth       | deep-earth | `#64FFDA` | `#004D40` | `--color-malachite`  |
+| Sodalite   | Intelligence | deep-earth | `#3D5AFE` | `#283593` | `--color-sodalite`   |
+| Gold       | Value        | hand       | `#FFD740` | `#5D4037` | `--color-gold`       |
+| Terracotta | Community    | hand       | `#E1B07E` | `#A0522D` | `--color-terracotta` |
+| Copper     | Stewardship  | hand       | `#FF8A65` | `#BF5A36` | `--color-copper`     |
 
-**Semantic color tokens** (theme-adaptive via CSS custom properties):
+**Per-brand accent.** Colour is a role contract, not decoration. The operating brand picks its accent via `--brand-accent`: **nyuchi** (this portal) = **gold**, **mukoko** = **tanzanite** (Identity), **bundu** = its own. Never hardcode a brand's accent hex — consume `--brand-accent`.
+
+**Seven heritage** — atmospheric tones (sourced from `styling-heritage-colors`; no role/family):
+
+| Heritage | Dark      | Light     | CSS Variable       |
+| -------- | --------- | --------- | ------------------ |
+| Indigo   | `#7986CB` | `#4527A0` | `--color-indigo`   |
+| Savanna  | `#E5C158` | `#8D6E1A` | `--color-savanna`  |
+| Baobab   | `#A1887F` | `#4E342E` | `--color-baobab`   |
+| Sunset   | `#FF7043` | `#D84315` | `--color-sunset`   |
+| River    | `#4DD0E1` | `#006064` | `--color-river`    |
+| Hematite | `#90A4AE` | `#546E7A` | `--color-hematite` |
+| Kalahari | `#E8D9B5` | `#C9B589` | `--color-kalahari` |
+
+**Status** — semantic state tokens (values in `app/globals.css` `:root`/`.dark`; `error` maps to `--destructive`): `--success`, `--warning`, `--info`, `--destructive` (error), `--neutral`, `--offline`, `--syncing`.
+
+**The Experimental Seven** — computed, not chosen. Seven maximally-separated hues on a heptagon offset by the founding prime (17°), prime saturations, and every foreground solved to a ≥7:1 (P7) contrast floor. Names: **ember, acacia, fern, lagoon, storm, dusk, protea**. Each ships four computed tiers — text (`--exp-<name>`), UI accent (`--exp-<name>-ui`), and container / on-container (`--exp-<name>-container` / `--exp-<name>-on`) — with `--color-<name>` mapping to the text tier via `@theme`. Provenance: the bundu newsroom, "Colours Computed, Not Chosen" (`styling-experimental`, doctrine 4.2.0). Currently a **hand-authored** block in `globals.css` (not yet wired into `tokens:sync`); the proving ground for data series + candidate accents.
+
+**Surface / semantic tokens** (theme-adaptive via CSS custom properties):
 
 > **Values synced from the `nyuchi-tokens` registry (N1), April 2026 AAA-optimised swap.**
 > Surfaces were re-arranged: `background` is now the ambient page base, `card` is the content surface, `muted` is the deepest fill. Border/input alpha tightened to 0.06. Two new tokens added: `overlay` (modal/sheet surface) and `scrim` (modal backdrop).
@@ -575,7 +604,7 @@ npx shadcn@latest add https://mzizi.dev/api/v1/ui/button
 npx shadcn@latest add https://mzizi.dev/api/v1/ui/card
 ```
 
-Every new app inherits the canonical typography (Noto Sans / Noto Serif / JetBrains Mono), the Five African Minerals palette, the layered architecture, the pill-button identity, and the touch-target floor. Long-form product docs for any bundu app belong in `nyuchi/bundu-docs`; engineering docs belong in `nyuchi/nyuchi-docs`. Mzizi tooling (MCP, SDK, skills, console mini-app) is consumed from `nyuchi/mzizi-tools` as published npm packages.
+Every new app inherits the canonical typography (Noto Sans / Noto Serif / JetBrains Mono), the Seven African Minerals palette, the layered architecture, the pill-button identity, and the touch-target floor. Long-form product docs for any bundu app belong in `nyuchi/bundu-docs`; engineering docs belong in `nyuchi/nyuchi-docs`. Mzizi tooling (MCP, SDK, skills, console mini-app) is consumed from `nyuchi/mzizi-tools` as published npm packages.
 
 ### 8.6 Distribution surface
 
@@ -898,7 +927,7 @@ When working on this codebase as an AI assistant:
 1. **Supabase is the source of truth.** Component source code, docs, brand data, architecture data, AI instructions, changelog, document-route docs — all live in Supabase. Do not reintroduce hardcoded JSON/TS files for any of these.
 2. **`registry.json` is generated, not authored.** Never hand-edit it. CI runs `pnpm registry:verify` to catch drift.
 3. **Never break the shadcn registry schema** — downstream apps depend on it.
-4. **Use the Five African Minerals palette** — never introduce colors outside the token system.
+4. **Use the Seven African Minerals palette** (plus heritage / status / experimental sets — §7) — never introduce colors outside the token system.
 5. **Follow the CVA + Radix + cn() pattern** — every component uses this stack.
 6. **Keep components self-contained** — each file is independently installable via the registry.
 7. **Preserve accessibility** — APCA 3.0 AAA contrast, 56px default / 48px minimum touch targets, Radix primitives for keyboard/screen reader behaviour.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ git checkout -b feature/your-feature
 ### Before You Code
 
 1. **Read [CLAUDE.md](CLAUDE.md)** -- it is the definitive reference for this codebase, covering architecture, conventions, and the full design system specification
-1. **Understand the [Five African Minerals design system](https://mzizi.dev/brand/colors)** -- all colors come from five mineral-named tokens
+1. **Understand the [Seven African Minerals design system](https://mzizi.dev/tokens)** -- all colors come from the mineral-named tokens (seven minerals + seven heritage tones + status + the Experimental Seven)
 1. **Browse existing components** in `components/ui/` to understand the CVA + Radix + cn() pattern
 1. **Check `registry.json`** before modifying components to understand the dependency graph
 1. **Understand the DB-first architecture** -- API routes read from Supabase, not hardcoded objects
@@ -89,7 +89,7 @@ git checkout -b feature/your-feature
 
 - The registry is the **single source of truth** for the entire bundu ecosystem. Changes here propagate to every app that consumes the registry.
 - Every component must be **independently installable** via the shadcn CLI.
-- The **Five African Minerals palette** is the only approved color system. Never introduce colors outside the token system.
+- The **Seven African Minerals palette** (minerals + heritage + status + experimental) is the only approved color system. Never introduce colors outside the token system.
 - **Accessibility is mandatory** -- APCA 3.0 AAA contrast, 56px default / 48px minimum touch targets, keyboard navigation, screen reader support.
 
 ---

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## What is Mzizi?
 
-**Mzizi** (Swahili for _root_) is an independent open-architecture project of the **Bundu Foundation**, operated and developed by **Nyuchi**. It owns the open 3D frontend architecture, the component registry served at `mzizi.dev/r/`, the Mzizi API at `mzizi.dev/api`, the Five African Minerals design system, and the document-route Model Context Protocol (MCP) server at `mzizi.dev/mcp`. It is **not** a Nyuchi product — it is a Bundu-governed standard the whole bundu ecosystem (Mukoko consumer mini-apps, Nyuchi enterprise products, sister brands) installs from. Backed by a DB-first architecture (Supabase) and served as a shadcn-compatible API, every component is installable into any project with one command.
+**Mzizi** (Swahili for _root_) is an independent open-architecture project of the **Bundu Foundation**, operated and developed by **Nyuchi**. It owns the open 3D frontend architecture, the component registry served at `mzizi.dev/r/`, the Mzizi API at `mzizi.dev/api`, the Seven African Minerals design system, and the document-route Model Context Protocol (MCP) server at `mzizi.dev/mcp`. It is **not** a Nyuchi product — it is a Bundu-governed standard the whole bundu ecosystem (Mukoko consumer mini-apps, Nyuchi enterprise products, sister brands) installs from. Backed by a DB-first architecture (Supabase) and served as a shadcn-compatible API, every component is installable into any project with one command.
 
 ---
 
@@ -34,7 +34,7 @@ npx shadcn@latest add \
   https://mzizi.dev/api/v1/ui/data-table
 ```
 
-Every install carries the canonical typography (Noto Sans / Noto Serif / JetBrains Mono), the Five African Minerals palette, the layered architecture, the pill-button identity, and the 56px touch-target floor.
+Every install carries the canonical typography (Noto Sans / Noto Serif / JetBrains Mono), the Seven African Minerals palette, the layered architecture, the pill-button identity, and the 56px touch-target floor.
 
 ---
 
@@ -69,17 +69,21 @@ The standalone Cloudflare Worker variant (for consumers that don't want to go th
 
 ---
 
-## Five African Minerals
+## Seven African Minerals
 
-The design system is built on five colors named after African minerals — constant across light and dark mode:
+The design system is built on seven colors named after African minerals, each carrying a semantic **role** and grouped in two **families**. Values are DB-generated (Supabase `styling-minerals` → `pnpm tokens:sync`); the live, theme-adaptive swatches render at [mzizi.dev/tokens](https://mzizi.dev/tokens).
 
-| Mineral    | Hex       | CSS Variable         | Usage                              |
-| ---------- | --------- | -------------------- | ---------------------------------- |
-| Cobalt     | `#0047AB` | `--color-cobalt`     | Primary blue, links, CTAs          |
-| Tanzanite  | `#B388FF` | `--color-tanzanite`  | Purple accent, brand/logo          |
-| Malachite  | `#64FFDA` | `--color-malachite`  | Cyan accent, success states        |
-| Gold       | `#FFD740` | `--color-gold`       | Yellow accent, rewards, highlights |
-| Terracotta | `#D4A574` | `--color-terracotta` | Warm accent, community             |
+| Mineral    | Role         | Family     | CSS Variable         |
+| ---------- | ------------ | ---------- | -------------------- |
+| Cobalt     | Knowledge    | deep-earth | `--color-cobalt`     |
+| Tanzanite  | Identity     | deep-earth | `--color-tanzanite`  |
+| Malachite  | Growth       | deep-earth | `--color-malachite`  |
+| Sodalite   | Intelligence | deep-earth | `--color-sodalite`   |
+| Gold       | Value        | hand       | `--color-gold`       |
+| Terracotta | Community    | hand       | `--color-terracotta` |
+| Copper     | Stewardship  | hand       | `--color-copper`     |
+
+Alongside the minerals the palette carries **seven heritage tones** (indigo, savanna, baobab, sunset, river, hematite, kalahari), the **status** set (success/warning/info/error/neutral/offline/syncing), and the computed **Experimental Seven** (ember, acacia, fern, lagoon, storm, dusk, protea). See [mzizi.dev/tokens](https://mzizi.dev/tokens) for the full, live palette.
 
 **Buttons are always pill-shaped (`rounded-full`).** This is a brand identity decision — not a radius scale value.
 


### PR DESCRIPTION
## Summary

The palette shipped this cycle from **Five African Minerals** to a four-family colour system — **seven minerals** (each with a semantic role + `deep-earth`/`hand` family), **seven heritage** tones, the **status** set, and the computed **Experimental Seven** — surfaced live on `/tokens` and generated by `tokens:sync`. The written doctrine still described five minerals. This PR brings the docs in line with what ships.

## Changes

- **CLAUDE.md §7** — rewrote the colour-system section: seven minerals with roles + families + dark/light hexes, seven heritage tones, the status tokens, and the Experimental Seven (four computed tiers — text / UI / container / on-container). Documents that `tokens:sync` generates minerals + heritage from Supabase (`styling-minerals` / `styling-heritage-colors`) and that the Experimental block is currently hand-authored in `globals.css`.
- **CLAUDE.md §1 / §2 / §8.5 / §15.4** — "Five African Minerals" → "Seven".
- **README.md** — Seven Minerals table (role + family) + heritage/status/experimental note; intro lines updated.
- **CONTRIBUTING.md** — point contributors at `/tokens`; Seven-mineral palette rule.
- **.claude/skills** — `nyuchi-design-system.md` + `ecosystem-app-setup.md`: seven minerals with roles/families, dropped stale `brand_*` table names in favour of the `styling-*` collections, added sodalite + copper to the scaffold token block.

`§15.14` ("the mineral strip uses 5 mineral colors") was left unchanged — the portal's `MineralStrip` genuinely renders five accent bands; the palette having seven minerals doesn't change the strip.

## Type

- [x] Documentation
- [x] Brand/design system update (docs only)

## Pre-commit Gate (must pass locally before pushing)

- [x] `pnpm lint` — zero warnings
- [x] `pnpm typecheck` — zero errors
- [ ] `pnpm audit` — not run here (offline sandbox; npm registry unreachable). Docs-only change, no dependency delta.
- [x] `pnpm exec prettier --check` — lint-staged reformatted the staged files

## Quality Checklist

- [x] No hardcoded colors introduced in code — the mineral hexes shown in docs are the DB snapshot, labelled as such, with `/tokens` named as the live source
- [x] Brand wordmarks are lowercase

## Registry / Design System

- N/A — no Supabase `components` row, no `registry.json`, no `palette.generated.ts`, and no `globals.css` change. Pure documentation.

## Architecture / Docs

- [x] `CLAUDE.md` updated (colour-system doctrine)
- [ ] `CHANGELOG.md` — not touched; no released version cut here (maintainer's call)
- [ ] `openapi.yaml` — N/A (no API surface change)

## Follow-up (not in this PR)

The Experimental Seven `--exp-*` block and the status tokens are hand-authored in `globals.css`, outside the `tokens:generated` markers. Wiring `tokens:sync` to project them from `styling-experimental` (as it already does for minerals + heritage) is a code change and belongs in its own PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbhwRNvsW6Lbx5jf7H8TrE)_