### PR TITLE
feat(api)!: retire the axis routes — serve only the DNA double helix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -684,41 +684,43 @@ All responses include schema.org JSON-LD metadata (`@context`, `@type`) where ap
 
 **Common headers:** `Cache-Control: public, max-age=3600, s-maxage=86400`, `Access-Control-Allow-Origin: *` (except `/stats` which is `max-age=60, s-maxage=120` and `/health` which is `no-cache, no-store`).
 
-| Endpoint                                   | Description                                                                         | Landed in |
-| ------------------------------------------ | ----------------------------------------------------------------------------------- | --------- |
-| `GET /api/v1`                              | Discovery document — lists all resources                                            | —         |
-| `GET /api/v1/brand`                        | Brand system (minerals, typography, spacing, ecosystem)                             | —         |
-| `GET /api/v1/ui`                           | Component registry index                                                            | —         |
-| `GET /api/v1/ui/{name}`                    | Individual component (shadcn format, with source code)                              | —         |
-| `GET /api/v1/ui/{name}/docs`               | Component docs (use cases, variants, a11y)                                          | —         |
-| `GET /api/v1/ui/{name}/versions`           | Component version history                                                           | —         |
-| `GET /api/v1/ecosystem`                    | Architecture principles & framework decision                                        | —         |
-| `GET /api/v1/data-layer`                   | Local-first + cloud layer specification                                             | —         |
-| `GET /api/v1/pipeline`                     | Open data pipeline (Redpanda → Flink → Doris)                                       | —         |
-| `GET /api/v1/sovereignty`                  | Technology sovereignty assessments                                                  | —         |
-| `GET /api/v1/architecture`                 | Full architecture snapshot                                                          | —         |
-| `GET /api/v1/architecture/axes`            | Per-axis summary with live component counts                                         | —         |
-| `GET /api/v1/architecture/layers/{n}`      | Per-layer detail (covenant, rules, breakdown)                                       | —         |
-| `GET /api/v1/architecture/frontend/axes`   | **Legacy axis-era route** — per-axis summary; the model is now the DNA helix (§6.2) | —         |
-| `GET /api/v1/architecture/frontend/layers` | **Legacy axis-era route** — per-node detail; the model is now the DNA helix (§6.2)  | —         |
-| `GET /api/v1/ubuntu/pillars`               | 5 Ubuntu Pillars                                                                    | —         |
-| `GET /api/v1/ubuntu/principles`            | 5 Ubuntu Principles                                                                 | —         |
-| `GET /api/v1/docs`                         | **HTTP 410 Gone** — content moved to bundu-docs                                     | —         |
-| `GET /api/v1/docs/{slug}`                  | **HTTP 410 Gone** — see `/api/v1/docs` for the slug map                             | —         |
-| `GET /api/v1/changelog`                    | All releases (from `changelog` table)                                               | #107      |
-| `GET /api/v1/changelog/{version}`          | Single release                                                                      | #107      |
-| `GET /api/v1/ai/instructions`              | List AI instruction sets                                                            | —         |
-| `GET /api/v1/ai/instructions/{name}`       | Instruction set by target (mcp-server, claude, copilot)                             | —         |
-| `GET /api/v1/skills`                       | List published agent skills (lightweight, no body_mdx)                              | —         |
-| `GET /api/v1/skills/summary`               | Same shape as `/skills`; reserved for CLI update path                               | —         |
-| `GET /api/v1/skills/{name}`                | Single skill with full `body_mdx`                                                   | —         |
-| `GET /api/v1/search?q=`                    | Cross-resource search (components + docs + changelog)                               | —         |
-| `GET /api/v1/stats?days=`                  | Open-data usage metrics (CC BY 4.0) — backs `/observability`                        | #105      |
-| `GET /api/v1/health`                       | Service health check (`no-cache, no-store`)                                         | —         |
+| Endpoint                                   | Description                                                             | Landed in |
+| ------------------------------------------ | ----------------------------------------------------------------------- | --------- |
+| `GET /api/v1`                              | Discovery document — lists all resources                                | —         |
+| `GET /api/v1/brand`                        | Brand system (minerals, typography, spacing, ecosystem)                 | —         |
+| `GET /api/v1/ui`                           | Component registry index                                                | —         |
+| `GET /api/v1/ui/{name}`                    | Individual component (shadcn format, with source code)                  | —         |
+| `GET /api/v1/ui/{name}/docs`               | Component docs (use cases, variants, a11y)                              | —         |
+| `GET /api/v1/ui/{name}/versions`           | Component version history                                               | —         |
+| `GET /api/v1/ecosystem`                    | Architecture principles & framework decision                            | —         |
+| `GET /api/v1/data-layer`                   | Local-first + cloud layer specification                                 | —         |
+| `GET /api/v1/pipeline`                     | Open data pipeline (Redpanda → Flink → Doris)                           | —         |
+| `GET /api/v1/sovereignty`                  | Technology sovereignty assessments                                      | —         |
+| `GET /api/v1/architecture`                 | Full architecture snapshot                                              | —         |
+| `GET /api/v1/architecture/axes`            | **HTTP 410 Gone** — the axis model is retired; only the helix is served | —         |
+| `GET /api/v1/architecture/layers/{n}`      | Per-layer detail (covenant, rules, breakdown)                           | —         |
+| `GET /api/v1/architecture/frontend/axes`   | **HTTP 410 Gone** — retired with the axis model (§6.2)                  | —         |
+| `GET /api/v1/architecture/frontend/layers` | **HTTP 410 Gone** — retired with the axis/layer model (§6.2)            | —         |
+| `GET /api/v1/ubuntu/pillars`               | 5 Ubuntu Pillars                                                        | —         |
+| `GET /api/v1/ubuntu/principles`            | 5 Ubuntu Principles                                                     | —         |
+| `GET /api/v1/docs`                         | **HTTP 410 Gone** — content moved to bundu-docs                         | —         |
+| `GET /api/v1/docs/{slug}`                  | **HTTP 410 Gone** — see `/api/v1/docs` for the slug map                 | —         |
+| `GET /api/v1/changelog`                    | All releases (from `changelog` table)                                   | #107      |
+| `GET /api/v1/changelog/{version}`          | Single release                                                          | #107      |
+| `GET /api/v1/ai/instructions`              | List AI instruction sets                                                | —         |
+| `GET /api/v1/ai/instructions/{name}`       | Instruction set by target (mcp-server, claude, copilot)                 | —         |
+| `GET /api/v1/skills`                       | List published agent skills (lightweight, no body_mdx)                  | —         |
+| `GET /api/v1/skills/summary`               | Same shape as `/skills`; reserved for CLI update path                   | —         |
+| `GET /api/v1/skills/{name}`                | Single skill with full `body_mdx`                                       | —         |
+| `GET /api/v1/search?q=`                    | Cross-resource search (components + docs + changelog)                   | —         |
+| `GET /api/v1/stats?days=`                  | Open-data usage metrics (CC BY 4.0) — backs `/observability`            | #105      |
+| `GET /api/v1/health`                       | Service health check (`no-cache, no-store`)                             | —         |
 
