### PR TITLE
fix(tokens): resync 4.2.0 surface tokens (pitch/void/wash) + overlay drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -475,19 +475,25 @@ Minerals + heritage are **DB-generated**: `pnpm tokens:sync` projects the Supaba
 > **Values synced from the `nyuchi-tokens` registry (N1), April 2026 AAA-optimised swap.**
 > Surfaces were re-arranged: `background` is now the ambient page base, `card` is the content surface, `muted` is the deepest fill. Border/input alpha tightened to 0.06. Two new tokens added: `overlay` (modal/sheet surface) and `scrim` (modal backdrop).
 
-| Token                  | Light                 | Dark                     | Usage                         |
-| ---------------------- | --------------------- | ------------------------ | ----------------------------- |
-| `--background`         | `#F3F2EE`             | `#1B1A17`                | Ambient page base (L10% dark) |
-| `--foreground`         | `#141413`             | `#F5F5F4`                | Primary text                  |
-| `--card`               | `#FFFFFF`             | `#100F0E`                | Content surface (L6% dark)    |
-| `--muted`              | `#FAF9F5`             | `#050504`                | Deepest fill (L2% dark)       |
-| `--muted-foreground`   | `#494840`             | `#B2AFA8`                | Secondary text (AAA)          |
-| `--overlay`            | `#FFFFFF`             | `#252421`                | Modal / sheet surface (L14%)  |
-| `--scrim`              | `rgba(0,0,0,0.40)`    | `rgba(0,0,0,0.60)`       | Modal backdrop                |
-| `--border`             | `rgba(10,10,10,0.06)` | `rgba(255,255,255,0.06)` | Borders                       |
-| `--primary`            | `#141413`             | `#F5F5F4`                | Primary interactive           |
-| `--primary-foreground` | `#FFFFFF`             | `#1B1A17`                | Text on `--primary`           |
-| `--destructive`        | `#B3261E`             | `#F2B8B5`                | Error / danger                |
+| Token                  | Light                     | Dark                       | Usage                         |
+| ---------------------- | ------------------------- | -------------------------- | ----------------------------- |
+| `--background`         | `#F3F2EE`                 | `#1B1A17`                  | Ambient page base (L10% dark) |
+| `--foreground`         | `#141413`                 | `#F5F5F4`                  | Primary text                  |
+| `--card`               | `#FFFFFF`                 | `#100F0E`                  | Content surface (L6% dark)    |
+| `--muted`              | `#FAF9F5`                 | `#050504`                  | Deepest fill (L2% dark)       |
+| `--muted-foreground`   | `#494840`                 | `#B2AFA8`                  | Secondary text (AAA)          |
+| `--pitch`              | `#FAFAFA`                 | `#050505`                  | Highest surface (P2)          |
+| `--void`               | `#F8F8F7`                 | `#080807`                  | Near-highest surface (P3)     |
+| `--surface`            | `#EEEEEC`                 | `#131211`                  | Content surface rung (P7)     |
+| `--container`          | `#E5E4E1`                 | `#1E1D1A`                  | Container rung (P11)          |
+| `--overlay`            | `#E0DFDC`                 | `#23221F`                  | Modal / sheet surface (P13)   |
+| `--raised`             | `#D6D5D1`                 | `#2E2C29`                  | Raised rung (P17)             |
+| `--wash`               | `mix(surface, accent 7%)` | `mix(surface, accent 12%)` | Cover-colour page wash        |
+| `--scrim`              | `rgba(0,0,0,0.40)`        | `rgba(0,0,0,0.60)`         | Modal backdrop                |
+| `--border`             | `rgba(10,10,10,0.06)`     | `rgba(255,255,255,0.06)`   | Borders                       |
+| `--primary`            | `#141413`                 | `#F5F5F4`                  | Primary interactive           |
+| `--primary-foreground` | `#FFFFFF`                 | `#1B1A17`                  | Text on `--primary`           |
+| `--destructive`        | `#B3261E`                 | `#F2B8B5`                  | Error / danger                |
 
 **Chart colors** (theme-adaptive):
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -146,6 +146,9 @@
   --color-surface: var(--surface);
   --color-container: var(--container);
   --color-raised: var(--raised);
+  --color-pitch: var(--pitch);
+  --color-void: var(--void);
+  --color-wash: var(--wash);
 }
 
 /* Light mode — L1 tokens synced from nyuchi-tokens registry (April 2026).
@@ -204,7 +207,7 @@
   --accent: #faf9f5;
   --accent-foreground: #141413;
   --destructive: #b3261e;
-  --overlay: #ffffff;
+  --overlay: #e0dfdc;
   --overlay-foreground: #141413;
   --scrim: rgba(0, 0, 0, 0.4);
   --border: rgba(10, 10, 10, 0.06);
@@ -268,6 +271,10 @@
   --surface: #eeeeec;
   --container: #e5e4e1;
   --raised: #d6d5d1;
+  --pitch: #fafafa;
+  --void: #f8f8f7;
+  /* Cover wash — surface tinted with the active brand accent (~7% light). */
+  --wash: color-mix(in oklab, var(--surface) 93%, var(--brand-accent));
   /* Engineering dot-grid — subtle blueprint dots on the ambient base. */
   --dot-color: rgba(10, 10, 10, 0.05);
 }
