### PR TITLE
feat(site): reframe the decoupled UI to the DNA double helix

### DIFF
--- a/app/api/v1/route.ts
+++ b/app/api/v1/route.ts
@@ -68,12 +68,12 @@ export async function GET() {
           architectureFrontendAxes: {
             href: "/api/v1/architecture/frontend/axes",
             description:
-              "Five axes of the 3D frontend architecture (X, Y, Z, Outside, Documentation).",
+              "Legacy axis-era route (per-axis summary). The model is the Mzizi DNA double helix — see /api/v1/architecture.",
           },
           architectureFrontendLayers: {
             href: "/api/v1/architecture/frontend/layers",
             description:
-              "Ten layers of the 3D frontend architecture (L1 tokens .. L10 documentation).",
+              "Legacy axis-era route (per-node detail). The model is the Mzizi DNA double helix — see /api/v1/architecture.",
           },
           ubuntuPillars: {
             href: "/api/v1/ubuntu/pillars",

--- a/components/landing/explore-section.tsx
+++ b/components/landing/explore-section.tsx
@@ -25,8 +25,8 @@ export async function ExploreSection() {
       external: false,
     },
     {
-      title: "3D architecture",
-      description: "The open ten-node frontend architecture across five axes.",
+      title: "Architecture",
+      description: "The open Mzizi DNA double helix — nodes on strands, plus cross-cutting rungs.",
       href: "/architecture",
       icon: Box,
       mineral: "bg-[var(--color-tanzanite)]",

--- a/components/landing/resilient-by-design-section.tsx
+++ b/components/landing/resilient-by-design-section.tsx
@@ -6,18 +6,18 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Section, SectionHeader } from "@/components/landing/section"
 
 /**
- * "Resilient by design" — explains the two outliers of the 3D frontend
- * architecture (Outside / fundi and Documentation) and why they exist.
+ * "Resilient by design" — explains two of the Mzizi DNA helix's cross-cutting
+ * rungs (N9 fundi and N10 documentation) and why they exist.
  *
  * Most design systems ship as a snapshot — frozen at release time, drift
- * sets in, security findings pile up, docs go stale. The Mzizi system
- * has two layers whose entire job is to prevent that:
+ * sets in, security findings pile up, docs go stale. The Mzizi helix has two
+ * rungs — cross-cutting base pairs that bridge both backbones — whose entire
+ * job is to prevent that:
  *
- *   - L9 fundi (Outside axis): the self-healing node. Actors outside the
- *     build path consume L8 assurance signals and remediate the root cause.
- *   - L10 documentation (Documentation axis): the system documents
- *     itself — every component and every version is in Supabase,
- *     served live, never copy-pasted into a static file.
+ *   - N9 fundi: the self-healing rung. It consumes N8 assurance signals and
+ *     remediates the root cause.
+ *   - N10 documentation: the system documents itself — every component and
+ *     every version is in Supabase, served live, never copy-pasted.
  *
  * Together they're why the system stays current and secure without
  * manual maintenance pressure.
@@ -29,11 +29,11 @@ export async function ResilientBySection() {
     <Section bordered>
       <SectionHeader
         eyebrow="Resilient by design"
-        title="Two outlier layers keep the system updated and secure"
-        sub="The 3D frontend architecture is ten layers across five axes. Eight of those layers build the product. Two sit outside the build path on purpose — they exist so the system never goes stale or insecure."
+        title="Two rungs keep the system current and secure"
+        sub="The Mzizi DNA helix has two backbones that build the product; two cross-cutting rungs — fundi and documentation — exist so the system never goes stale or insecure."
       />
 
-      {/* Interactive 3D explorer — five axes + ten layer nodes, click to inspect */}
+      {/* Interactive model explorer */}
       <div className="mt-12 mb-10 overflow-hidden">
         <Suspense
           fallback={
@@ -47,7 +47,7 @@ export async function ResilientBySection() {
       <div className="grid gap-4 sm:gap-6 lg:grid-cols-2">
         <article className="flex flex-col gap-4 rounded-2xl border border-border bg-background p-6 sm:p-8">
           <div className="flex items-center justify-between">
-            <span className="font-mono text-xs text-muted-foreground">L9 · OUTSIDE AXIS</span>
+            <span className="font-mono text-xs text-muted-foreground">N9 · RUNG</span>
             <span className="rounded-full bg-[var(--color-cobalt)]/10 px-2.5 py-0.5 font-mono text-[10px] font-medium text-[var(--color-cobalt)]">
               fundi
             </span>
@@ -56,19 +56,19 @@ export async function ResilientBySection() {
             Self-healing — failure becomes a learning event
           </h3>
           <p className="text-sm leading-relaxed text-muted-foreground">
-            Fundi (Shona for &quot;artisan&quot;) is the architecture node that lives outside the
-            build path. It defines where self-healing belongs in the 3D model: actors outside the
-            build consume the L8 assurance layer&apos;s runtime signals and remediate the root
-            cause, so a failure becomes a learning event rather than a user-facing incident.
+            Fundi (Shona for &quot;artisan&quot;) is a <strong>rung</strong> — a cross-cutting base
+            pair that bridges both backbones of the helix rather than sitting on a single strand. It
+            consumes the N8 assurance node&apos;s runtime signals and remediates the root cause, so
+            a failure becomes a learning event rather than a user-facing incident.
           </p>
           <ul className="space-y-1.5 text-sm leading-relaxed text-muted-foreground">
             <li className="flex gap-2">
               <span aria-hidden="true">→</span>
-              <span>Outside-the-build axis — distinct from the eight product layers</span>
+              <span>A cross-cutting rung — bridges both backbones, sits on neither strand</span>
             </li>
             <li className="flex gap-2">
               <span aria-hidden="true">→</span>
-              <span>Consumes L8 assurance signals; never sits inside a component</span>
+              <span>Consumes N8 assurance signals; never sits inside a component</span>
             </li>
             <li className="flex gap-2">
               <span aria-hidden="true">→</span>
@@ -83,15 +83,13 @@ export async function ResilientBySection() {
             href="/architecture"
             className="mt-auto inline-flex items-center gap-1.5 text-sm font-medium text-foreground hover:underline"
           >
-            The 3D architecture model <ArrowRight className="size-4" />
+            The DNA helix model <ArrowRight className="size-4" />
           </Link>
         </article>
 
         <article className="flex flex-col gap-4 rounded-2xl border border-border bg-background p-6 sm:p-8">
           <div className="flex items-center justify-between">
-            <span className="font-mono text-xs text-muted-foreground">
-              L10 · DOCUMENTATION AXIS
-            </span>
+            <span className="font-mono text-xs text-muted-foreground">N10 · RUNG</span>
             <span className="rounded-full bg-[var(--color-tanzanite)]/10 px-2.5 py-0.5 font-mono text-[10px] font-medium text-[var(--color-tanzanite)]">
               documentation
             </span>
@@ -134,7 +132,7 @@ export async function ResilientBySection() {
             href="/architecture"
             className="mt-auto inline-flex items-center gap-1.5 text-sm font-medium text-foreground hover:underline"
           >
-            The 3D architecture model <ArrowRight className="size-4" />
+            The DNA helix model <ArrowRight className="size-4" />
           </Link>
         </article>
       </div>
@@ -148,7 +146,7 @@ export async function ResilientBySection() {
           <Link href="/architecture" className="underline hover:no-underline">
             the architecture page
           </Link>{" "}
-          for the full ten-layer model and{" "}
+          for the full helix model and{" "}
           <a
             href="https://github.com/nyuchi/mzizi/blob/main/SECURITY.md"
             target="_blank"

--- a/components/ui/node-badge.tsx
+++ b/components/ui/node-badge.tsx
@@ -4,15 +4,15 @@ import { cn } from "@/lib/utils"
 
 // NODE BADGE
 //
-// Renders a single ecosystem node (N1–N10) as a pill, axis-coloured per
-// the `nyuchi-changelog-renderer` (registry) v2.0.0 convention.
+// Renders an ecosystem node/rung (N1–N11) as a pill, coloured by its
+// classification on the Mzizi DNA double helix (CLAUDE.md §6.2):
 //
-//   horizontal (N2, N3, N6, N7)            → Cobalt
-//   vertical   (N1, N4, N5)                → Tanzanite
-//   depth      (N8)                        → Malachite
-//   outlier    (N9, N10)                   → Gold
+//   core-guarantee (N2, N4, N5, N8)  → Cobalt      (nodes on the engineering strand)
+//   shipped        (N3, N6, N7)      → Tanzanite   (nodes on the engineering strand)
+//   swappable      (N1)              → Malachite   (node on the engineering strand)
+//   rung           (N9, N10, N11)    → Gold        (cross-cutting base pairs)
 //
-// The labels / axis mapping mirror CLAUDE.md §6.2.
+// There are no axes and no outliers. N-numbers are labels, not a sequence.
 
 const NODE_LABELS: Record<number, string> = {
   1: "Tokens",
@@ -25,28 +25,30 @@ const NODE_LABELS: Record<number, string> = {
   8: "Assurance",
   9: "Fundi",
   10: "Documentation",
+  11: "Discovery",
 }
 
-type NodeAxis = "horizontal" | "vertical" | "depth" | "outlier"
+type HelixClass = "core-guarantee" | "shipped" | "swappable" | "rung"
 
-const NODE_AXIS: Record<number, NodeAxis> = {
-  1: "vertical",
-  2: "horizontal",
-  3: "horizontal",
-  4: "vertical",
-  5: "vertical",
-  6: "horizontal",
-  7: "horizontal",
-  8: "depth",
-  9: "outlier",
-  10: "outlier",
+const NODE_CLASS: Record<number, HelixClass> = {
+  1: "swappable",
+  2: "core-guarantee",
+  3: "shipped",
+  4: "core-guarantee",
+  5: "core-guarantee",
+  6: "shipped",
+  7: "shipped",
+  8: "core-guarantee",
+  9: "rung",
+  10: "rung",
+  11: "rung",
 }
 
-const AXIS_COLOURS: Record<NodeAxis, string> = {
-  horizontal: "bg-[var(--color-cobalt)]/10 text-[var(--color-cobalt)]",
-  vertical: "bg-[var(--color-tanzanite)]/10 text-[var(--color-tanzanite)]",
-  depth: "bg-[var(--color-malachite)]/10 text-[var(--color-malachite)]",
-  outlier: "bg-[var(--color-gold)]/10 text-[var(--color-gold)]",
+const CLASS_COLOURS: Record<HelixClass, string> = {
+  "core-guarantee": "bg-[var(--color-cobalt)]/10 text-[var(--color-cobalt)]",
+  shipped: "bg-[var(--color-tanzanite)]/10 text-[var(--color-tanzanite)]",
+  swappable: "bg-[var(--color-malachite)]/10 text-[var(--color-malachite)]",
+  rung: "bg-[var(--color-gold)]/10 text-[var(--color-gold)]",
 }
 
 export interface NodeBadgeProps extends React.ComponentProps<"span"> {
@@ -54,17 +56,18 @@ export interface NodeBadgeProps extends React.ComponentProps<"span"> {
 }
 
 export function NodeBadge({ node, className, ...props }: NodeBadgeProps) {
-  const axis = NODE_AXIS[node] ?? "horizontal"
+  const cls = NODE_CLASS[node] ?? "core-guarantee"
   const label = NODE_LABELS[node] ?? "Unknown"
+  const kind = cls === "rung" ? "rung" : `${cls} strand`
   return (
     <span
       data-slot="node-badge"
       data-node={node}
-      data-axis={axis}
-      title={`N${node} — ${label} (${axis} axis)`}
+      data-helix-class={cls}
+      title={`N${node} — ${label} (${kind})`}
       className={cn(
         "inline-flex h-5 items-center rounded-full px-2 py-0.5 text-xs font-medium",
-        AXIS_COLOURS[axis],
+        CLASS_COLOURS[cls],
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

The registry + docs are already on the **DNA double helix** (nodes on strands + cross-cutting rungs, no axes, no outliers). This brings the **decoupled** portal surfaces in line and flags the data/viz-coupled piece for a follow-up.

## Changes

- **`components/ui/node-badge.tsx`** — axis → **helix classification**. Colours by class (core-guarantee → cobalt, shipped → tanzanite, swappable → malachite, rung → gold), added **N11 Discovery**, and N9/N10/N11 render as **rungs**. No "axis" language.
- **`components/landing/resilient-by-design-section.tsx`** — fundi (N9) + documentation (N10) reframed from "outlier layers on the Outside/Documentation axis" to cross-cutting **rungs** that bridge both backbones; "3D model" → "DNA helix".
- **`components/landing/explore-section.tsx`** — the "3D architecture / ten-node across five axes" card → "Architecture / DNA double helix — nodes on strands + rungs".
- **`app/api/v1/route.ts`** — the `frontend/{axes,layers}` discovery entries marked **legacy axis-era**, pointing at the DNA-helix model.

## Type

- [x] Bug fix (doctrine consistency)
- [x] Portal page
- [x] Brand/design system update

## Verification

- [x] `pnpm typecheck` — clean
- [x] `eslint` (all four files) — clean
- [x] `prettier --write` — formatted
- [ ] `pnpm audit` — offline sandbox; no dependency delta

## Flagged follow-up (its own PR — data + visualization coupled)

`app/architecture/page.tsx` + `components/landing/architecture-canvas.tsx` (the literal 3D **cube**) + `getArchitectureSnapshot` + the `/api/v1/architecture/frontend/*` routes all render the **axis model from the legacy `architecture_frontend_*` tables** (N1–N10 only; no strands, rungs, or N11). Reframing them faithfully needs (a) re-plumbing the data to the helix collections and (b) a new **helix visualization** replacing the cube — a real design + data effort. Left intact and marked legacy so nothing breaks in the meantime; I'll bring a proposal for the visualization.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbhwRNvsW6Lbx5jf7H8TrE)_