-Routes outside `/api/v1/` (intentionally not part of the public v1 contract): `GET /api/openapi` (serves `openapi.yaml`), `GET /api/chaos/{name}` (N5/Y-axis chaos-injection), `GET /api/health/{name}` (per-resource health probe).
+Routes outside `/api/v1/` (intentionally not part of the public v1 contract): `GET /api/openapi` (serves `openapi.yaml`), `GET /api/chaos/{name}` (N5 resilience chaos-injection), `GET /api/health/{name}` (per-resource health probe).
 
-**Error responses:** 400 (invalid input), 404 (not found), 410 (gone — `/docs*`), 500 (server error), **503** (Supabase env vars missing — clear "Database not configured" message).
+**Error responses:** 400 (invalid input), 404 (not found), 410 (gone — `/docs*` and the retired axis routes), 500 (server error), **503** (Supabase env vars missing — clear "Database not configured" message).
+
+**Serve only the DNA double helix.** The axis model is retired and is not served anywhere — not at a route, not nested in a payload, not relabelled. `absence is the correct state for anything axis-shaped, not repair`: emitting strand data through a field named `axis_geometry` would look correct and teach the wrong model to every consumer downstream, which is how the drift started. The three axis routes above return 410 with a `migrated_to` map, matching the `/api/v1/docs*` precedent. `lib/db`'s `getAxesSummary` / `getArchitectureFrontendAxes` / `getArchitectureFrontendLayers` helpers and the `FrontendAxis` / `FrontendLayer` OpenAPI schemas are deleted rather than deprecated.
 
 The OpenAPI document is also served at `GET /api/openapi`.
 

