### PR TITLE
feat(site): rebuild the /architecture centerpiece as a 3D DNA double helix

### DIFF
--- a/app/architecture/page.tsx
+++ b/app/architecture/page.tsx
@@ -1,82 +1,141 @@
-import Link from "next/link"
-import { ArrowRight } from "lucide-react"
-import { getArchitectureSnapshot, isSupabaseConfigured } from "@/lib/db"
-import type { ArchitectureSnapshotAxis, ArchitectureSnapshotLayer } from "@/lib/db/types"
+import { Suspense } from "react"
+import { getHelixModel, isSupabaseConfigured } from "@/lib/db"
+import type { HelixNode, HelixStrand } from "@/lib/db/types"
+import { Skeleton } from "@/components/ui/skeleton"
+import { ArchitectureExplorer } from "@/components/landing/architecture-explorer"
 
 export const revalidate = 3600
 
 export const metadata = {
-  title: "Architecture — nyuchi design portal",
+  title: "Architecture — Mzizi DNA double helix",
   description:
-    "The Nyuchi 3D Architecture Model — five axes, ten layers, every count read live from Supabase. Doctrine that documents itself.",
+    "The Mzizi DNA double helix — two entwined backbones (engineering + meaning) held by cross-cutting rungs. Nodes on strands, no axes, no outliers. Every count read live from Supabase.",
 }
 
