### PR TITLE
docs: deeper editorial pass — reconcile CONTRIBUTING/README/SECURITY/CLAUDE with the current repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,11 +149,12 @@ design-portal/
 │   └── pre-commit                    # lint-staged → typecheck → audit
 ├── __tests__/                        # Vitest test suite
 │   ├── playground-routes.test.ts     # /playground + /playground/[name] route surface
-│   └── api/
-│       ├── brand-route.test.ts       # /api/v1/brand response & headers
-│       ├── registry-route.test.ts    # /api/v1/ui registry integrity
-│       └── v1/
-│           └── architecture-routes.test.ts  # v1 route file existence
+│   ├── api/
+│   │   ├── architecture-routes.test.ts   # architecture route surface
+│   │   ├── brand-route.test.ts       # /api/v1/brand response & headers
+│   │   ├── registry-route.test.ts    # /api/v1/ui registry integrity
+│   │   └── v1/                        # architecture-routes + docs-route (410) tests
+│   └── components/                   # breadcrumbs, callout, dashboard-sidebar, toc render tests
 ├── app/                              # Next.js App Router
 │   ├── globals.css                   # Theme tokens + Tailwind imports (token SOURCE OF TRUTH)
 │   ├── layout.tsx                    # Root layout — Mzizi dashboard shell
@@ -828,17 +829,25 @@ If you genuinely need a category-level list for navigation or doc grouping, deri
 ```
 __tests__/
 ├── playground-routes.test.ts                    # /playground + /playground/[name] route surface
-└── api/
-    ├── brand-route.test.ts                      # /api/v1/brand response, headers, data
-    ├── registry-route.test.ts                   # /api/v1/ui registry integrity
-    └── v1/
-        └── architecture-routes.test.ts          # v1 route file existence; legacy routes removed
+├── api/
+│   ├── architecture-routes.test.ts              # architecture route surface
+│   ├── brand-route.test.ts                      # /api/v1/brand response, headers, data
+│   ├── registry-route.test.ts                   # /api/v1/ui registry integrity
+│   └── v1/
+│       ├── architecture-routes.test.ts          # v1 route file existence; legacy routes removed
+│       └── docs-route.test.ts                   # /api/v1/docs* HTTP 410 behaviour
+└── components/                                  # component rendering tests
+    ├── breadcrumbs.test.tsx
+    ├── callout.test.tsx
+    ├── dashboard-sidebar.test.tsx
+    └── toc.test.tsx
 ```
 
 ### What Tests Cover
 
-- **API routes:** Brand API returns the correct headers/status/payload shape; the registry response matches the shadcn schema; all expected v1 route files exist on disk; removed legacy routes are confirmed gone.
+- **API routes:** Brand API returns the correct headers/status/payload shape; the registry response matches the shadcn schema; all expected v1 route files exist on disk; removed legacy routes are confirmed gone; `/api/v1/docs*` returns HTTP 410.
 - **Portal pages:** `/playground` + `/playground/[name]` exist and render through the playground demo registry.
+- **Portal components:** breadcrumbs, callout, dashboard sidebar, and table-of-contents render correctly.
 
 ### Running Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Contributing to nyuchi design portal
+# Contributing to Mzizi
 
-Thank you for your interest in contributing to the nyuchi design portal -- the Nyuchi Design Portal.
+Thank you for your interest in contributing to **Mzizi** — the open component registry, brand system, and DNA-helix architecture portal for the bundu ecosystem (the `design-portal` repository).
 
-This guide covers everything you need to get started, from setting up your environment to submitting a pull request.
+This guide covers everything you need to get started, from setting up your environment to opening a pull request.
 
 ---
 
@@ -22,31 +22,24 @@ cd design-portal
 pnpm install
 ```
 
-The repo is a **pnpm workspace**. One `pnpm install` at the root resolves the Next.js app + every workspace package under `packages/`:
+The repo is a **pnpm workspace** — one `pnpm install` at the root installs everything. Today the workspace contains a single project: the Next.js portal app at the root. The published Mzizi tooling packages (the CLI, the `mzizi-skills` bundle, the standalone MCP worker, and the SDK) live in **[`nyuchi/mzizi-tools`](https://github.com/nyuchi/mzizi-tools)**, not here — see [CLAUDE.md §2](CLAUDE.md) for the split.
 
-| Package                                                         | Purpose                                                                     |
-| --------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| `packages/design-cli/` (`@nyuchi/design-cli`)                   | CLI binary — bootstraps consumer apps, wraps shadcn install, manages skills |
-| `packages/design-agent-skills/` (`@nyuchi/design-agent-skills`) | Published snapshot of the Supabase `skills` table                           |
-
-Useful workspace commands:
+Useful root commands:
 
 ```bash