--- a/__tests__/api/architecture-routes.test.ts
+++ b/__tests__/api/architecture-routes.test.ts
@@ -20,7 +20,13 @@ vi.mock("@/lib/metrics", () => ({
 // Real DB-backed assertions live in the live deploy smoke checks.
 
 type Resp = {
-  data: { error?: string; message?: string }
+  data: {
+    error?: string
+    message?: string
+    /** Retired routes name the model that replaced them. */
+    model?: string
+    migrated_to?: Record<string, string>
+  }
   status: number
   headers: Record<string, string>
 }
@@ -35,13 +41,52 @@ describe("GET /api/v1/architecture (no Supabase)", () => {
   })
 })
 
-describe("GET /api/v1/architecture/axes (no Supabase)", () => {
-  it("returns 503 with a clear 'not configured' message", async () => {
+// The axis routes are RETIRED, not merely legacy-labelled. Mzizi serves the DNA
+// double helix — nodes on two backbones held by cross-cutting rungs; there are
+// no axes and no outliers (§6.2). These assert 410 rather than 503 because the
+// answer no longer depends on whether Supabase is configured: there is nothing
+// to serve either way.
+describe("GET /api/v1/architecture/axes (retired)", () => {
+  it("returns 410 Gone with a helix pointer", async () => {
     const { GET } = await import("@/app/api/v1/architecture/axes/route")
     const r = (await GET()) as unknown as Resp
-    expect(r.status).toBe(503)
-    expect(r.data.error).toBe("Database not configured")
+    expect(r.status).toBe(410)
+    expect(r.data.error).toBe("Gone")
     expect(r.headers["Access-Control-Allow-Origin"]).toBe("*")
+  })
+
+  it("never emits axis-shaped DATA, only prose explaining the retirement", async () => {
+    const { GET } = await import("@/app/api/v1/architecture/axes/route")
+    const r = (await GET()) as unknown as Resp
+    // `message` is human-readable prose and legitimately says "axis" and
+    // "outliers" to explain WHY the route is gone. The assertion is about the
+    // structured payload: no geometry field, no axis rows, no outlier entries.
+    const { message: _prose, ...structured } = r.data
+    const blob = JSON.stringify(structured)
+    expect(blob).not.toMatch(/"geometry"/)
+    expect(blob).not.toMatch(/horizontal|vertical|outlier/i)
+    expect(blob).not.toMatch(/axis_|axes_/)
+    expect(r.data.model).toBe("mzizi-dna-helix")
+  })
+})
+
+describe("GET /api/v1/architecture/frontend/axes (retired)", () => {
+  it("returns 410 Gone", async () => {
+    const { GET } = await import("@/app/api/v1/architecture/frontend/axes/route")
+    const r = (await GET()) as unknown as Resp
+    expect(r.status).toBe(410)
+    expect(r.data.error).toBe("Gone")
+    expect(r.data.model).toBe("mzizi-dna-helix")
+  })
+})
+
+describe("GET /api/v1/architecture/frontend/layers (retired)", () => {
+  it("returns 410 Gone", async () => {
+    const { GET } = await import("@/app/api/v1/architecture/frontend/layers/route")
+    const r = (await GET()) as unknown as Resp
+    expect(r.status).toBe(410)
+    expect(r.data.error).toBe("Gone")
+    expect(r.data.model).toBe("mzizi-dna-helix")
   })
 })
 

--- a/app/api/v1/architecture/axes/route.ts
+++ b/app/api/v1/architecture/axes/route.ts
@@ -1,61 +1,48 @@
 import { NextResponse } from "next/server"
-import { createLogger } from "@/lib/observability"
-import { isSupabaseConfigured, getAxesSummary } from "@/lib/db"
 import { trackApiCall } from "@/lib/metrics"
 
-const logger = createLogger("architecture-axes-summary")
-
-const CORS_CACHE = {
-  "Cache-Control": "public, max-age=3600, s-maxage=86400",
+const CORS = {
   "Access-Control-Allow-Origin": "*",
+  "Cache-Control": "public, max-age=3600, s-maxage=86400",
 }
 
-const CORS = { "Access-Control-Allow-Origin": "*" }
-
-export const revalidate = 3600
-
 /**
- * GET /api/v1/architecture/axes
+ * GET /api/v1/architecture/axes — HTTP 410 Gone.
  *
- * One row per axis with `layer_count` and `component_count` joined live
- * from `architecture_frontend_layers` and `components`. Wraps the
- * `get_axes_summary()` SQL helper.
+ * The axis model is retired. Mzizi serves the **DNA double helix**: nodes on an
+ * engineering backbone and a meaning backbone, held by cross-cutting rungs.
+ * There are no axes, no outliers, no 3D and no X/Y/Z (§6.2).
+ *
+ * This route wrapped `get_axes_summary()`, which returned four rows —
+ * horizontal / vertical / depth / outlier — with `node_count` and
+ * `component_count` zeroed on every one, because the joins behind it stopped
+ * resolving after the helix migration. It served a retired model *and* hollow
+ * numbers.
+ *
+ * Retired rather than remapped: emitting strand data through a field named
+ * `axis_geometry` would look correct and teach the wrong model to every
+ * consumer that read it, which is how this drift started. Absence is the
+ * correct state for anything axis-shaped, not repair.
  */
 export async function GET() {
-  const start = Date.now()
-  try {
-    if (!isSupabaseConfigured()) {
-      trackApiCall({
-        endpoint: "/api/v1/architecture/axes",
-        durationMs: Date.now() - start,
-        statusCode: 503,
-      })
-      return NextResponse.json(
-        {
-          error: "Database not configured",
-          message: "Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.",
-        },
-        { status: 503, headers: CORS }
-      )
-    }
-
-    const axes = await getAxesSummary()
-    trackApiCall({
-      endpoint: "/api/v1/architecture/axes",
-      durationMs: Date.now() - start,
-      statusCode: 200,
-    })
-
-    return NextResponse.json({ data: axes, meta: { count: axes.length } }, { headers: CORS_CACHE })
-  } catch (error) {
-    logger.error("Axes summary error", {
-      error: error instanceof Error ? error : new Error(String(error)),
-    })
-    trackApiCall({
-      endpoint: "/api/v1/architecture/axes",
-      durationMs: Date.now() - start,
-      statusCode: 500,
-    })
-    return NextResponse.json({ error: "Internal server error" }, { status: 500, headers: CORS })
-  }
+  trackApiCall({
+    endpoint: "/api/v1/architecture/axes",
+    durationMs: 0,
+    statusCode: 410,
+  })
+  return NextResponse.json(
+    {
+      error: "Gone",
+      message:
+        "The axis model is retired. Mzizi serves the DNA double helix — nodes on an engineering and a meaning backbone, held by cross-cutting rungs. There are no axes and no outliers. This route previously returned four axis rows with every count zeroed.",
+      model: "mzizi-dna-helix",
+      migrated_to: {
+        architecture: "https://mzizi.dev/api/v1/architecture",
+        "node detail": "https://mzizi.dev/api/v1/architecture/layers/{n}",
+        "nodes (MCP)": "get_node_documents",
+        "per-node counts (MCP)": "get_node_counts",
+      },
+    },
+    { status: 410, headers: CORS }
+  )
 }

--- a/app/api/v1/architecture/frontend/axes/route.ts
+++ b/app/api/v1/architecture/frontend/axes/route.ts
@@ -1,57 +1,39 @@
 import { NextResponse } from "next/server"
-import { createLogger } from "@/lib/observability"
-import { isSupabaseConfigured, getArchitectureFrontendAxes } from "@/lib/db"
+import { trackApiCall } from "@/lib/metrics"
 
-const logger = createLogger("architecture-frontend-axes")
-
-const CORS_CACHE = {
-  "Cache-Control": "public, max-age=3600, s-maxage=86400",
+const CORS = {
   "Access-Control-Allow-Origin": "*",
+  "Cache-Control": "public, max-age=3600, s-maxage=86400",
 }
 
+/**
+ * GET /api/v1/architecture/frontend/axes — HTTP 410 Gone.
+ *
+ * Retired with the axis model. This route served one row per axis with a
+ * `geometry` field carrying `horizontal` / `vertical` / `depth` / `external`,
+ * which is the retired model by name and by shape.
+ *
+ * Mzizi serves the DNA double helix: nodes on two backbones held by
+ * cross-cutting rungs (§6.2). See /api/v1/architecture/axes for the same
+ * reasoning on why this is retired rather than remapped.
+ */
 export async function GET() {
-  try {
-    if (!isSupabaseConfigured()) {
-      return NextResponse.json(
-        {
-          error: "Database not configured",
-          message: "Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.",
-        },
-        { status: 503, headers: { "Access-Control-Allow-Origin": "*" } }
-      )
-    }
-
-    const rows = await getArchitectureFrontendAxes()
-
-    const axes = rows.map((r) => ({
-      name: r.name,
-      title: r.title,
-      description: r.description,
-      geometry: r.geometry,
-      metaphor: r.metaphor,
-      sortOrder: r.sort_order,
-    }))
-
-    logger.info("Frontend axes served", { data: { count: axes.length } })
-
-    return NextResponse.json(
-      {
-        "@context": "https://schema.org",
-        "@type": "ItemList",
-        name: "3D Frontend Architecture — Axes",
-        description:
-          "Five axes of the 3D frontend architecture: X (horizontal composition), Y (vertical infrastructure), Z (depth observation), Outside (actors beyond the build), Documentation (self-describing system).",
-        itemListElement: axes,
+  trackApiCall({
+    endpoint: "/api/v1/architecture/frontend/axes",
+    durationMs: 0,
+    statusCode: 410,
+  })
+  return NextResponse.json(
+    {
+      error: "Gone",
+      message:
+        "The axis model is retired. Mzizi serves the DNA double helix — nodes on an engineering and a meaning backbone, held by cross-cutting rungs. This route served axis rows with a horizontal/vertical/depth/external geometry field.",
+      model: "mzizi-dna-helix",
+      migrated_to: {
+        architecture: "https://mzizi.dev/api/v1/architecture",
+        "strands + nodes (MCP)": "get_node_documents",
       },
-      { headers: CORS_CACHE }
-    )
-  } catch (error) {
-    logger.error("Frontend axes API error", {
-      error: error instanceof Error ? error : new Error(String(error)),
-    })
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500, headers: { "Access-Control-Allow-Origin": "*" } }
-    )
-  }
+    },
+    { status: 410, headers: CORS }
+  )
 }

--- a/app/api/v1/architecture/frontend/layers/route.ts
+++ b/app/api/v1/architecture/frontend/layers/route.ts
@@ -1,61 +1,41 @@
 import { NextResponse } from "next/server"
-import { createLogger } from "@/lib/observability"
-import { isSupabaseConfigured, getArchitectureFrontendLayers } from "@/lib/db"
+import { trackApiCall } from "@/lib/metrics"
 
-const logger = createLogger("architecture-frontend-layers")
-
-const CORS_CACHE = {
-  "Cache-Control": "public, max-age=3600, s-maxage=86400",
+const CORS = {
   "Access-Control-Allow-Origin": "*",
+  "Cache-Control": "public, max-age=3600, s-maxage=86400",
 }
 
+/**
+ * GET /api/v1/architecture/frontend/layers — HTTP 410 Gone.
+ *
+ * Retired with the axis model. This route served `layerNumber` / `subLabel` /
+ * **`axisName`** per row — layer-era vocabulary, with each entry naming the axis
+ * it belonged to. The model is nodes on strands plus rungs; nothing belongs to
+ * an axis, because there are none.
+ *
+ * The replacement is `/api/v1/architecture/layers/{n}` for per-node detail and
+ * the MCP `get_node_documents` for the live node/strand documents. The path
+ * segment `layers` there is retained for URL stability only — it serves nodes.
+ */
 export async function GET() {
-  try {
-    if (!isSupabaseConfigured()) {
-      return NextResponse.json(
-        {
-          error: "Database not configured",
-          message: "Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.",
-        },
-        { status: 503, headers: { "Access-Control-Allow-Origin": "*" } }
-      )
-    }
-
-    const rows = await getArchitectureFrontendLayers()
-
-    const layers = rows.map((r) => ({
-      layerNumber: r.layer_number,
-      subLabel: r.sub_label,
-      title: r.title,
-      axisName: r.axis_name,
-      role: r.role,
-      description: r.description,
-      covenant: r.covenant,
-      stakeholder: r.stakeholder,
-      implementationRules: r.implementation_rules,
-      sortOrder: r.sort_order,
-    }))
-
-    logger.info("Frontend layers served", { data: { count: layers.length } })
-
-    return NextResponse.json(
-      {
-        "@context": "https://schema.org",
-        "@type": "ItemList",
-        name: "3D Frontend Architecture — Layers",
-        description:
-          "Ten layers of the 3D frontend architecture (L1 tokens through L10 documentation). Each layer belongs to exactly one axis.",
-        itemListElement: layers,
+  trackApiCall({
+    endpoint: "/api/v1/architecture/frontend/layers",
+    durationMs: 0,
+    statusCode: 410,
+  })
+  return NextResponse.json(
+    {
+      error: "Gone",
+      message:
+        "The axis/layer model is retired. Mzizi serves the DNA double helix — nodes on strands, held by cross-cutting rungs. This route served layerNumber/axisName rows, which assumed every unit belonged to an axis.",
+      model: "mzizi-dna-helix",
+      migrated_to: {
+        "node detail": "https://mzizi.dev/api/v1/architecture/layers/{n}",
+        architecture: "https://mzizi.dev/api/v1/architecture",
+        "nodes + strands (MCP)": "get_node_documents",
       },
-      { headers: CORS_CACHE }
-    )
-  } catch (error) {
-    logger.error("Frontend layers API error", {
-      error: error instanceof Error ? error : new Error(String(error)),
-    })
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500, headers: { "Access-Control-Allow-Origin": "*" } }
-    )
-  }
+    },
+    { status: 410, headers: CORS }
+  )
 }

--- a/app/api/v1/route.ts
+++ b/app/api/v1/route.ts
@@ -65,16 +65,6 @@ export async function GET() {
             href: "/api/v1/health",
             description: "Service health check — database and registry status.",
           },
-          architectureFrontendAxes: {
-            href: "/api/v1/architecture/frontend/axes",
-            description:
-              "Legacy axis-era route (per-axis summary). The model is the Mzizi DNA double helix — see /api/v1/architecture.",
-          },
-          architectureFrontendLayers: {
-            href: "/api/v1/architecture/frontend/layers",
-            description:
-              "Legacy axis-era route (per-node detail). The model is the Mzizi DNA double helix — see /api/v1/architecture.",
-          },
           ubuntuPillars: {
             href: "/api/v1/ubuntu/pillars",
             description: "Five Ubuntu pillars — spheres in which Ubuntu is lived.",

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -74,9 +74,6 @@ import type {
   ComponentVersionRow,
   McpToolRegistryRow,
   DesignTokens,
-  ArchitectureFrontendAxisRow,
-  ArchitectureFrontendLayerRow,
-  AxisSummaryRow,
   LayerDetailRow,
   ArchitectureSnapshotAxis,
   ArchitectureSnapshotLayer,
@@ -1286,51 +1283,6 @@ export async function getComponentLinks(name: string): Promise<ComponentLink[]> 
 // No in-code fallback dataset is kept — per doctrine, the DB is the only
 // source of truth and seeding happens out-of-band. Callers must tolerate
 // an empty array and render an empty state.
-
-/**
- * Live fetch from `architecture_frontend_axes`. Returns an empty array if
- * Supabase isn't configured or the table is empty — the DB is the single
- * source of truth and callers must tolerate an empty response.
- */
-export async function getArchitectureFrontendAxes(): Promise<ArchitectureFrontendAxisRow[]> {
-  if (!isSupabaseConfigured()) return []
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data, error } = await (getPublicClient() as any)
-    .from("architecture_frontend_axes")
-    .select("*")
-    .order("sort_order", { ascending: true })
-
-  if (error || !Array.isArray(data)) return []
-  return data as ArchitectureFrontendAxisRow[]
-}
-
-/**
- * Live fetch from `architecture_frontend_layers`. Returns an empty array
- * if Supabase isn't configured or the table is empty.
- */
-export async function getArchitectureFrontendLayers(): Promise<ArchitectureFrontendLayerRow[]> {
-  if (!isSupabaseConfigured()) return []
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data, error } = await (getPublicClient() as any)
-    .from("architecture_frontend_layers")
-    .select("*")
-    .order("layer_number", { ascending: true })
-
-  if (error || !Array.isArray(data)) return []
-  return data as ArchitectureFrontendLayerRow[]
-}
-
-/**
- * Per-axis summary with live `layer_count` and `component_count` joins.
- * Wraps the `get_axes_summary()` SQL helper.
- */
-export async function getAxesSummary(): Promise<AxisSummaryRow[]> {
-  if (!isSupabaseConfigured()) return []
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data, error } = await (getPublicClient() as any).rpc("get_axes_summary")
-  if (error || !Array.isArray(data)) return []
-  return data as AxisSummaryRow[]
-}
 
 /**
  * Single-layer detail (covenant, stakeholder, implementation rules,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: Mzizi API
   version: "1.0.0"
   description: |
-    The Mzizi API — components, brand, architecture, Ubuntu doctrine, the open 3D frontend
+    The Mzizi API — components, brand, architecture, Ubuntu doctrine, the open DNA-helix frontend
     model, and design system. Mzizi is an open-architecture project of the Bundu Foundation,
     operated and developed by Nyuchi.
 
@@ -38,7 +38,7 @@ tags:
   - name: Registry
     description: Component registry (shadcn-compatible)
   - name: Architecture
-    description: Ecosystem architecture, data layer, pipeline, sovereignty, 3D frontend axes/layers
+    description: Ecosystem architecture, data layer, pipeline, sovereignty, the DNA-helix frontend model
   - name: Ubuntu
     description: Ubuntu doctrine — Five Pillars and Five Principles
   - name: Content
@@ -326,16 +326,18 @@ paths:
 
   /architecture:
     get:
-      summary: 3D Architecture snapshot
+      summary: Architecture snapshot (DNA double helix)
       description: |
-        Full snapshot of the Nyuchi 3D Architecture model — every axis with its layers,
-        covenants, stakeholders, implementation rules, and live component counts. Wraps
-        the `get_architecture()` SQL helper. ISR cache: 1 hour.
+        Full snapshot of the Mzizi DNA double helix — nodes on an engineering backbone
+        and a meaning backbone, held together by cross-cutting rungs, with their
+        covenants, stakeholders, implementation rules, and live component counts. There
+        are no axes and no outliers. Wraps the `get_architecture()` SQL helper.
+        ISR cache: 1 hour.
       operationId: getArchitectureSnapshot
       tags: [Architecture]
       responses:
         "200":
-          description: "Snapshot reshaped as `{ data: axes[].layers[], meta }`."
+          description: "Snapshot of the helix — strands with their nodes, plus the rungs."
           headers:
             Cache-Control:
               $ref: "#/components/headers/CachePublic"
@@ -359,15 +361,27 @@ paths:
 
   /architecture/axes:
     get:
-      summary: Per-axis summary with live counts
+      summary: Per-axis summary (retired)
       description: |
-        One row per axis with `layer_count` and `component_count` joined live from
-        `architecture_frontend_layers` and `components`. Wraps `get_axes_summary()`.
-      operationId: getAxesSummary
+        **HTTP 410 Gone — retired.** The axis model is retired. Mzizi serves the
+        DNA double helix: nodes on an engineering backbone and a meaning
+        backbone, held together by cross-cutting rungs. There are no axes, no
+        outliers, no 3D and no X/Y/Z.
+
+        Wrapped `get_axes_summary()`, which returned four rows — horizontal / vertical / depth / outlier — with every count zeroed after the helix migration.
+
+        Retired rather than remapped — emitting strand data through an
+        axis-shaped field would look correct and teach the wrong model to every
+        consumer that read it.
+
+        Replaced by:
+        - `GET /architecture` — the helix snapshot
+        - MCP `get_node_counts` — per-node counts
+      operationId: architecture-axes-gone
       tags: [Architecture]
       responses:
-        "200":
-          description: 5 axes ordered by sort_order.
+        "410":
+          description: Gone — the axis model is retired.
           headers:
             Cache-Control:
               $ref: "#/components/headers/CachePublic"
@@ -378,15 +392,18 @@ paths:
               schema:
                 type: object
                 properties:
-                  data:
-                    type: array
-                    items: { type: object }
-                  meta:
+                  error:
+                    type: string
+                    example: Gone
+                  message:
+                    type: string
+                  model:
+                    type: string
+                    example: mzizi-dna-helix
+                  migrated_to:
                     type: object
-                    properties:
-                      count: { type: integer }
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+                    additionalProperties:
+                      type: string
 
   /architecture/layers/{n}:
     get:
@@ -427,17 +444,27 @@ paths:
 
   /architecture/frontend/axes:
     get:
-      summary: Frontend Axes (3D)
+      summary: Frontend axes (retired)
       description: |
-        The five axes of the 3D frontend architecture: X (horizontal composition),
-        Y (vertical infrastructure), Z (depth observation), Outside (actors beyond
-        the build), Documentation (self-describing system). Sourced from the
-        `architecture_frontend_axes` table.
-      operationId: getFrontendAxes
+        **HTTP 410 Gone — retired.** The axis model is retired. Mzizi serves the
+        DNA double helix: nodes on an engineering backbone and a meaning
+        backbone, held together by cross-cutting rungs. There are no axes, no
+        outliers, no 3D and no X/Y/Z.
+
+        Served one row per axis with a `geometry` field carrying horizontal / vertical / depth / external.
+
+        Retired rather than remapped — emitting strand data through an
+        axis-shaped field would look correct and teach the wrong model to every
+        consumer that read it.
+
+        Replaced by:
+        - `GET /architecture` — the helix snapshot
+        - MCP `get_node_documents`
+      operationId: architecture-frontend-axes-gone
       tags: [Architecture]
       responses:
-        "200":
-          description: 3D frontend axes
+        "410":
+          description: Gone — the axis model is retired.
           headers:
             Cache-Control:
               $ref: "#/components/headers/CachePublic"
@@ -446,24 +473,44 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/FrontendAxesResponse"
-        "500":
-          $ref: "#/components/responses/InternalError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: Gone
+                  message:
+                    type: string
+                  model:
+                    type: string
+                    example: mzizi-dna-helix
+                  migrated_to:
+                    type: object
+                    additionalProperties:
+                      type: string
 
   /architecture/frontend/layers:
     get:
-      summary: Frontend Layers (3D)
+      summary: Frontend layers (retired)
       description: |
-        The ten layers of the 3D frontend architecture (L1 tokens .. L10 documentation).
-        Each layer belongs to exactly one axis. Sourced from the
-        `architecture_frontend_layers` table.
-      operationId: getFrontendLayers
+        **HTTP 410 Gone — retired.** The axis model is retired. Mzizi serves the
+        DNA double helix: nodes on an engineering backbone and a meaning
+        backbone, held together by cross-cutting rungs. There are no axes, no
+        outliers, no 3D and no X/Y/Z.
+
+        Served `layerNumber` / `subLabel` / `axisName` per row — layer-era vocabulary in which every unit belonged to an axis.
+
+        Retired rather than remapped — emitting strand data through an
+        axis-shaped field would look correct and teach the wrong model to every
+        consumer that read it.
+
+        Replaced by:
+        - `GET /architecture/layers/{n}` — per-node detail
+        - MCP `get_node_documents` — live node and strand documents
+      operationId: architecture-frontend-layers-gone
       tags: [Architecture]
       responses:
-        "200":
-          description: 3D frontend layers
+        "410":
+          description: Gone — the axis model is retired.
           headers:
             Cache-Control:
               $ref: "#/components/headers/CachePublic"
@@ -472,11 +519,20 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/FrontendLayersResponse"
-        "500":
-          $ref: "#/components/responses/InternalError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: Gone
+                  message:
+                    type: string
+                  model:
+                    type: string
+                    example: mzizi-dna-helix
+                  migrated_to:
+                    type: object
+                    additionalProperties:
+                      type: string
 
   /ubuntu/pillars:
     get:
@@ -1768,66 +1824,6 @@ components:
           type: string
         itemCount:
           type: integer
-
-    # ── 3D Frontend Architecture ──────────────────────────────────
-
-    FrontendAxis:
-      type: object
-      required: [name, title, description, geometry, metaphor, sortOrder]
-      properties:
-        name: { type: string, example: "x-axis" }
-        title: { type: string, example: "Horizontal Composition" }
-        description: { type: string }
-        geometry:
-          type: string
-          enum: [horizontal, vertical, depth, external]
-        metaphor: { type: string }
-        sortOrder: { type: integer }
-
-    FrontendAxesResponse:
-      type: object
-      required: ["@context", "@type", name, itemListElement]
-      properties:
-        "@context": { type: string, example: "https://schema.org" }
-        "@type": { type: string, example: "ItemList" }
-        name: { type: string }
-        description: { type: string }
-        itemListElement:
-          type: array
-          items:
-            $ref: "#/components/schemas/FrontendAxis"
-
-    FrontendLayer:
-      type: object
-      required: [layerNumber, subLabel, title, axisName, role, description, covenant, stakeholder]
-      properties:
-        layerNumber: { type: integer, minimum: 1, maximum: 10 }
-        subLabel: { type: string, example: "primitive" }
-        title: { type: string }
-        axisName: { type: string, example: "x-axis" }
-        role: { type: string }
-        description: { type: string }
-        covenant: { type: string }
-        stakeholder: { type: string }
-        implementationRules:
-          type: array
-          items: { type: string }
-        sortOrder: { type: integer }
-
-    FrontendLayersResponse:
-      type: object
-      required: ["@context", "@type", name, itemListElement]
-      properties:
-        "@context": { type: string }
-        "@type": { type: string, example: "ItemList" }
-        name: { type: string }
-        description: { type: string }
-        itemListElement:
-          type: array
-          items:
-            $ref: "#/components/schemas/FrontendLayer"
-
-    # ── Ubuntu doctrine ───────────────────────────────────────────
 
     UbuntuPillar:
       type: object


### PR DESCRIPTION
## ⚠️ Breaking, and left as a draft deliberately

Three public `v1` routes now return **HTTP 410 Gone**. That's a breaking change to a public API, so this is a draft for your review rather than something I'd land on your behalf.

| Route | Was serving |
| --- | --- |
| `/api/v1/architecture/axes` | 4 rows — horizontal / vertical / depth / outlier — with `node_count` **and** `component_count` zeroed on every one |
| `/api/v1/architecture/frontend/axes` | a `geometry` field carrying horizontal / vertical / depth / external |
| `/api/v1/architecture/frontend/layers` | `layerNumber` / `subLabel` / **`axisName`** — every unit belonging to an axis |

The first one is worth dwelling on: it was serving a **retired model *and* hollow numbers**. The joins behind `get_axes_summary()` stopped resolving after the helix migration, so it returned four confidently-shaped rows of zeros.

## Why 410 rather than a remap

Doctrine (§6.2): Mzizi serves the DNA double helix — nodes on an engineering backbone and a meaning backbone, held by cross-cutting rungs. No axes, no outliers, no 3D, no X/Y/Z. **Absence is the correct state for anything axis-shaped, not repair.**

The cheaper option was to keep the `axis_*` wire contract and emit strands underneath it. That's rejected: a field named `axis_geometry` returning a strand *looks* correct and teaches the wrong model to every consumer that reads it — which is how this drift started in the first place.

410 + `migrated_to` follows the precedent already in this repo for `/api/v1/docs*`, so consumers get a pointer instead of a bare 404. I followed the house pattern rather than inventing one.

## Dead code deleted, not deprecated

- **`lib/db`** — `getAxesSummary`, `getArchitectureFrontendAxes`, `getArchitectureFrontendLayers` had zero remaining consumers once the routes returned 410. Gone, along with their three row types.
- **`openapi.yaml`** — the `FrontendAxis` / `FrontendAxesResponse` / `FrontendLayer` / `FrontendLayersResponse` schemas (60 lines) were orphaned. Gone.

> One thing that fell out of this: `FrontendLayer` declared `layerNumber: { maximum: 10 }`. **The node cap was in the public API contract too**, not just the tool registry — so N11 was unrepresentable in the published spec.

## Contract and discovery kept in step (§15.19)

- `openapi.yaml`: three paths rewritten as documented 410s. Also corrected the top-level API description, the `Architecture` tag, and the `/architecture` summary — all three still said "3D" / "every axis with its layers".
- `/api/v1` discovery document: the two axis entries are **removed, not relabelled**. Retired routes shouldn't be advertised.
- `CLAUDE.md` §9: table updated, plus an explicit doctrine paragraph so nobody "restores" these later.

## Verified

`pnpm typecheck` exit 0 · **88 tests pass** · `eslint` clean · `prettier` clean · `openapi.yaml` parses as valid YAML, 30 paths, no orphan `$ref`s. Pre-commit hooks (lint-staged + typecheck + audit) passed.

`pnpm registry:verify` was **not** run — it needs Supabase credentials I don't have here. This PR touches no `registry.json` or `components/ui/*`, so it shouldn't be affected, but CI will confirm.

I added a test asserting the retired routes emit no axis-shaped data. My first version of it failed — the explanatory `message` legitimately says "no axes and no outliers", so a naive vocabulary check tripped on its own prose. Narrowed to assert on the **structured** payload (no `geometry` field, no axis rows, no `axis_*` keys) while letting the message explain itself.

## Still open elsewhere

`get_architecture()` itself still returns `{"rows":[]}` in the DB, and `get_system_health` still embeds the zeroed axis block inside the readiness probe. Both are function bodies in `mzizi_db` and tracked in `nyuchi/mzizi-tools` → `docs/registry-doctrine-drift.md` §20 (full 8-item axis inventory). This PR closes items 7 and 8 of that list.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_