-const GEOMETRY_BADGE: Record<string, string> = {
-  horizontal: "bg-[var(--color-cobalt)]/10 text-[var(--color-cobalt)]",
-  vertical: "bg-[var(--color-tanzanite)]/10 text-[var(--color-tanzanite)]",
-  depth: "bg-[var(--color-malachite)]/10 text-[var(--color-malachite)]",
-  external: "bg-[var(--color-gold)]/10 text-[var(--color-gold)]",
+const STRAND_BADGE: Record<string, string> = {
+  "core-guarantee": "bg-[var(--color-cobalt)]/10 text-[var(--color-cobalt)]",
+  shipped: "bg-[var(--color-tanzanite)]/10 text-[var(--color-tanzanite)]",
+  swappable: "bg-[var(--color-malachite)]/10 text-[var(--color-malachite)]",
+  spine: "bg-[var(--color-copper)]/10 text-[var(--color-copper)]",
+  "genetic-code": "bg-[var(--color-terracotta)]/10 text-[var(--color-terracotta)]",
+  transcription: "bg-[var(--color-sodalite)]/10 text-[var(--color-sodalite)]",
+}
+const RUNG_BADGE = "bg-[var(--color-gold)]/10 text-[var(--color-gold)]"
+
+function strandBadge(strand: string): string {
+  return STRAND_BADGE[strand] ?? "bg-muted text-muted-foreground"
 }
 
-function geometryClass(geometry: string): string {
-  return GEOMETRY_BADGE[geometry] ?? "bg-muted text-muted-foreground"
-}
-
-function LayerCard({ layer }: { layer: ArchitectureSnapshotLayer }) {
+function NodeCard({ node }: { node: HelixNode }) {
   return (
-    <Link
-      href={`/architecture/layers/${layer.layer_number}`}
-      className="group flex flex-col gap-3 rounded-xl border border-border bg-background p-5 transition-colors hover:border-foreground/30 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-    >
+    <article className="flex flex-col gap-3 rounded-xl border border-border bg-background p-5">
       <div className="flex items-baseline justify-between gap-3">
         <span className="font-mono text-[10px] tracking-widest text-muted-foreground uppercase">
-          L{layer.layer_number} · {layer.sub_label}
+          {node.sub_label} · {node.title}
         </span>
         <span className="font-mono text-xs text-muted-foreground">
-          {layer.component_count} {layer.component_count === 1 ? "component" : "components"}
+          {node.component_count} {node.component_count === 1 ? "component" : "components"}
         </span>
       </div>
-      <h3 className="font-serif text-xl font-semibold text-foreground">{layer.title}</h3>
-      <p className="text-sm leading-relaxed text-muted-foreground">{layer.role}</p>
+      <p className="text-sm leading-relaxed text-muted-foreground">{node.role}</p>
       <p className="border-l-2 border-border pl-3 text-sm leading-relaxed text-foreground italic">
-        &ldquo;{layer.covenant}&rdquo;
+        &ldquo;{node.covenant}&rdquo;
       </p>
-      <span className="mt-auto inline-flex items-center gap-1 text-xs font-medium text-foreground opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
-        Open detail <ArrowRight className="size-3" />
-      </span>
-    </Link>
+    </article>
   )
 }
 
-function AxisSection({ axis }: { axis: ArchitectureSnapshotAxis }) {
-  const componentTotal = axis.layers.reduce((sum, layer) => sum + layer.component_count, 0)
-
+function StrandBlock({ strand, nodes }: { strand: HelixStrand; nodes: HelixNode[] }) {
+  const componentTotal = nodes.reduce((sum, n) => sum + n.component_count, 0)
   return (
-    <section className="border-t border-border pt-10 first:border-t-0 first:pt-0">
-      <header className="mb-6 flex flex-col gap-3 sm:mb-8">
+    <section className="rounded-2xl border border-border bg-muted/10 p-5 sm:p-6">
+      <header className="mb-5 flex flex-col gap-2">
         <div className="flex items-center gap-3">
           <span
-            className={`rounded-full px-2.5 py-0.5 font-mono text-[10px] font-medium tracking-widest uppercase ${geometryClass(
-              axis.geometry
+            className={`rounded-full px-2.5 py-0.5 font-mono text-[10px] font-medium tracking-widest uppercase ${strandBadge(
+              strand.name
             )}`}
           >
-            {axis.geometry}
+            {strand.name}
           </span>
           <span className="font-mono text-xs text-muted-foreground">
-            {axis.layers.length} {axis.layers.length === 1 ? "layer" : "layers"} · {componentTotal}{" "}
-            {componentTotal === 1 ? "component" : "components"}
+            {nodes.length === 0
+              ? "doctrine strand"
+              : `${nodes.length} ${nodes.length === 1 ? "node" : "nodes"} · ${componentTotal} ${
+                  componentTotal === 1 ? "component" : "components"
+                }`}
           </span>
         </div>
-        <h2 className="font-serif text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
-          {axis.name} — {axis.title}
-        </h2>
-        <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
-          <span className="text-foreground italic">{axis.metaphor}.</span> {axis.description}
+        <h3 className="font-serif text-xl font-semibold text-foreground">{strand.title}</h3>
+        <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground">
+          <span className="text-foreground italic">&ldquo;{strand.covenant}&rdquo;</span>{" "}
+          {strand.description}
         </p>
       </header>
-      <div className="grid gap-4 sm:gap-5 lg:grid-cols-2">
-        {axis.layers.map((layer) => (
-          <LayerCard key={layer.layer_number} layer={layer} />
+      {nodes.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {nodes
+            .slice()
+            .sort((a, b) => a.node_number - b.node_number)
+            .map((node) => (
+              <NodeCard key={node.node_number} node={node} />
+            ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function RungCard({ rung }: { rung: HelixNode }) {
+  return (
+    <article className="flex flex-col gap-3 rounded-xl border border-border bg-background p-5">
+      <div className="flex items-center justify-between gap-3">
+        <span className="font-mono text-[10px] tracking-widest text-muted-foreground uppercase">
+          {rung.sub_label} · {rung.title}
+        </span>
+        <span
+          className={`rounded-full px-2 py-0.5 font-mono text-[10px] font-medium ${RUNG_BADGE}`}
+        >
+          rung
+        </span>
+      </div>
+      <p className="text-sm leading-relaxed text-muted-foreground">{rung.description}</p>
+      <p className="border-l-2 border-border pl-3 text-sm leading-relaxed text-foreground italic">
+        &ldquo;{rung.covenant}&rdquo;
+      </p>
+    </article>
+  )
+}
+
+function BackboneSection({
+  title,
+  blurb,
+  strands,
+  nodesByStrand,
+}: {
+  title: string
+  blurb: string
+  strands: HelixStrand[]
+  nodesByStrand: Map<string, HelixNode[]>
+}) {
+  if (strands.length === 0) return null
+  return (
+    <section className="border-t border-border pt-10 first:border-t-0 first:pt-0">
+      <header className="mb-6 flex flex-col gap-2">
+        <h2 className="font-serif text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+          {title}
+        </h2>
+        <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
+          {blurb}
+        </p>
+      </header>
+      <div className="space-y-5">
+        {strands.map((strand) => (
+          <StrandBlock
+            key={strand.name}
+            strand={strand}
+            nodes={nodesByStrand.get(strand.name) ?? []}
+          />
         ))}
       </div>
     </section>
@@ -97,61 +156,80 @@ export default async function ArchitecturePage() {
           <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
             NEXT_PUBLIC_SUPABASE_ANON_KEY
           </code>{" "}
-          to render the live 3D architecture model.
+          to render the live DNA-helix model.
         </p>
       </article>
     )
   }
 
-  const axes = await getArchitectureSnapshot()
-  const totalLayers = axes.reduce((sum, axis) => sum + axis.layers.length, 0)
-  const totalComponents = axes.reduce(
-    (sum, axis) => sum + axis.layers.reduce((s, layer) => s + layer.component_count, 0),
-    0
-  )
+  const model = await getHelixModel()
+  const nodesByStrand = new Map<string, HelixNode[]>()
+  for (const node of model.nodes) {
+    if (!node.strand) continue
+    const list = nodesByStrand.get(node.strand) ?? []
+    list.push(node)
+    nodesByStrand.set(node.strand, list)
+  }
+  const engineeringStrands = model.strands.filter((s) => s.backbone === "engineering")
+  const meaningStrands = model.strands.filter((s) => s.backbone === "meaning")
+  const totalComponents = model.nodes.reduce((sum, n) => sum + n.component_count, 0)
 
   return (
     <article data-mdx className="mx-auto max-w-5xl py-8">
-      <header className="mb-10">
+      <header className="mb-8">
         <p className="mb-3 font-mono text-[11px] tracking-widest text-muted-foreground sm:text-xs">
-          3D ARCHITECTURE
+          DNA DOUBLE HELIX
         </p>
         <h1 className="mb-4 font-serif text-3xl font-bold tracking-tight text-foreground sm:text-4xl md:text-5xl">
-          Five axes. Ten layers. Doctrine that documents itself.
+          Two backbones. Cross-cutting rungs. No axes.
         </h1>
         <p className="max-w-2xl text-base leading-relaxed text-muted-foreground">
           Most component libraries are flat: primitives at the bottom, composed components above,
-          pages on top. That stack fails when the system needs to express concerns that don&apos;t
-          fit linearly — safety doesn&apos;t live above pages, it threads through every layer;
-          observability doesn&apos;t live below primitives, it watches the whole thing without being
-          inside it. The Nyuchi 3D model gives each kind of concern its own dimension.
+          pages on top. Mzizi is a <span className="text-foreground">double helix</span>. Two
+          entwined backbones run through it — an{" "}
+          <span className="text-foreground">engineering</span> backbone that builds the product and
+          a <span className="text-foreground">meaning</span> backbone that carries the doctrine —
+          held together by cross-cutting <span className="text-foreground">rungs</span>. Nodes sit
+          on strands; rungs bridge both. The node numbers (N1–N11) are labels, not a sequence, and
+          nothing lives &ldquo;outside.&rdquo;
         </p>
         <p className="mt-4 max-w-2xl text-sm leading-relaxed text-muted-foreground">
-          Every count below is read live from{" "}
+          Every element and count below is read live from{" "}
           <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
-            architecture_frontend_axes
-          </code>
-          ,{" "}
+            component_documents
+          </code>{" "}
+          (
           <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
-            architecture_frontend_layers
+            documentation-architecture-&#123;nodes,strands&#125;
           </code>
-          , and <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">components</code> —
-          never hardcoded. Click any layer card for its covenant, stakeholder, and implementation
-          rules.
+          ) — the single source of truth the MCP serves — never hardcoded. Click any bead or strand
+          chip in the model for its covenant and rules.
         </p>
 
-        <dl className="mt-6 grid grid-cols-3 gap-4 border-y border-border py-4 text-sm">
+        <dl className="mt-6 grid grid-cols-2 gap-4 border-y border-border py-4 text-sm sm:grid-cols-4">
           <div>
             <dt className="font-mono text-[10px] tracking-widest text-muted-foreground uppercase">
-              Axes
+              Nodes
             </dt>
-            <dd className="font-serif text-2xl font-semibold text-foreground">{axes.length}</dd>
+            <dd className="font-serif text-2xl font-semibold text-foreground">
+              {model.nodes.length}
+            </dd>
           </div>
           <div>
             <dt className="font-mono text-[10px] tracking-widest text-muted-foreground uppercase">
-              Layers
+              Rungs
             </dt>
-            <dd className="font-serif text-2xl font-semibold text-foreground">{totalLayers}</dd>
+            <dd className="font-serif text-2xl font-semibold text-foreground">
+              {model.rungs.length}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-mono text-[10px] tracking-widest text-muted-foreground uppercase">
+              Strands
+            </dt>
+            <dd className="font-serif text-2xl font-semibold text-foreground">
+              {model.strands.length}
+            </dd>
           </div>
           <div>
             <dt className="font-mono text-[10px] tracking-widest text-muted-foreground uppercase">
@@ -162,10 +240,52 @@ export default async function ArchitecturePage() {
         </dl>
       </header>
 
+      {/* Interactive 3D double-helix explorer */}
+      <div className="mb-12 overflow-hidden">
+        <Suspense
+          fallback={
+            <Skeleton className="h-[340px] w-full rounded-2xl border border-border sm:h-[440px]" />
+          }
+        >
+          <ArchitectureExplorer />
+        </Suspense>
+      </div>
+
       <div className="space-y-12">
-        {axes.map((axis) => (
-          <AxisSection key={axis.name} axis={axis} />
-        ))}
+        <BackboneSection
+          title="Engineering backbone"
+          blurb="The strands that build the product. Core guarantees travel unchanged; shipped components come in the box but evolve; swappable seams are the only defined fork points; the spine pre-wires it all."
+          strands={engineeringStrands}
+          nodesByStrand={nodesByStrand}
+        />
+        <BackboneSection
+          title="Meaning backbone"
+          blurb="The strands that carry the doctrine. The genetic code is the Ubuntu + Bundu sequence everything is read from; transcription stores every convention and decision as queryable data — not tribal knowledge."
+          strands={meaningStrands}
+          nodesByStrand={nodesByStrand}
+        />
+
+        {model.rungs.length > 0 && (
+          <section className="border-t border-border pt-10">
+            <header className="mb-6 flex flex-col gap-2">
+              <h2 className="font-serif text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+                Cross-cutting rungs
+              </h2>
+              <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
+                The base pairs that bridge both backbones. Bound to no single strand, they keep the
+                system healing, documented, and discoverable.
+              </p>
+            </header>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {model.rungs
+                .slice()
+                .sort((a, b) => a.node_number - b.node_number)
+                .map((rung) => (
+                  <RungCard key={rung.node_number} rung={rung} />
+                ))}
+            </div>
+          </section>
+        )}
       </div>
 
       <footer className="mt-16 rounded-2xl border border-border bg-muted/20 p-6 text-sm leading-relaxed text-muted-foreground">
@@ -173,15 +293,11 @@ export default async function ArchitecturePage() {
           Source of truth
         </p>
         <p>
-          The doctrine is the data. Layer covenants, stakeholders, and implementation rules live in
-          the database — relabel a layer with an{" "}
+          The doctrine is the data. Node covenants, strand groupings, and rung classifications live
+          in Supabase as documents — relabel one with an{" "}
           <code className="rounded bg-background px-1 py-0.5 font-mono text-xs">UPDATE</code> and
-          every consumer (this page, the API at{" "}
-          <code className="rounded bg-background px-1 py-0.5 font-mono text-xs">
-            /api/v1/architecture
-          </code>
-          , the MCP server, AI assistants) sees the new shape on the next read. No migration. No
-          drift.
+          every consumer (this page, the MCP server, AI assistants) sees the new shape on the next
+          read. No migration. No drift.
         </p>
       </footer>
     </article>

--- a/components/landing/architecture-canvas.tsx
+++ b/components/landing/architecture-canvas.tsx
@@ -3,119 +3,170 @@
 import { useMemo, useState } from "react"
 import { Canvas } from "@react-three/fiber"
 import { OrbitControls } from "@react-three/drei"
-import type { ArchitectureFrontendAxisRow, ArchitectureFrontendLayerRow } from "@/lib/db/types"
+import * as THREE from "three"
+import type { HelixModel, HelixNode, HelixStrand } from "@/lib/db/types"
 import { paletteColor } from "@/lib/tokens"
 
 // ──────────────────────────────────────────────────────────────────────
-// Geometry — coordinate convention
+// The Mzizi DNA double helix
 //
-//   X-axis (horizontal composition)  → world +X
-//   Y-axis (vertical infrastructure) → world +Y
-//   Z-axis (depth observation)       → world +Z
-//   Outside (fundi)                  → off-cube, +X +Y +Z corner
-//   Documentation                    → off-cube, -X +Y -Z corner
+//   Two backbones wind around the vertical axis, 180° out of phase:
+//     · engineering backbone — carries the eight build NODES (N1–N8),
+//       rendered as beads coloured by their strand class.
+//     · meaning backbone     — the doctrine backbone (genetic-code,
+//       transcription).
+//   Cross-cutting RUNGS (N9 fundi, N10 documentation, N11 discovery)
+//   are gold base pairs bridging both backbones — bound to no strand.
 //
-// Each layer is a small cube placed along its axis. Click a cube → set
-// the active layer; the HTML overlay below the canvas shows the row's
-// description, covenant, and rules. Mineral palette for the axis colours
-// keeps the picture brand-correct.
+// Click a bead (node or rung) or a strand chip to read its covenant,
+// description, and rules in the panel. There are no axes and no outliers.
+//
+// Raw hex is used for the WebGL materials — the §7.4 exception. Bead and
+// bridge colours come from the DB mineral snapshot via paletteColor() so
+// the picture stays brand-correct without hardcoding values.
 // ──────────────────────────────────────────────────────────────────────
 
-// Mineral palette for the axis colours — sourced from the DB token snapshot
-// so the picture stays brand-correct without hardcoding hex.
-const AXIS_COLOR: Record<string, string> = {
-  "X-axis": paletteColor("cobalt", "light"),
-  "Y-axis": paletteColor("malachite"),
-  "Z-axis": paletteColor("tanzanite"),
-  Outside: paletteColor("terracotta"),
-  Documentation: paletteColor("gold"),
+const R = 1.6 // backbone radius
+const H = 6.2 // total height
+const TURNS = 2 // full turns top-to-bottom
+const T_MARGIN = 0.07 // keep beads off the very tips
+
+function mineral(name: string): string {
+  try {
+    return paletteColor(name) // vivid dark-mode hex
+  } catch {
+    return "#8a8a8a"
+  }
 }
 
-// X-axis layers (2, 3, 6, 7) get spaced along +X.
-// Y-axis layers (1, 4, 5) get spaced along +Y.
-// Z-axis layer (8) sits along +Z.
-// Outside (9) sits at the far +X +Y +Z corner.
-// Documentation (10) sits at the far -X +Y -Z corner.
-function positionFor(layer: ArchitectureFrontendLayerRow): [number, number, number] {
-  // Tier order along each axis; index inside the tier determines spacing.
-  const X_LAYERS = [2, 3, 6, 7]
-  const Y_LAYERS = [1, 4, 5]
-  const Z_LAYERS = [8]
-  const span = (i: number, n: number, length = 4) =>
-    n === 1 ? 0 : -length / 2 + (i * length) / (n - 1)
+// Strand → mineral. Node beads inherit their strand's colour; the six
+// strand chips use the same map. Rungs are gold (they sit on no strand).
+const STRAND_COLOR: Record<string, string> = {
+  "core-guarantee": mineral("cobalt"),
+  shipped: mineral("tanzanite"),
+  swappable: mineral("malachite"),
+  spine: mineral("copper"),
+  "genetic-code": mineral("terracotta"),
+  transcription: mineral("sodalite"),
+}
+const RUNG_COLOR = mineral("gold")
+const BACKBONE_COLOR = "#6b6a66" // neutral — beads carry the palette
 
-  if (layer.axis_name === "X-axis") {
-    const i = X_LAYERS.indexOf(layer.layer_number)
-    return [span(i, X_LAYERS.length, 4.5), 0, 0]
-  }
-  if (layer.axis_name === "Y-axis") {
-    const i = Y_LAYERS.indexOf(layer.layer_number)
-    return [0, span(i, Y_LAYERS.length, 3.5), 0]
-  }
-  if (layer.axis_name === "Z-axis") {
-    const i = Z_LAYERS.indexOf(layer.layer_number)
-    return [0, 0, span(i, Z_LAYERS.length, 3.5) + 1.5]
-  }
-  if (layer.axis_name === "Outside") {
-    return [3, 2.2, 2.5] // off-cube, far +X +Y +Z
-  }
-  if (layer.axis_name === "Documentation") {
-    return [-3, 2.2, -2.5] // off-cube, far -X +Y -Z
-  }
-  return [0, 0, 0]
+function strandColor(strand: string | null | undefined): string {
+  return (strand && STRAND_COLOR[strand]) || "#8a8a8a"
 }
 
-interface AxisLineProps {
-  from: [number, number, number]
-  to: [number, number, number]
-  color: string
+// A point on a backbone at parameter t ∈ [0,1] and phase offset.
+function helixPoint(t: number, phase: number): THREE.Vector3 {
+  const y = (t - 0.5) * H
+  const theta = t * TURNS * Math.PI * 2 + phase
+  return new THREE.Vector3(Math.cos(theta) * R, y, Math.sin(theta) * R)
 }
 
-function AxisLine({ from, to, color }: AxisLineProps) {
-  // Render a thin cylinder between two points so it picks up scene
-  // lighting (lines from the deprecated <line> primitive don't shade).
-  const start = useMemo(() => from, [from])
-  const end = useMemo(() => to, [to])
-  const dir: [number, number, number] = [end[0] - start[0], end[1] - start[1], end[2] - start[2]]
-  const length = Math.sqrt(dir[0] ** 2 + dir[1] ** 2 + dir[2] ** 2)
-  const mid: [number, number, number] = [
-    (start[0] + end[0]) / 2,
-    (start[1] + end[1]) / 2,
-    (start[2] + end[2]) / 2,
-  ]
-  // Cylinder is built along Y by default; rotate to match dir.
-  // For the three primary axes the rotation is exact; for the outliers
-  // we just point from origin to the offset position.
-  const rotationFor = (): [number, number, number] => {
-    if (Math.abs(dir[0]) > 0 && dir[1] === 0 && dir[2] === 0) return [0, 0, Math.PI / 2]
-    if (dir[0] === 0 && dir[1] === 0 && Math.abs(dir[2]) > 0) return [Math.PI / 2, 0, 0]
-    if (dir[0] === 0 && Math.abs(dir[1]) > 0 && dir[2] === 0) return [0, 0, 0]
-    // Generic: rotate Y axis to point at end-from.
-    const yx = Math.atan2(dir[2], dir[0])
-    const yz = Math.atan2(Math.sqrt(dir[0] ** 2 + dir[2] ** 2), dir[1])
-    return [0, -yx, yz]
-  }
+// Evenly space n beads across the usable span of the helix.
+function tForIndex(i: number, n: number): number {
+  if (n <= 1) return 0.5
+  return T_MARGIN + (i * (1 - 2 * T_MARGIN)) / (n - 1)
+}
+
+function Backbone({ phase, color }: { phase: number; color: string }) {
+  const curve = useMemo(() => {
+    const pts: THREE.Vector3[] = []
+    const SAMPLES = 120
+    for (let i = 0; i <= SAMPLES; i++) pts.push(helixPoint(i / SAMPLES, phase))
+    return new THREE.CatmullRomCurve3(pts)
+  }, [phase])
 
   return (
-    <mesh position={mid} rotation={rotationFor()}>
-      <cylinderGeometry args={[0.02, 0.02, length, 12]} />
-      <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.35} />
+    <mesh>
+      <tubeGeometry args={[curve, 160, 0.05, 10, false]} />
+      <meshStandardMaterial
+        color={color}
+        emissive={color}
+        emissiveIntensity={0.15}
+        roughness={0.6}
+      />
     </mesh>
   )
 }
 
-interface LayerNodeProps {
-  layer: ArchitectureFrontendLayerRow
+// A rung: a gold bar bridging the two backbones at height t, with a
+// clickable bead at its midpoint (on the central axis).
+function Rung({ t, isActive, onClick }: { t: number; isActive: boolean; onClick: () => void }) {
+  const { mid, rotation, length } = useMemo(() => {
+    const a = helixPoint(t, 0)
+    const b = helixPoint(t, Math.PI)
+    const dir = b.clone().sub(a)
+    const len = dir.length()
+    const q = new THREE.Quaternion().setFromUnitVectors(
+      new THREE.Vector3(0, 1, 0),
+      dir.clone().normalize()
+    )
+    const e = new THREE.Euler().setFromQuaternion(q)
+    return {
+      mid: a.clone().add(b).multiplyScalar(0.5),
+      rotation: [e.x, e.y, e.z] as [number, number, number],
+      length: len,
+    }
+  }, [t])
+  const [hovered, setHovered] = useState(false)
+  const scale = isActive ? 1.45 : hovered ? 1.2 : 1
+
+  return (
+    <group>
+      <mesh position={mid} rotation={rotation}>
+        <cylinderGeometry args={[0.025, 0.025, length, 12]} />
+        <meshStandardMaterial
+          color={RUNG_COLOR}
+          emissive={RUNG_COLOR}
+          emissiveIntensity={isActive ? 0.6 : 0.3}
+        />
+      </mesh>
+      <group
+        position={mid}
+        onPointerOver={(e) => {
+          e.stopPropagation()
+          setHovered(true)
+          document.body.style.cursor = "pointer"
+        }}
+        onPointerOut={() => {
+          setHovered(false)
+          document.body.style.cursor = ""
+        }}
+        onClick={(e) => {
+          e.stopPropagation()
+          onClick()
+        }}
+      >
+        <mesh scale={scale}>
+          <octahedronGeometry args={[0.24, 0]} />
+          <meshStandardMaterial
+            color={RUNG_COLOR}
+            emissive={RUNG_COLOR}
+            emissiveIntensity={isActive ? 0.75 : hovered ? 0.5 : 0.28}
+            metalness={0.35}
+            roughness={0.35}
+          />
+        </mesh>
+      </group>
+    </group>
+  )
+}
+
+// A node bead on the engineering backbone.
+function NodeBead({
+  position,
+  color,
+  isActive,
+  onClick,
+}: {
+  position: THREE.Vector3
   color: string
   isActive: boolean
   onClick: () => void
-}
-
-function LayerNode({ layer, color, isActive, onClick }: LayerNodeProps) {
+}) {
   const [hovered, setHovered] = useState(false)
-  const position = useMemo(() => positionFor(layer), [layer])
-  const scale = isActive ? 1.4 : hovered ? 1.18 : 1
-
+  const scale = isActive ? 1.5 : hovered ? 1.22 : 1
   return (
     <group
       position={position}
@@ -134,11 +185,11 @@ function LayerNode({ layer, color, isActive, onClick }: LayerNodeProps) {
       }}
     >
       <mesh scale={scale}>
-        <boxGeometry args={[0.55, 0.55, 0.55]} />
+        <sphereGeometry args={[0.2, 24, 24]} />
         <meshStandardMaterial
           color={color}
           emissive={color}
-          emissiveIntensity={isActive ? 0.7 : hovered ? 0.45 : 0.2}
+          emissiveIntensity={isActive ? 0.7 : hovered ? 0.45 : 0.22}
           metalness={0.3}
           roughness={0.4}
         />
@@ -147,69 +198,77 @@ function LayerNode({ layer, color, isActive, onClick }: LayerNodeProps) {
   )
 }
 
-interface ArchitectureCanvasProps {
-  axes: ArchitectureFrontendAxisRow[]
-  layers: ArchitectureFrontendLayerRow[]
-}
-
 type Selection =
-  | { kind: "layer"; layer: ArchitectureFrontendLayerRow }
-  | { kind: "axis"; axis: ArchitectureFrontendAxisRow }
+  | { kind: "node"; node: HelixNode }
+  | { kind: "rung"; rung: HelixNode }
+  | { kind: "strand"; strand: HelixStrand }
   | null
 
-export function ArchitectureCanvas({ axes, layers }: ArchitectureCanvasProps) {
+export function ArchitectureCanvas({ model }: { model: HelixModel }) {
   const [selection, setSelection] = useState<Selection>(null)
-  const axesByName = useMemo(() => Object.fromEntries(axes.map((a) => [a.name, a])), [axes])
 
-  const PRIMARY_AXES: Array<{
-    name: string
-    from: [number, number, number]
-    to: [number, number, number]
-  }> = [
-    { name: "X-axis", from: [-2.6, 0, 0], to: [2.6, 0, 0] },
-    { name: "Y-axis", from: [0, -2, 0], to: [0, 2, 0] },
-    { name: "Z-axis", from: [0, 0, -1.2], to: [0, 0, 3.6] },
-  ]
-  const OUTLIER_AXES: Array<{
-    name: string
-    from: [number, number, number]
-    to: [number, number, number]
-  }> = [
-    { name: "Outside", from: [0, 0, 0], to: [3, 2.2, 2.5] },
-    { name: "Documentation", from: [0, 0, 0], to: [-3, 2.2, -2.5] },
-  ]
+  // Engineering nodes carry the beads (all eight are engineering strand),
+  // ordered by node number and spaced along the backbone.
+  const nodes = useMemo(
+    () => [...model.nodes].sort((a, b) => a.node_number - b.node_number),
+    [model.nodes]
+  )
+  const rungs = useMemo(
+    () => [...model.rungs].sort((a, b) => a.node_number - b.node_number),
+    [model.rungs]
+  )
+  const strandsByBackbone = useMemo(() => {
+    const eng = model.strands.filter((s) => s.backbone === "engineering")
+    const mean = model.strands.filter((s) => s.backbone === "meaning")
+    return { eng, mean }
+  }, [model.strands])
+
+  const nodePositions = useMemo(
+    () => nodes.map((_, i) => helixPoint(tForIndex(i, nodes.length), 0)),
+    [nodes]
+  )
+  // Rungs spaced across the mid band of the helix (they bridge, they
+  // don't sequence — even spacing reads as "cross-cutting").
+  const rungT = useMemo(() => {
+    const n = rungs.length
+    const LO = 0.2
+    const SPAN = 0.6
+    return rungs.map((_, i) => (n <= 1 ? 0.5 : LO + (i * SPAN) / (n - 1)))
+  }, [rungs])
 
   return (
     <div className="grid gap-4 sm:gap-6 lg:grid-cols-[2fr_1fr]">
-      <div className="relative h-[320px] overflow-hidden rounded-2xl border border-border bg-gradient-to-br from-background to-muted/30 sm:h-[420px]">
-        <Canvas camera={{ position: [5, 4, 6], fov: 45 }}>
-          <ambientLight intensity={0.55} />
+      <div className="relative h-[340px] overflow-hidden rounded-2xl border border-border bg-gradient-to-br from-background to-muted/30 sm:h-[440px]">
+        <Canvas camera={{ position: [5.5, 2.5, 6.5], fov: 45 }}>
+          <ambientLight intensity={0.6} />
           <directionalLight position={[6, 8, 4]} intensity={0.9} />
 
-          {/* Origin marker */}
-          <mesh>
-            <sphereGeometry args={[0.07, 16, 16]} />
-            <meshStandardMaterial color="#888" />
-          </mesh>
+          {/* Two backbones, 180° out of phase */}
+          <Backbone phase={0} color={BACKBONE_COLOR} />
+          <Backbone phase={Math.PI} color={BACKBONE_COLOR} />
 
-          {/* Primary axis beams (X, Y, Z) */}
-          {PRIMARY_AXES.map((a) => (
-            <AxisLine key={a.name} from={a.from} to={a.to} color={AXIS_COLOR[a.name]} />
+          {/* Cross-cutting rungs — gold base pairs */}
+          {rungs.map((rung, i) => (
+            <Rung
+              key={rung.node_number}
+              t={rungT[i]}
+              isActive={
+                selection?.kind === "rung" && selection.rung.node_number === rung.node_number
+              }
+              onClick={() => setSelection({ kind: "rung", rung })}
+            />
           ))}
 
-          {/* Outlier rays (Outside, Documentation) */}
-          {OUTLIER_AXES.map((a) => (
-            <AxisLine key={a.name} from={a.from} to={a.to} color={AXIS_COLOR[a.name]} />
-          ))}
-
-          {/* Layer nodes — clickable */}
-          {layers.map((layer) => (
-            <LayerNode
-              key={layer.layer_number}
-              layer={layer}
-              color={AXIS_COLOR[layer.axis_name] ?? "#888"}
-              isActive={selection?.kind === "layer" && selection.layer.id === layer.id}
-              onClick={() => setSelection({ kind: "layer", layer })}
+          {/* Node beads on the engineering backbone */}
+          {nodes.map((node, i) => (
+            <NodeBead
+              key={node.node_number}
+              position={nodePositions[i]}
+              color={strandColor(node.strand)}
+              isActive={
+                selection?.kind === "node" && selection.node.node_number === node.node_number
+              }
+              onClick={() => setSelection({ kind: "node", node })}
             />
           ))}
 
@@ -217,114 +276,159 @@ export function ArchitectureCanvas({ axes, layers }: ArchitectureCanvasProps) {
             enablePan={false}
             enableZoom
             minDistance={5}
-            maxDistance={14}
+            maxDistance={15}
             autoRotate={!selection}
             autoRotateSpeed={0.6}
           />
         </Canvas>
 
-        {/* Axis legend overlaid on the canvas */}
-        <div className="pointer-events-auto absolute bottom-3 left-3 flex flex-wrap gap-1.5">
-          {axes.map((axis) => (
+        {/* Strand chips — the six strands, grouped by backbone */}
+        <div className="pointer-events-auto absolute bottom-3 left-3 flex max-w-[calc(100%-1.5rem)] flex-wrap gap-1.5">
+          {model.strands.map((strand) => (
             <button
-              key={axis.id}
-              onClick={() => setSelection({ kind: "axis", axis })}
+              key={strand.name}
+              onClick={() => setSelection({ kind: "strand", strand })}
               className="inline-flex items-center gap-1.5 rounded-full border border-border bg-background/80 px-2.5 py-1 text-[11px] font-medium text-muted-foreground backdrop-blur transition-colors hover:text-foreground"
-              aria-pressed={selection?.kind === "axis" && selection.axis.id === axis.id}
+              aria-pressed={selection?.kind === "strand" && selection.strand.name === strand.name}
             >
               <span
                 aria-hidden="true"
                 className="size-2 rounded-full"
-                style={{ background: AXIS_COLOR[axis.name] ?? "#888" }}
+                style={{ background: STRAND_COLOR[strand.name] ?? "#8a8a8a" }}
               />
-              {axis.name}
+              {strand.title}
             </button>
           ))}
         </div>
       </div>
 
-      {/* HTML overlay panel — populated from the selected layer/axis */}
+      {/* Detail panel — populated from the selected node / rung / strand */}
       <aside
         aria-live="polite"
         className="flex flex-col gap-3 rounded-2xl border border-border bg-background p-5 sm:p-6"
       >
         {!selection && (
-          <div className="text-sm text-muted-foreground">
-            Click a node or an axis chip to read what it does. Drag to rotate; scroll to zoom. Data
-            is live from the Supabase{" "}
-            <code className="font-mono text-xs">architecture_frontend_*</code> tables — edit a row,
-            refresh the page, the model updates.
+          <div className="flex flex-col gap-3 text-sm text-muted-foreground">
+            <p>
+              Two backbones wind around the axis: the{" "}
+              <span className="text-foreground">engineering</span> backbone carries the eight build
+              nodes (beads, coloured by strand); the{" "}
+              <span className="text-foreground">meaning</span> backbone carries the doctrine
+              strands. The gold bars are cross-cutting{" "}
+              <span className="text-foreground">rungs</span> — fundi, documentation, discovery —
+              bridging both.
+            </p>
+            <p>
+              Click a bead or a strand chip to read it. Drag to rotate; scroll to zoom. The model is
+              live from Supabase <code className="font-mono text-xs">component_documents</code> —{" "}
+              <code className="font-mono text-xs">
+                documentation-architecture-&#123;nodes,strands&#125;
+              </code>{" "}
+              — the same source the MCP serves.
+            </p>
+            <p className="text-xs">
+              {nodes.length} nodes · {rungs.length} rungs · {model.strands.length} strands ·{" "}
+              {strandsByBackbone.eng.length} engineering / {strandsByBackbone.mean.length} meaning
+            </p>
           </div>
         )}
 
-        {selection?.kind === "axis" && (
+        {selection?.kind === "node" && (
           <>
             <header className="flex items-center justify-between gap-3">
               <div>
                 <p className="font-mono text-xs text-muted-foreground">
-                  AXIS · {selection.axis.geometry}
+                  {selection.node.sub_label} · {selection.node.strand} strand
                 </p>
-                <h3 className="font-serif text-lg font-semibold">
-                  {selection.axis.name} — {selection.axis.title}
-                </h3>
+                <h3 className="font-serif text-lg font-semibold">{selection.node.title}</h3>
               </div>
               <span
                 aria-hidden="true"
                 className="size-3 rounded-full"
-                style={{ background: AXIS_COLOR[selection.axis.name] ?? "#888" }}
+                style={{ background: strandColor(selection.node.strand) }}
               />
             </header>
-            <p className="text-sm leading-relaxed text-muted-foreground">
-              {selection.axis.description}
-            </p>
-            {selection.axis.metaphor && (
-              <p className="text-sm leading-relaxed text-muted-foreground italic">
-                {selection.axis.metaphor}
-              </p>
-            )}
-          </>
-        )}
-
-        {selection?.kind === "layer" && (
-          <>
-            <header className="flex items-center justify-between gap-3">
-              <div>
-                <p className="font-mono text-xs text-muted-foreground">
-                  L{selection.layer.layer_number} · {selection.layer.axis_name}
-                </p>
-                <h3 className="font-serif text-lg font-semibold">{selection.layer.title}</h3>
-              </div>
-              <span
-                aria-hidden="true"
-                className="size-3 rounded-full"
-                style={{
-                  background: AXIS_COLOR[selection.layer.axis_name] ?? "#888",
-                }}
-              />
-            </header>
-            <p className="text-sm leading-relaxed text-foreground">{selection.layer.description}</p>
+            <p className="text-sm leading-relaxed text-foreground">{selection.node.description}</p>
             <div className="rounded-xl bg-muted/60 px-3 py-2 text-xs leading-relaxed text-foreground italic">
-              “{selection.layer.covenant}”
+              “{selection.node.covenant}”
             </div>
-            {axesByName[selection.layer.axis_name]?.title && (
-              <p className="text-xs text-muted-foreground">
-                Lives on the{" "}
-                <span className="text-foreground">
-                  {axesByName[selection.layer.axis_name].title}
-                </span>{" "}
-                axis · stakeholder:{" "}
-                <span className="text-foreground">{selection.layer.stakeholder}</span>
-              </p>
-            )}
-            {selection.layer.implementation_rules?.length > 0 && (
+            <p className="text-xs text-muted-foreground">
+              On the <span className="text-foreground">{selection.node.backbone}</span> backbone ·
+              stakeholder: <span className="text-foreground">{selection.node.stakeholder}</span> ·{" "}
+              {selection.node.component_count}{" "}
+              {selection.node.component_count === 1 ? "component" : "components"}
+            </p>
+            {selection.node.implementation_rules.length > 0 && (
               <ul className="space-y-1 text-xs text-muted-foreground">
-                {selection.layer.implementation_rules.map((rule, i) => (
+                {selection.node.implementation_rules.map((rule, i) => (
                   <li key={i} className="flex gap-2">
                     <span aria-hidden="true">→</span>
                     <span>{rule}</span>
                   </li>
                 ))}
               </ul>
+            )}
+          </>
+        )}
+
+        {selection?.kind === "rung" && (
+          <>
+            <header className="flex items-center justify-between gap-3">
+              <div>
+                <p className="font-mono text-xs text-muted-foreground">
+                  {selection.rung.sub_label} · RUNG
+                </p>
+                <h3 className="font-serif text-lg font-semibold">{selection.rung.title}</h3>
+              </div>
+              <span
+                aria-hidden="true"
+                className="size-3 rounded-full"
+                style={{ background: RUNG_COLOR }}
+              />
+            </header>
+            <p className="text-sm leading-relaxed text-foreground">{selection.rung.description}</p>
+            <div className="rounded-xl bg-muted/60 px-3 py-2 text-xs leading-relaxed text-foreground italic">
+              “{selection.rung.covenant}”
+            </div>
+            <p className="text-xs text-muted-foreground">
+              A cross-cutting rung — bridges both backbones, bound to no strand · stakeholder:{" "}
+              <span className="text-foreground">{selection.rung.stakeholder}</span>
+            </p>
+            {selection.rung.implementation_rules.length > 0 && (
+              <ul className="space-y-1 text-xs text-muted-foreground">
+                {selection.rung.implementation_rules.map((rule, i) => (
+                  <li key={i} className="flex gap-2">
+                    <span aria-hidden="true">→</span>
+                    <span>{rule}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
+        )}
+
+        {selection?.kind === "strand" && (
+          <>
+            <header className="flex items-center justify-between gap-3">
+              <div>
+                <p className="font-mono text-xs text-muted-foreground">
+                  STRAND · {selection.strand.backbone} backbone
+                </p>
+                <h3 className="font-serif text-lg font-semibold">{selection.strand.title}</h3>
+              </div>
+              <span
+                aria-hidden="true"
+                className="size-3 rounded-full"
+                style={{ background: STRAND_COLOR[selection.strand.name] ?? "#8a8a8a" }}
+              />
+            </header>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              {selection.strand.description}
+            </p>
+            {selection.strand.covenant && (
+              <div className="rounded-xl bg-muted/60 px-3 py-2 text-xs leading-relaxed text-foreground italic">
+                “{selection.strand.covenant}”
+              </div>
             )}
           </>
         )}

--- a/components/landing/architecture-explorer.tsx
+++ b/components/landing/architecture-explorer.tsx
@@ -1,38 +1,37 @@
-import { getArchitectureFrontendAxes, getArchitectureFrontendLayers } from "@/lib/db"
+import { getHelixModel } from "@/lib/db"
 // Direct import is fine: `architecture-canvas.tsx` carries `"use client"`,
 // so Next.js evaluates it only in the browser. Three.js never runs during
 // SSR. Next.js automatically code-splits the client bundle.
 import { ArchitectureCanvas } from "./architecture-canvas"
 
 /**
- * Server wrapper for the interactive 3D architecture explorer.
+ * Server wrapper for the interactive DNA-helix architecture explorer.
  *
- * Fetches layer + axis rows from Supabase. If the tables are empty
- * (issue #46's DDL is applied but the out-of-band seed hasn't run),
- * renders an empty-state notice instead of a broken canvas. The canvas
- * itself is a client component — three.js never runs during SSR.
+ * Reads the live model from Supabase `component_documents`
+ * (`documentation-architecture-{nodes,strands}`) — the single source of
+ * truth the MCP serves. If the collections are empty, renders an
+ * empty-state notice instead of a broken canvas. The canvas itself is a
+ * client component — three.js never runs during SSR.
  */
 export async function ArchitectureExplorer() {
-  const [axes, layers] = await Promise.all([
-    getArchitectureFrontendAxes(),
-    getArchitectureFrontendLayers(),
-  ])
+  const model = await getHelixModel()
 
-  if (axes.length === 0 || layers.length === 0) {
+  if (model.nodes.length === 0 || model.strands.length === 0) {
     return (
       <div className="rounded-xl border border-border bg-muted/20 p-8 text-center text-sm text-muted-foreground">
-        The 3D architecture explorer needs{" "}
+        The DNA-helix explorer needs the{" "}
         <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
-          architecture_frontend_axes
+          documentation-architecture-nodes
         </code>{" "}
         and{" "}
         <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
-          architecture_frontend_layers
+          documentation-architecture-strands
         </code>{" "}
-        to be populated. See issue #46.
+        collections to be populated in{" "}
+        <code className="font-mono text-xs">component_documents</code>.
       </div>
     )
   }
 
-  return <ArchitectureCanvas axes={axes} layers={layers} />
+  return <ArchitectureCanvas model={model} />
 }

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -80,6 +80,9 @@ import type {
   LayerDetailRow,
   ArchitectureSnapshotAxis,
   ArchitectureSnapshotLayer,
+  HelixModel,
+  HelixNode,
+  HelixStrand,
   SkillRow,
   SkillSummary,
   UbuntuPillarRow,
@@ -1412,6 +1415,105 @@ export async function getArchitectureSnapshot(): Promise<ArchitectureSnapshotAxi
   }
 
   return Array.from(byAxis.values()).sort((a, b) => a.sort_order - b.sort_order)
+}
+
+/**
+ * Live per-node component counts via the `get_node_counts()` RPC, keyed
+ * by node number. Empty object if Supabase isn't configured.
+ */
+export async function getNodeCounts(): Promise<Record<number, number>> {
+  if (!isSupabaseConfigured()) return {}
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (getPublicClient() as any).rpc("get_node_counts")
+  if (error || !Array.isArray(data)) return {}
+  const counts: Record<number, number> = {}
+  for (const row of data as Array<{ ecosystem_node: number; component_count: number }>) {
+    if (typeof row?.ecosystem_node === "number") {
+      counts[row.ecosystem_node] = row.component_count ?? 0
+    }
+  }
+  return counts
+}
+
+/**
+ * The Mzizi DNA double helix — nodes (on engineering strands) + rungs
+ * (cross-cutting base pairs) + the six strands, read live from
+ * `component_documents` (`documentation-architecture-{nodes,strands}`),
+ * the single source of truth the MCP serves. Per-node component counts
+ * come from `get_node_counts()`. Returns empty arrays if Supabase isn't
+ * configured or the collections are empty — callers render an empty
+ * state. There are no axes and no outliers.
+ */
+export async function getHelixModel(): Promise<HelixModel> {
+  const empty: HelixModel = { nodes: [], rungs: [], strands: [] }
+  if (!isSupabaseConfigured()) return empty
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = getPublicClient() as any
+
+  const [nodeRes, strandRes, counts] = await Promise.all([
+    client
+      .from("component_documents")
+      .select("document")
+      .eq("collection", "documentation-architecture-nodes"),
+    client
+      .from("component_documents")
+      .select("document")
+      .eq("collection", "documentation-architecture-strands"),
+    getNodeCounts(),
+  ])
+
+  if (nodeRes.error || !Array.isArray(nodeRes.data)) return empty
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const read = (row: any) => (row?.document ?? {}) as Record<string, unknown>
+  const str = (v: unknown) => (typeof v === "string" ? v : "")
+  const num = (v: unknown) => (typeof v === "number" ? v : Number(v) || 0)
+
+  const strandRows: unknown[] = Array.isArray(strandRes?.data) ? strandRes.data : []
+  const strands: HelixStrand[] = strandRows
+    .map(read)
+    .map((d) => ({
+      name: str(d.strand) || str(d._id),
+      title: str(d.title),
+      backbone: str(d.backbone),
+      covenant: str(d.covenant),
+      description: str(d.description),
+      sort_order: num(d.sort_order),
+    }))
+    .sort((a, b) => a.sort_order - b.sort_order)
+
+  const backboneByStrand = new Map<string, string>(strands.map((s) => [s.name, s.backbone]))
+
+  const all: HelixNode[] = (nodeRes.data as unknown[])
+    .map(read)
+    .map((d) => {
+      const strand = d.strand == null ? null : str(d.strand)
+      const nodeNumber = num(d.node_number)
+      return {
+        node_number: nodeNumber,
+        sub_label: str(d.sub_label) || (nodeNumber ? `N${nodeNumber}` : ""),
+        title: str(d.title),
+        type: d.type === "rung" ? ("rung" as const) : ("node" as const),
+        strand,
+        backbone: strand ? (backboneByStrand.get(strand) ?? null) : null,
+        role: str(d.role),
+        covenant: str(d.covenant),
+        description: str(d.description),
+        stakeholder: str(d.stakeholder),
+        implementation_rules: Array.isArray(d.implementation_rules)
+          ? (d.implementation_rules as string[])
+          : [],
+        sort_order: num(d.sort_order) || nodeNumber,
+        component_count: counts[nodeNumber] ?? 0,
+      }
+    })
+    .sort((a, b) => a.sort_order - b.sort_order)
+
+  return {
+    nodes: all.filter((n) => n.type === "node"),
+    rungs: all.filter((n) => n.type === "rung"),
+    strands,
+  }
 }
 
 // ── Skills — issue #54 / #58 (FRD-15 Part A, `skills` table) ────────

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -859,6 +859,63 @@ export interface ArchitectureSnapshotAxis {
   sort_order: number
   layers: ArchitectureSnapshotLayer[]
 }
+
+// ── Architecture (Mzizi DNA double helix) — nodes on strands + rungs ──
+//
+// The live model lives in `component_documents` under the collections
+// `documentation-architecture-nodes` (11 docs: 8 nodes + 3 rungs) and
+// `documentation-architecture-strands` (6 docs). This is the single
+// source of truth the MCP already serves — no axes, no outliers. The
+// legacy `architecture_frontend_*` tables + their `/api/v1/architecture`
+// routes are retained (marked legacy) for unmigrated consumers.
+
+export type HelixStrandKey =
+  | "core-guarantee"
+  | "shipped"
+  | "swappable"
+  | "spine"
+  | "genetic-code"
+  | "transcription"
+
+export type HelixBackbone = "engineering" | "meaning"
+
+/** A backbone grouping (`documentation-architecture-strands`). */
+export interface HelixStrand {
+  name: HelixStrandKey | string
+  title: string
+  backbone: HelixBackbone | string
+  covenant: string
+  description: string
+  sort_order: number
+}
+
+/**
+ * A helix element from `documentation-architecture-nodes`. Both nodes
+ * (`type: "node"`, bound to one engineering strand) and rungs
+ * (`type: "rung"`, cross-cutting — `strand`/`backbone` null) share this
+ * shape; `getHelixModel()` splits them by `type`.
+ */
+export interface HelixNode {
+  node_number: number
+  sub_label: string
+  title: string
+  type: "node" | "rung"
+  strand: HelixStrandKey | string | null
+  backbone: HelixBackbone | string | null
+  role: string
+  covenant: string
+  description: string
+  stakeholder: string
+  implementation_rules: string[]
+  sort_order: number
+  component_count: number
+}
+
+export interface HelixModel {
+  nodes: HelixNode[]
+  rungs: HelixNode[]
+  strands: HelixStrand[]
+}
 //
 // Five Ubuntu Pillars (the spheres in which Ubuntu is lived) and Five
 // Ubuntu Principles (the operating rules that translate Ubuntu to software).


### PR DESCRIPTION
## Summary

The flagged follow-up from #178. That PR reframed the **decoupled** surfaces to the DNA helix and left the data + visualization-coupled unit intact (marked legacy) with a promise to bring a proposal. This is that work: the `/architecture` page and its 3D **cube** are rebuilt as a **DNA double helix**, reading live from the already-migrated helix collections.

Approach was confirmed before building: **3D double helix (Three.js)** + **read from the new helix collections in `component_documents`** (not a second copy in the legacy tables).

## Changes

- **`lib/db/{types,index}.ts`** — new `getHelixModel()` + `getNodeCounts()`. `getHelixModel` reads `documentation-architecture-{nodes,strands}` from `component_documents` (the single source of truth the MCP serves) and returns typed **nodes** (8, on engineering strands), **rungs** (3, cross-cutting), and **strands** (6, across the engineering + meaning backbones), with live per-node counts from the `get_node_counts()` RPC.
- **`components/landing/architecture-canvas.tsx`** — the 3D **cube** (X/Y/Z axes + two outlier rays) is replaced by a parametric **double helix**: two backbones 180° out of phase, node beads on the engineering backbone coloured by strand class (core-guarantee → cobalt, shipped → tanzanite, swappable → malachite), and **gold rungs** as base-pair bridges (fundi/documentation/discovery). Click a bead or a strand chip for its covenant, description, and rules.
- **`components/landing/architecture-explorer.tsx`** — feeds `getHelixModel()` instead of the legacy axes/layers; helix-shaped empty state.
- **`app/architecture/page.tsx`** — rewritten from axis-grouped sections to an **engineering-backbone** section (strands → their nodes), a **meaning-backbone** section (doctrine strands), and a **cross-cutting rungs** section, with the 3D helix embedded as the centerpiece. Headline: "Two backbones. Cross-cutting rungs. No axes."

## Registry (data)

- Migration `helix_fundi_node_drop_outlier_language` — the N9 **fundi** node document still described itself as a "self-healing **outlier** actor **outside the build**", which the new page + 3D panel render live, directly contradicting the "no outliers" doctrine. Rewritten to "the self-healing rung … bridges both backbones." No other live node/strand doc carries outlier/axis language.

## Type

- [x] Bug fix (doctrine consistency — page contradicted its own model + retired-doctrine drift in the registry)
- [x] Portal page
- [x] Brand/design system update

## Verification

- [x] `pnpm typecheck` — clean
- [x] `eslint` (all changed files) — clean
- [x] `prettier --write` — formatted
- [x] `pnpm test` — 85/85 pass
- [x] `pnpm build` — compiles + Pagefind postbuild succeeds
- [ ] `pnpm audit` — offline sandbox; no dependency delta

## Notes

- The legacy `architecture_frontend_*` tables and their `/api/v1/architecture/frontend/*` routes are **untouched** (already marked legacy in the discovery doc). They serve a separate, documented API contract with its own OpenAPI spec + tests; re-plumbing them is out of scope for the page rebuild and would break that contract. This PR moves the *page/canvas/explorer* onto the helix collections.
- `app/architecture/layers/[n]/page.tsx` is left in place (still legacy-backed) but no longer linked from the reframed page; the 3D explorer's detail panel is the interactive surface now.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbhwRNvsW6Lbx5jf7H8TrE)_