### PR TITLE
release: v1.0.0 — first public release of the Mzizi portal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ It serves the full stable registry across the **Mzizi DNA double helix** — two
 npx shadcn@latest add https://mzizi.dev/api/v1/ui/<component>
 ```
 
-**Version:** 4.1.8
+**Version:** 1.0.0
 
 **Live at:** mzizi.dev
 
@@ -257,7 +257,7 @@ design-portal/
 ├── vitest.config.ts, vitest.setup.ts
 ├── components.json                   # shadcn CLI configuration
 ├── next.config.mjs, tsconfig.json, postcss.config.mjs, eslint.config.mjs, .prettierrc
-└── package.json                      # v4.1.8 (the Next.js app at root)
+└── package.json                      # v1.0.0 (the Next.js app at root)
 ```
 
 > **Note on `registry.json`:** post-v4.0.26 the authoritative registry lives in the
@@ -892,8 +892,10 @@ Three workflows in `.github/workflows/`:
 
 ### Versioning
 
-- **Current version:** 4.1.8 (must match in `package.json`, `lib/mcp-server.ts` (`VERSION` const), the `changelog` table in Supabase, `components/landing/footer.tsx`, `components/landing/dashboard-sidebar.tsx`, `app/layout.tsx` (`softwareVersion`), `README.md`, and CLAUDE.md §1)
-- **Scheme:** `4.1.x` is the current internal pre-1.0-public iteration (the `4.1.0` DNA-helix reframe onward, tracked in the Supabase `changelog` table); `5.0.0` is the maintainers' call for the first public release
+- **Current version:** 1.0.0 (must match in `package.json`, `lib/mcp-server.ts` (`VERSION` const), the `changelog` table in Supabase, `components/landing/footer.tsx`, `components/landing/dashboard-sidebar.tsx`, `app/layout.tsx` (`softwareVersion`), `README.md`, and CLAUDE.md §1)
+- **Scheme (two independent tracks — do not conflate):**
+  - **Code SemVer** — the portal codebase versioned in `package.json` et al. **`1.0.0` is the first public release** of the Mzizi code. The prior `4.1.x` line was the internal pre-1.0 iteration; the portal is not published to npm, so resetting to `1.0.0` carries no backwards-version conflict. The next code major (`2.0.0`) is a maintainers' call.
+  - **Doctrine / IP line** — the design-system doctrine and tooling IP, currently at **v5**. This is the intellectual-property version (doctrine + Mzizi tooling maturity), tracked in the Supabase doctrine/`changelog` metadata, and is deliberately **decoupled** from the code SemVer. A code release bumps the SemVer; a doctrine revision bumps the IP line. (Component tokens still carry their own `doctrineVersion`, e.g. `4.2.0`, orthogonal to both.)
 - **Release process:**
   1. Update version in `package.json`
   2. Update the `VERSION` constant in `lib/mcp-server.ts`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CodeQL](https://github.com/nyuchi/design-portal/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/nyuchi/design-portal/security/code-scanning)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
-**Version:** 4.1.8 | **Live:** [mzizi.dev](https://mzizi.dev) | **Product docs:** [docs.bundu.org](https://docs.bundu.org) | **Engineering docs:** [docs.nyuchi.com](https://docs.nyuchi.com) | **Observability:** [mzizi.dev/observability](https://mzizi.dev/observability)
+**Version:** 1.0.0 | **Live:** [mzizi.dev](https://mzizi.dev) | **Product docs:** [docs.bundu.org](https://docs.bundu.org) | **Engineering docs:** [docs.nyuchi.com](https://docs.nyuchi.com) | **Observability:** [mzizi.dev/observability](https://mzizi.dev/observability)
 
 > The previous Mintlify docs site is retired — long-form docs now live at [docs.bundu.org](https://docs.bundu.org) (product) and [docs.nyuchi.com](https://docs.nyuchi.com) (engineering).
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -125,7 +125,7 @@ const jsonLd = {
       },
       description: SITE_DESCRIPTION,
       creator: { "@id": `${SITE_URL}/#organization` },
-      softwareVersion: "4.1.8",
+      softwareVersion: "1.0.0",
       downloadUrl: "https://mzizi.dev/api/v1/ui",
     },
   ],

--- a/components/landing/dashboard-sidebar.tsx
+++ b/components/landing/dashboard-sidebar.tsx
@@ -77,7 +77,7 @@ export function DashboardSidebar() {
       </SidebarContent>
 
       <SidebarFooter className="text-xs text-muted-foreground">
-        <span className="px-2 font-mono">v4.1.8</span>
+        <span className="px-2 font-mono">v1.0.0</span>
       </SidebarFooter>
 
       <SidebarRail />

--- a/components/landing/footer.tsx
+++ b/components/landing/footer.tsx
@@ -232,7 +232,7 @@ export function Footer() {
               Terms
             </a>
             <span aria-hidden="true">·</span>
-            <span className="font-mono text-xs">v4.1.8</span>
+            <span className="font-mono text-xs">v1.0.0</span>
           </div>
         </div>
       </div>

--- a/lib/mcp-server.ts
+++ b/lib/mcp-server.ts
@@ -19,7 +19,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import type { SupabaseClient } from "@supabase/supabase-js"
 import { z } from "zod"
 
-const VERSION = "4.1.8"
+const VERSION = "1.0.0"
 
 // ─── Result helpers ─────────────────────────────────────────────────────────
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mzizi",
-  "version": "4.1.8",
+  "version": "1.0.0",
   "private": true,
   "description": "Mzizi — an open-architecture project of the Bundu Foundation. Open 3D frontend architecture, component registry, and MCP server, operated and developed by Nyuchi.",
   "homepage": "https://mzizi.dev",


### PR DESCRIPTION
## Summary

First public release of the Mzizi design-portal codebase. Per the two-track version model:

- **Code SemVer → `1.0.0`** — the first public release of the portal codebase. The prior `4.1.x` line was the internal pre-1.0 iteration; the portal is not published to npm, so resetting to `1.0.0` carries no backwards-version conflict.
- **Doctrine / IP line stays at `v5`** — the design-system doctrine + Mzizi tooling IP version, deliberately decoupled from code SemVer.

## Changes
- Bump version `4.1.8 → 1.0.0` in lockstep across the eight tracked locations: `package.json`, `lib/mcp-server.ts` (`VERSION`), `components/landing/footer.tsx`, `components/landing/dashboard-sidebar.tsx`, `app/layout.tsx` (`softwareVersion`), `README.md`, and CLAUDE.md §1 (+ the directory-structure comment).
- Rewrite CLAUDE.md §14 **Versioning** to document the two independent tracks (code SemVer `1.0.0` vs doctrine/IP line `v5`), replacing the old "`5.0.0` is the first public release" language.
- Insert the `1.0.0` row into the Supabase `changelog` collection (`total_stable=315`, nodes 1–11), surfaced by `/api/v1/changelog` and `/changelog`.

## Verification
- `pnpm typecheck` — clean
- `pnpm test` — 85/85 pass
- `pnpm lint:md` — 0 issues
- `pnpm prettier --check` — clean
- Security audit (pre-commit) — no known vulnerabilities

Merge with `merge_method=merge`; tag `v1.0.0` after merge (the `release.yml` workflow validates the tag matches `package.json` and creates the GitHub release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbhwRNvsW6Lbx5jf7H8TrE)_