-pnpm dev                                              # Next.js dev server (root)
-pnpm --filter @nyuchi/design-cli build                 # build only the CLI
-pnpm --filter @nyuchi/design-cli test                  # run the CLI's vitest
-pnpm --filter "./packages/*" build                     # build every package
-pnpm typecheck                                         # root (Next.js app only)
-pnpm typecheck:packages                                # every workspace package
-pnpm skills:sync                                       # regen packages/design-agent-skills/skills/* from Supabase
-pnpm skills:verify                                     # CI-style drift check (non-zero exit on drift)
+pnpm dev             # Next.js dev server
+pnpm typecheck       # typecheck the portal app
+pnpm test            # run the Vitest suite
+pnpm registry:sync   # regenerate registry.json from Supabase
+pnpm skills:sync     # refresh the skill snapshots from the Supabase `skills` table
+pnpm skills:verify   # CI-style drift check (non-zero exit on drift)
 ```
 
-Skill content lives in the Supabase `skills` table — never edit `.md` files in `packages/design-agent-skills/skills/` directly. See [CLAUDE.md §15.24](CLAUDE.md) for the four-paths-one-source doctrine.
+Skill content lives in the Supabase `skills` table — never hand-edit the generated `.md` snapshots. See [CLAUDE.md §15](CLAUDE.md) for the single-source-of-truth doctrine.
 
 ### 3. Set up the database (optional for UI work)
 
-The registry uses a DB-first architecture with Supabase. For component development and documentation work, you can run the portal without a database connection -- but API routes will not function.
+The registry uses a DB-first architecture with Supabase. For component development and documentation work, you can run the portal without a database connection — but API routes will not function.
 
 For full functionality:
 
@@ -79,18 +72,18 @@ git checkout -b feature/your-feature
 
 ### Before You Code
 
-1. **Read [CLAUDE.md](CLAUDE.md)** -- it is the definitive reference for this codebase, covering architecture, conventions, and the full design system specification
-1. **Understand the [Seven African Minerals design system](https://mzizi.dev/tokens)** -- all colors come from the mineral-named tokens (seven minerals + seven heritage tones + status + the Experimental Seven)
+1. **Read [CLAUDE.md](CLAUDE.md)** — it is the definitive reference for this codebase, covering architecture, conventions, and the full design system specification
+1. **Understand the [Seven African Minerals design system](https://mzizi.dev/tokens)** — all colors come from the mineral-named tokens (seven minerals + seven heritage tones + status + the Experimental Seven)
 1. **Browse existing components** in `components/ui/` to understand the CVA + Radix + cn() pattern
 1. **Check `registry.json`** before modifying components to understand the dependency graph
-1. **Understand the DB-first architecture** -- API routes read from Supabase, not hardcoded objects
+1. **Understand the DB-first architecture** — API routes read from Supabase, not hardcoded objects
 
 ### Key Principles
 
 - The registry is the **single source of truth** for the entire bundu ecosystem. Changes here propagate to every app that consumes the registry.
 - Every component must be **independently installable** via the shadcn CLI.
 - The **Seven African Minerals palette** (minerals + heritage + status + experimental) is the only approved color system. Never introduce colors outside the token system.
-- **Accessibility is mandatory** -- APCA 3.0 AAA contrast, 56px default / 48px minimum touch targets, keyboard navigation, screen reader support.
+- **Accessibility is mandatory** — APCA 3.0 AAA contrast, 56px default / 48px minimum touch targets, keyboard navigation, screen reader support.
 
 ---
 
@@ -98,28 +91,28 @@ git checkout -b feature/your-feature
 
 ### TypeScript
 
-- **Strict mode** -- no `any` without explicit justification in a comment
-- **Path alias** -- use `@/*` for imports (e.g., `import { cn } from "@/lib/utils"`)
-- **Named exports** -- `export { Button, buttonVariants }`, not `export default Button`
+- **Strict mode** — no `any` without explicit justification in a comment
+- **Path alias** — use `@/*` for imports (e.g., `import { cn } from "@/lib/utils"`)
+- **Named exports** — `export { Button, buttonVariants }`, not `export default Button`
 
 ### Styling
 
-- **Tailwind utility classes only** -- no inline styles, no CSS modules
-- **Never hardcode hex colors** -- use Tailwind classes backed by CSS custom properties from `globals.css`
-- **`cn()` for all className composition** -- never string concatenation
-- **CVA for variants** -- use class-variance-authority for any component with visual states
+- **Tailwind utility classes only** — no inline styles, no CSS modules
+- **Never hardcode hex colors** — use Tailwind classes backed by CSS custom properties from `globals.css`
+- **`cn()` for all className composition** — never string concatenation
+- **CVA for variants** — use class-variance-authority for any component with visual states
 
 ### File Conventions
 
 - **kebab-case** for file names: `button-group.tsx`, `date-range-picker.tsx`
 - **PascalCase** for component names: `ButtonGroup`, `DateRangePicker`
-- **All brand wordmarks lowercase** -- mukoko, nyuchi, shamwari, bundu, nhimbe
+- **All brand wordmarks lowercase** — mzizi, mukoko, nyuchi, shamwari, bundu, nhimbe
 - **`data-slot` attribute** on every component for CSS selection and identification
-- **`"use client"` only when necessary** -- components are React Server Components by default; add the directive only when using hooks, event handlers, or browser APIs
+- **`"use client"` only when necessary** — components are React Server Components by default; add the directive only when using hooks, event handlers, or browser APIs
 
 ### DB-First Architecture
 
-- All API routes read from Supabase -- never return hardcoded fallback data
+- All API routes read from Supabase — never return hardcoded fallback data
 - Database operations go through `lib/db/index.ts`
 - Types are defined in `lib/db/types.ts`
 - Seeding uses upsert (ON CONFLICT) for idempotency
@@ -170,7 +163,15 @@ function MyComponent({
 export { MyComponent, myComponentVariants }
 ```
 
-1. **Add an entry to `registry.json`**:
+1. **Upsert the component into the Supabase `components` table** — Supabase is the source of truth. Include `source_code`, `architecture_layer`, `category`, `dependencies`, `registry_dependencies`, and `status = 'stable'`. The portal serves it from the DB on the next request — no rebuild required.
+
+1. **Regenerate the registry snapshot.** `registry.json` is generated, never hand-edited (CLAUDE.md §15 rule 2); `pnpm registry:sync` rewrites it from Supabase and CI fails on drift via `pnpm registry:verify`:
+
+```bash
+pnpm registry:sync
+```
+
+The generated entry looks like this:
 
 ```json
 {
@@ -186,14 +187,6 @@ export { MyComponent, myComponentVariants }
     }
   ]
 }
-```
-
-1. **Upsert the component** into Supabase (`components` table). The portal serves it from the DB on the next request — no rebuild required.
-
-1. **Sync the registry snapshot** (regenerates `registry.json` + any committed portal primitives from Supabase; CI fails on drift via `pnpm registry:verify`):
-
-```bash
-pnpm registry:sync
 ```
 
 1. **Add tests** in `__tests__/components/`:
@@ -244,21 +237,23 @@ Blocks are complete page compositions (dashboards, login pages, settings panels,
 }
 ```
 
-1. **Seed the database and rebuild the registry** as with UI components.
+1. **Upsert into Supabase and run `pnpm registry:sync`** as with UI components.
 
 ---
 
 ## Adding a Portal Page
 
 The portal hosts the **functional** surfaces only — the component gallery
-(`/components`), the 3D architecture explorer (`/architecture`), and
+(`/components`), the DNA-helix architecture explorer (`/architecture`), and
 observability (`/observability`). Each is a standard Next.js App Router
 `page.tsx`.
 
 Long-form documentation (installation, CLI, theming, contributing, brand,
-foundations, patterns, registry internals) lives in the standalone Mzizi
-Mintlify docs site at <https://docs.bundu.org/mzizi> — not in this repo. To edit
-a guide, contribute to the Mintlify docs project instead.
+foundations, patterns, registry internals) lives in the standalone Astro
+Starlight docs sites — product docs at <https://docs.bundu.org> and engineering
+docs at <https://docs.nyuchi.com> — not in this repo. To edit a guide,
+contribute to those docs repos instead. (The previous Mintlify docs site is
+retired.)
 
 To add a new functional page to the portal:
 
@@ -281,11 +276,11 @@ pnpm test:watch       # Watch mode for development
 
 ### What to Test
 
-- **New components** -- rendering, variant application, accessibility attributes
-- **New API routes** -- response format, status codes, headers
-- **Brand data changes** -- integrity checks (minerals match globals.css hex values)
-- **Architecture data changes** -- data integrity validation
-- **Registry changes** -- all referenced files exist on disk, schema validation
+- **New components** — rendering, variant application, accessibility attributes
+- **New API routes** — response format, status codes, headers
+- **Brand data changes** — integrity checks (minerals match globals.css hex values)
+- **Architecture data changes** — data integrity validation
+- **Registry changes** — all referenced files exist on disk, schema validation
 
 ### Test Location
 
@@ -314,12 +309,14 @@ That's equivalent to:
 ```bash
 pnpm format:check    # prettier check (no writes)
 pnpm lint            # ESLint, zero warnings
+pnpm lint:colors     # guard against off-token hardcoded colors
 pnpm lint:md         # markdownlint-cli2
 pnpm lint:json       # every tracked JSON parses
 pnpm typecheck       # tsc --noEmit
 pnpm test            # vitest single run
 pnpm audit:check     # pnpm audit --audit-level=moderate
 pnpm registry:verify # CI fails if registry.json drifts from Supabase
+pnpm tokens:verify   # CI fails if the design tokens drift from Supabase
 pnpm build           # next build (terminal gate)
 ```
 
@@ -372,7 +369,7 @@ Tier 3 terminal:  Build                             (waits on all of the above)
 - [ ] New components are upserted into the Supabase `components` table; `pnpm registry:sync` regenerates `registry.json`
 - [ ] Tests added for new functionality
 - [ ] Accessibility reviewed (APCA contrast, 56px default / 48px minimum touch targets, keyboard nav)
-- [ ] Brand wordmarks are lowercase (`mukoko`, `nyuchi`, `shamwari`, `bundu`, `nhimbe`)
+- [ ] Brand wordmarks are lowercase (`mzizi`, `mukoko`, `nyuchi`, `shamwari`, `bundu`, `nhimbe`)
 - [ ] Buttons are pill-shaped (`rounded-full`)
 - [ ] Any security finding from `/security-review` is fixed in this PR (per CLAUDE.md §15 rule 22 — never deferred)
 
@@ -389,28 +386,23 @@ Tier 3 terminal:  Build                             (waits on all of the above)
 
 ## Versioning
 
-This project uses semantic versioning. The version number appears in **four places** that must stay in sync:
-
-1. `package.json` -- `version` field
-1. `lib/brand.ts` -- `BRAND_SYSTEM.version`
-1. `lib/architecture.ts` -- version reference
-1. `components/landing/footer.tsx` -- footer display
+This project uses semantic versioning; the current version is **1.0.0**. A version bump must be propagated to every surface listed in [CLAUDE.md §14](CLAUDE.md) — `package.json`, `lib/mcp-server.ts` (`VERSION`), the Supabase `changelog` row, `components/landing/footer.tsx`, `components/landing/dashboard-sidebar.tsx`, `app/layout.tsx` (`softwareVersion`), `README.md`, and CLAUDE.md §1 — which must all stay in sync.
 
 Only maintainers create version tags and releases. The release process:
 
-1. Update version in all four locations
-1. Commit: `git commit -m "Release vX.Y.Z"`
-1. Tag: `git tag vX.Y.Z`
-1. Push: `git push && git push --tags`
-1. GitHub Actions validates and creates the release automatically
+1. Update the version across every surface listed in CLAUDE.md §14.
+1. Insert a row into the Supabase `changelog` table for the new version.
+1. Commit and open a PR; merge with `merge_method=merge` (never squash).
+1. Tag `vX.Y.Z` and push the tag.
+1. GitHub Actions validates the tag against `package.json` and creates the release automatically.
 
 ---
 
 ## Reporting Issues
 
-- **Bugs** -- describe the problem, include steps to reproduce, expected vs actual behavior
-- **Feature requests** -- describe the use case and why it benefits the ecosystem
-- **Security vulnerabilities** -- see [SECURITY.md](SECURITY.md) for responsible disclosure
+- **Bugs** — describe the problem, include steps to reproduce, expected vs actual behavior
+- **Feature requests** — describe the use case and why it benefits the ecosystem
+- **Security vulnerabilities** — see [SECURITY.md](SECURITY.md) for responsible disclosure
 
 When filing issues, include:
 
@@ -426,7 +418,7 @@ When filing issues, include:
 We follow the Ubuntu philosophy: **"I am because we are."**
 
 - Be respectful and inclusive in all interactions
-- Value constructive feedback -- give it kindly, receive it graciously
+- Value constructive feedback — give it kindly, receive it graciously
 - Remember that this project serves a pan-African ecosystem with diverse users and contributors
 - Write code and documentation that is accessible and welcoming to newcomers
 - Assume good intent; ask clarifying questions before making judgments

--- a/README.md
+++ b/README.md
@@ -180,14 +180,16 @@ Raw data: `GET https://mzizi.dev/api/v1/stats` — licensed CC BY 4.0.
 | `pnpm test:watch`      | Vitest watch mode                                                                  |
 | `pnpm audit:check`     | `pnpm audit --audit-level=moderate` — same gate CI runs                            |
 | `pnpm registry:sync`   | Regenerate `registry.json` + committed primitives from Supabase                    |
-| `pnpm registry:verify` | Non-mutating drift check (run this if you've touched the DB)                       |
+| `pnpm registry:verify` | Non-mutating registry drift check (run this if you've touched the DB)              |
+| `pnpm tokens:sync`     | Regenerate the generated palette (`globals.css` + `palette.generated.ts`)          |
+| `pnpm tokens:verify`   | Non-mutating token drift check (run this if you've touched the DB palette)         |
 
 ### Run every CI gate before pushing
 
 ```bash
 pnpm check
-# = format:check && lint && lint:md && lint:json
-#   && typecheck && test && audit:check && registry:verify && build
+# = format:check && lint && lint:colors && lint:md && lint:json && typecheck
+#   && test && audit:check && registry:verify && tokens:verify && build
 ```
 
 If `pnpm check` is green, CI will be too.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-The Mzizi is the public registry + design system for the bundu ecosystem. It handles no end-user PII, but because it serves source code and AI instructions into downstream production apps (mukoko, nyuchi, nhimbe, shamwari, etc.), a supply-chain issue here can ripple out. Please report issues responsibly.
+Mzizi is the public registry and design system for the bundu ecosystem. It handles no end-user PII, but because it serves source code and AI instructions into downstream production apps (mukoko, nyuchi, nhimbe, shamwari, etc.), a supply-chain issue here can ripple out. Please report issues responsibly.
 
 ## Supported Versions
 
@@ -55,7 +55,7 @@ This policy covers anything the portal itself owns:
 
 - The Next.js app deployed to `mzizi.dev` (and `registry.mukoko.com`)
 - The registry API (`/api/v1/ui`, `/api/v1/ui/{name}`, `/api/v1/ui/{name}/{docs,versions}`, `/api/v1/stats`, `/api/v1/search`)
-- The content API (`/api/v1/changelog`, `/api/v1/ai/instructions`) — `/api/v1/docs/*` is HTTP 410 (long-form docs moved to repo MDX, see CLAUDE.md §15.18)
+- The content API (`/api/v1/changelog`, `/api/v1/ai/instructions`) — `/api/v1/docs/*` is HTTP 410 (long-form docs moved to the bundu-docs / nyuchi-docs Starlight sites, see CLAUDE.md §15.18)
 - The fundi self-healing surface (`/api/v1/fundi`, `/api/v1/fundi/{id}`, `/api/v1/fundi/stats`)
 - The brand + architecture APIs (`/api/v1/brand`, `/api/v1/ecosystem`, `/api/v1/data-layer`, `/api/v1/pipeline`, `/api/v1/sovereignty`)
 - The Model Context Protocol server at `/mcp` (Streamable HTTP)
@@ -107,7 +107,7 @@ The same checks that block a merge to `main` are runnable locally with one comma
 pnpm check
 ```
 
-This chains every CI gate — `format:check`, `lint`, `lint:md`, `lint:json`, `typecheck`, `test`, `audit:check`, `registry:verify`, `build` — and exits non-zero on the first failure. Run it before every push to keep contributions clean and tidy. See [`CONTRIBUTING.md`](CONTRIBUTING.md#before-submitting--run-the-same-gates-ci-runs) for the contributor workflow and one-time tooling setup.
+This chains every CI gate — `format:check`, `lint`, `lint:colors`, `lint:md`, `lint:json`, `typecheck`, `test`, `audit:check`, `registry:verify`, `tokens:verify`, `build` — and exits non-zero on the first failure. Run it before every push to keep contributions clean and tidy. See [`CONTRIBUTING.md`](CONTRIBUTING.md#before-submitting--run-the-same-gates-ci-runs) for the contributor workflow and one-time tooling setup.
 
 CI workflows that gate merge to `main`:
 


### PR DESCRIPTION
## Summary

Deeper editorial pass over the repo's top-level docs (the mzizi half of the cross-repo docs cleanup; the mzizi-tools half shipped as nyuchi/mzizi-tools#39). Docs-only — no `src`/app/registry changes. Brings the prose back in line with what the repo actually is: removes fabricated package references, aligns the command/CI-gate tables with the real scripts, and syncs the documented test layout with what's on disk.

## Changes

- **CONTRIBUTING.md** — retitled to "Contributing to Mzizi"; replaced the fabricated `packages/design-cli` + `packages/design-agent-skills` workspace table (no such packages — the CLI/skills/MCP worker/SDK live in `nyuchi/mzizi-tools`) with an accurate root-commands section; reworked "Adding a New Component" to lead with the Supabase upsert then `pnpm registry:sync` (registry.json is generated, never hand-edited — CLAUDE.md §15 rule 2); corrected retired-Mintlify guidance to point at the Astro Starlight sites (docs.bundu.org / docs.nyuchi.com); renamed the "3D" explorer to "DNA-helix"; replaced stale versioning surfaces (`lib/brand.ts`, `lib/architecture.ts` — neither exists) with the CLAUDE.md §14 propagation list; aligned the `pnpm check` expansion (adds `lint:colors`, `tokens:verify`); added `mzizi` to the wordmark lists; normalized `--` to em dashes.
- **README.md** — corrected the `pnpm check` expansion to match the real script and added `tokens:sync` / `tokens:verify` rows for parity with `registry:sync` / `registry:verify`.
- **SECURITY.md** — grammar fix ("The Mzizi is"), corrected the `/api/v1/docs*` note (long-form docs moved to the bundu-docs / nyuchi-docs Starlight sites, not "repo MDX"), aligned the `pnpm check` gate list.
- **CLAUDE.md** — synced the §5 directory tree and §13 test structure with what's on disk (`__tests__/components/*` render tests, `api/architecture-routes.test.ts`, `api/v1/docs-route.test.ts`) and added coverage notes for the docs-410 and component-render tests.

## Type

- [x] Documentation

## Pre-commit Gate

- [x] `pnpm exec prettier --check` — all four files formatted
- [x] `pnpm lint:md` (markdownlint-cli2) — 0 issues
- [x] `pnpm typecheck` — N/A (no code changed)

## Quality Checklist

- [x] No hardcoded colors introduced — pure documentation
- [x] Brand wordmarks are lowercase (`mzizi`, `mukoko`, `nyuchi`, `shamwari`, `bundu`, `nhimbe`)

## Registry / Design System

- N/A — no Supabase `components` row, no `registry.json`, no `globals.css` change. Documentation only.

## Architecture / Docs

- [x] `CLAUDE.md` updated (directory tree + test structure)
- [ ] `CHANGELOG.md` — not touched; no version cut here (maintainer's call)
- [ ] `openapi.yaml` — N/A (no API surface change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbhwRNvsW6Lbx5jf7H8TrE

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbhwRNvsW6Lbx5jf7H8TrE)_