@@ -328,7 +335,7 @@
   --accent: #050504;
   --accent-foreground: #f5f5f4;
   --destructive: #f2b8b5;
-  --overlay: #252421;
+  --overlay: #23221f;
   --overlay-foreground: #f5f5f4;
   --scrim: rgba(0, 0, 0, 0.6);
   --border: rgba(255, 255, 255, 0.06);
@@ -391,6 +398,10 @@
   --surface: #131211;
   --container: #1e1d1a;
   --raised: #2e2c29;
+  --pitch: #050505;
+  --void: #080807;
+  /* Cover wash — surface tinted with the active brand accent (~12% dark). */
+  --wash: color-mix(in oklab, var(--surface) 88%, var(--brand-accent));
   /* Engineering dot-grid — subtle blueprint dots on the ambient base. */
   --dot-color: rgba(255, 255, 255, 0.05);
 }

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -84,16 +84,16 @@ present today).
 managed schemas created automatically on any new project, so they are
 deliberately excluded:
 
-| Schema                | Managed by         |
-| --------------------- | ------------------ |
-| `auth`                | Supabase Auth      |
-| `storage`             | Supabase Storage   |
-| `realtime`            | Supabase Realtime  |
-| `graphql`, `graphql_public` | pg_graphql   |
-| `extensions`          | Postgres extensions |
-| `vault`               | Supabase Vault     |
-| `pgbouncer`           | connection pooler  |
-| `supabase_migrations` | Supabase internal  |
+| Schema                        | Managed by          |
+| ----------------------------- | ------------------- |
+| `auth`                        | Supabase Auth       |
+| `storage`                     | Supabase Storage    |
+| `realtime`                    | Supabase Realtime   |
+| `graphql`, `graphql_public`   | pg_graphql          |
+| `extensions`                  | Postgres extensions |
+| `vault`                       | Supabase Vault      |
+| `pgbouncer`                   | connection pooler   |
+| `supabase_migrations`         | Supabase internal   |
 
 If you ever add custom RLS on `storage.objects` or `auth.users`, those
 policies live outside `public` and must be captured separately.

--- a/supabase/functions/README.md
+++ b/supabase/functions/README.md
@@ -2,8 +2,8 @@
 
 Deno-runtime functions that run close to the database. One is scaffolded here:
 
-| Function    | Route (Supabase-prefixed)      | Purpose                                                                                              |
-| ----------- | ------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| Function    | Route (Supabase-prefixed)      | Purpose                                                                                                           |
+| ----------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
 | `analytics` | `POST /functions/v1/analytics` | Fire-and-forget ingest for `usage_events`. Replaces the inline `trackApiCall` / `trackMcpTool` path from Next.js. |
 
 Project ref: `grjsboqkaywpwatvrzmy` (`nyuchi_design_db`, region `ap-southeast-1`).


### PR DESCRIPTION
## Summary

Closes the two genuinely-remaining design-token gaps found while auditing the 4.2.0 surface-token work against the live Supabase `styling-semantic-colors` collection (the rest of #154's refresh — the 14 washed themes #156, the doctrine bump, and #160 — were verified already-shipped and are being closed as done, not re-implemented).

### #168 — `--overlay` drift + missing `--pitch`/`--void`
- `app/globals.css`: light `--overlay` was `#ffffff`, dark was `#252421`; both now match the DB `styling-semantic-colors` P13 value (`#e0dfdc` / `#23221f`).
- Added the `--pitch` (P2) and `--void` (P3) surface rungs in both `:root` and `.dark`, and registered `--color-pitch` / `--color-void` in the `@theme` block so utilities resolve.

### #155 — `--wash` cover token
- Added `--wash` in both themes as `color-mix(in oklab, var(--surface) 93%/88%, var(--brand-accent))` — surface tinted with the **active brand accent** (so nyuchi renders gold, mukoko tanzanite, etc., never a hardcoded hex), matching the new `wash` doc added to `styling-semantic-colors` (doctrineVersion 4.2.0, mirroring `scrim`'s envelope).
- Registered `--color-wash` in `@theme`.

### Docs + CI
- `CLAUDE.md` §7.1: synced the surface-token table with the added `--pitch`/`--void`/`--wash` rows and the corrected `--overlay` values.
- `supabase/README.md` + `supabase/functions/README.md`: aligned two pre-existing tables that started failing `MD060/table-column-style` after the markdownlint-cli2 0.23 bump — a CI-unblock, no content change.

## Verification
- `pnpm typecheck` — clean
- `pnpm build` — ✓ compiled successfully
- `pnpm test` — 85/85 pass
- `pnpm lint:colors` — clean (no hardcoded palette colours)
- `pnpm lint:md` — 0 issues
- `pnpm prettier --check` — clean

`--primary` and `--brand-accent` are deliberately unchanged: the portal's near-black primary and gold accent are correct; the DB's tanzanite `--primary` is the generic/mukoko default the nyuchi portal overrides.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbhwRNvsW6Lbx5jf7H8TrE)_