### PR TITLE
feat(n11): move discovery component source onto disk — the pilot, and it found a bug

### DIFF
--- a/components/registry/n11-discovery/nyuchi-seo.tsx
+++ b/components/registry/n11-discovery/nyuchi-seo.tsx
@@ -1,0 +1,169 @@
+import type { Metadata } from "next"
+
+/* ═══════════════════════════════════════════════════════════════
+   NYUCHI SEO — Layer 6 Page Composition
+   Server-side metadata generation for Next.js App Router.
+   ═══════════════════════════════════════════════════════════════ */
+
+interface NyuchiSEOConfig {
+  title: string
+  description?: string
+  canonicalUrl?: string
+  ogImage?: string
+  ogType?: "website" | "article" | "profile" | "product"
+  twitterCard?: "summary" | "summary_large_image" | "player"
+  noIndex?: boolean
+  locale?: string
+  alternateLocales?: string[]
+  /** Schema.org structured data */
+  schema?: SchemaOrgData | SchemaOrgData[]
+}
+
+interface SchemaOrgData {
+  "@type": string
+  [key: string]: unknown
+}
+
+const BASE_URL = "https://mukoko.com"
+const SITE_NAME = "Mukoko"
+const DEFAULT_OG_IMAGE = "/og-default.png"
+
+/**
+ * Generate Next.js Metadata object from NyuchiSEOConfig.
+ * Use in page.tsx: export const metadata = generateMetadata({ title: "..." })
+ */
+export function generateMetadata(config: NyuchiSEOConfig): Metadata {
+  const {
+    title,
+    description,
+    canonicalUrl,
+    ogImage,
+    ogType = "website",
+    twitterCard = "summary_large_image",
+    noIndex = false,
+    locale = "en",
+    alternateLocales = [],
+  } = config
+  const fullTitle = `${title} — ${SITE_NAME}`
+  const image = ogImage || DEFAULT_OG_IMAGE
+  const url = canonicalUrl ? `${BASE_URL}${canonicalUrl}` : undefined
+
+  return {
+    title: fullTitle,
+    description,
+    ...(noIndex && { robots: { index: false, follow: false } }),
+    alternates: {
+      canonical: url,
+      languages: Object.fromEntries(
+        alternateLocales.map((l) => [l, `${BASE_URL}/${l}${canonicalUrl || ""}`])
+      ),
+    },
+    // `product` is a real og:type (ogp.me/ns/product) and commerce pages need
+    // it, but Next.js's `OpenGraph` union only accepts website | article |
+    // profile — so passing it straight through is a type error in every
+    // consumer's app. Keep it in this component's public API, declare the
+    // supported value to Next, and emit the true og:type through `other`,
+    // which Next renders verbatim. Narrowing the prop instead would silently
+    // downgrade every product page's metadata.
+    openGraph: {
+      title: fullTitle,
+      description,
+      url,
+      siteName: SITE_NAME,
+      type: ogType === "product" ? "website" : ogType,
+      locale,
+      images: [{ url: image, width: 1200, height: 630, alt: title }],
+    },
+    ...(ogType === "product" && { other: { "og:type": "product" } }),
+    twitter: { card: twitterCard, title: fullTitle, description, images: [image] },
+  }
+}
+
+/**
+ * Generate Schema.org JSON-LD script tag content.
+ * Use in layout.tsx: <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: generateSchemaLD(schema) }} />
+ */
+export function generateSchemaLD(schema: SchemaOrgData | SchemaOrgData[]): string {
+  const items = Array.isArray(schema) ? schema : [schema]
+  const graph = items.map((item) => ({ "@context": "https://schema.org", ...item }))
+  return JSON.stringify(
+    graph.length === 1 ? graph[0] : { "@context": "https://schema.org", "@graph": graph }
+  )
+}
+
+/** Pre-built Schema.org templates for common Mukoko content types */
+export const schemaTemplates = {
+  jobPosting: (job: {
+    title: string
+    company: string
+    location: string
+    description: string
+    datePosted: string
+    salary?: { min: number; max: number; currency: string }
+  }): SchemaOrgData => ({
+    "@type": "JobPosting",
+    title: job.title,
+    hiringOrganization: { "@type": "Organization", name: job.company },
+    jobLocation: { "@type": "Place", address: job.location },
+    description: job.description,
+    datePosted: job.datePosted,
+    ...(job.salary && {
+      baseSalary: {
+        "@type": "MonetaryAmount",
+        currency: job.salary.currency,
+        value: {
+          "@type": "QuantitativeValue",
+          minValue: job.salary.min,
+          maxValue: job.salary.max,
+          unitText: "MONTH",
+        },
+      },
+    }),
+  }),
+  article: (a: {
+    title: string
+    author: string
+    datePublished: string
+    image?: string
+  }): SchemaOrgData => ({
+    "@type": "Article",
+    headline: a.title,
+    author: { "@type": "Person", name: a.author },
+    datePublished: a.datePublished,
+    ...(a.image && { image: a.image }),
+  }),
+  event: (e: {
+    name: string
+    startDate: string
+    endDate?: string
+    location: string
+    description?: string
+  }): SchemaOrgData => ({
+    "@type": "Event",
+    name: e.name,
+    startDate: e.startDate,
+    ...(e.endDate && { endDate: e.endDate }),
+    location: { "@type": "Place", name: e.location },
+    ...(e.description && { description: e.description }),
+  }),
+  product: (p: {
+    name: string
+    price: number
+    currency: string
+    image?: string
+    description?: string
+  }): SchemaOrgData => ({
+    "@type": "Product",
+    name: p.name,
+    ...(p.description && { description: p.description }),
+    ...(p.image && { image: p.image }),
+    offers: {
+      "@type": "Offer",
+      price: p.price,
+      priceCurrency: p.currency,
+      availability: "https://schema.org/InStock",
+    },
+  }),
+}
+
+export type { NyuchiSEOConfig, SchemaOrgData }

--- a/components/registry/n11-discovery/nyuchi-seo.tsx
+++ b/components/registry/n11-discovery/nyuchi-seo.tsx
@@ -1,8 +1,14 @@
 import type { Metadata } from "next"
 
 /* ═══════════════════════════════════════════════════════════════
-   NYUCHI SEO — Layer 6 Page Composition
+   NYUCHI SEO — N11 discovery (a rung)
+   "If the machine can't see it, it doesn't exist."
    Server-side metadata generation for Next.js App Router.
+
+   Was labelled "Layer 6 Page Composition": wrong twice over. The layer/axis
+   model is retired in favour of the DNA double helix, and this is not a page
+   composition — it implements machine visibility and composes nothing, which
+   is why it moved off N6 to the N11 discovery rung.
    ═══════════════════════════════════════════════════════════════ */
 
 interface NyuchiSEOConfig {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "lint:md": "markdownlint-cli2",
     "lint:yaml": "yamllint .",
     "lint:json": "node -e \"const{execSync}=require('child_process');const fs=require('fs');const files=execSync(\\\"git ls-files '*.json' ':!pnpm-lock.yaml'\\\").toString().trim().split('\\n').filter(Boolean);let fail=0;for(const f of files){try{JSON.parse(fs.readFileSync(f,'utf8'))}catch(e){console.error('INVALID JSON:',f,e.message);fail=1}}process.exit(fail)\"",
-    "check": "pnpm format:check && pnpm lint && pnpm lint:colors && pnpm lint:md && pnpm lint:json && pnpm typecheck && pnpm test && pnpm audit:check && pnpm registry:verify && pnpm tokens:verify && pnpm build"
+    "check": "pnpm format:check && pnpm lint && pnpm lint:colors && pnpm lint:md && pnpm lint:json && pnpm typecheck && pnpm test && pnpm audit:check && pnpm registry:verify && pnpm tokens:verify && pnpm build",
+    "components:extract": "tsx scripts/extract-components.ts",
+    "components:verify": "tsx scripts/extract-components.ts --check"
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",

--- a/scripts/extract-components.ts
+++ b/scripts/extract-components.ts
@@ -1,0 +1,178 @@
+/**
+ * Extract component source out of Supabase and onto disk, one node at a time.
+ *
+ * See docs/component-source-migration.md. Source code is moving to the repo so
+ * the toolchain can see it; every other field stays in the database. This is
+ * the one-way door for a given node — run it, review the files, commit them.
+ *
+ *   pnpm components:extract --node 11
+ *   pnpm components:extract --node 11 --check    # non-mutating drift gate
+ *   pnpm components:extract --node 11 --dry-run  # print the plan, write nothing
+ *
+ * Reads through PostgREST with the ANON key, because `component_documents` is
+ * RLS public-read for the collections the `components` view exposes. There is
+ * deliberately no service-role path — extraction is a read, and a read never
+ * needs to outrank a policy.
+ *
+ * Layout on disk mirrors the helix so a directory listing teaches the model:
+ *
+ *   components/registry/n11-discovery/nyuchi-seo.tsx
+ *
+ * NOTE the distinction that trips people up: the registry's `files[].path`
+ * (e.g. "components/ui/nyuchi-seo.tsx") is where the shadcn CLI places the file
+ * in a CONSUMER's project. It is not where the file lives here, and the two are
+ * free to differ.
+ */
+
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs"
+import { existsSync } from "node:fs"
+import { join } from "node:path"
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL
+const SUPABASE_KEY =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.SUPABASE_PUBLISHABLE_KEY
+
+/** Node number → directory label. Matches `nodeLabel` in the registry. */
+const NODE_LABELS: Record<number, string> = {
+  1: "tokens",
+  2: "primitives",
+  3: "brand",
+  4: "safety",
+  5: "resilience",
+  6: "pages",
+  7: "shell",
+  8: "assurance",
+  9: "fundi",
+  10: "documentation",
+  11: "discovery",
+}
+
+const ROOT = join(process.cwd(), "components", "registry")
+
+interface Row {
+  name: string
+  source_code: string | null
+  ecosystem_node: number | null
+  status: string | null
+}
+
+function arg(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag)
+  return i === -1 ? undefined : process.argv[i + 1]
+}
+
+const hasFlag = (f: string) => process.argv.includes(f)
+
+async function fetchNode(node: number): Promise<Row[]> {
+  const url = new URL("/rest/v1/components", SUPABASE_URL)
+  url.searchParams.set("select", "name,source_code,ecosystem_node,status")
+  url.searchParams.set("ecosystem_node", `eq.${node}`)
+  url.searchParams.set("order", "name.asc")
+  const res = await fetch(url, {
+    headers: { apikey: SUPABASE_KEY!, Authorization: `Bearer ${SUPABASE_KEY}` },
+  })
+  if (!res.ok) {
+    throw new Error(`registry read failed (${res.status}): ${(await res.text()).slice(0, 300)}`)
+  }
+  return (await res.json()) as Row[]
+}
+
+/**
+ * A component whose source is empty is a real defect, not something to write as
+ * an empty file — an empty .tsx would typecheck and silently serve nothing.
+ */
+function assertUsable(rows: Row[]): Row[] {
+  const empty = rows.filter((r) => !r.source_code || r.source_code.trim().length === 0)
+  if (empty.length > 0) {
+    throw new Error(
+      `${empty.length} component(s) have no source in the registry and cannot be extracted: ` +
+        empty.map((r) => r.name).join(", ")
+    )
+  }
+  return rows
+}
+
+function fileFor(node: number, name: string): string {
+  const label = NODE_LABELS[node] ?? String(node)
+  return join(ROOT, `n${node}-${label}`, `${name}.tsx`)
+}
+
+async function main() {
+  if (!SUPABASE_URL || !SUPABASE_KEY) {
+    console.error(
+      "✖ Supabase env vars not set. Configure NEXT_PUBLIC_SUPABASE_URL and " +
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY (the anon key is public; the registry is RLS public-read)."
+    )
+    process.exit(1)
+  }
+
+  const nodeArg = arg("--node")
+  if (!nodeArg) {
+    console.error("✖ --node <n> is required. Nodes are never capped; pass whatever exists.")
+    process.exit(1)
+  }
+  const node = Number(nodeArg)
+  if (!Number.isInteger(node) || node < 1) {
+    console.error(`✖ --node must be a positive integer, got ${nodeArg}`)
+    process.exit(1)
+  }
+
+  const check = hasFlag("--check")
+  const dryRun = hasFlag("--dry-run")
+
+  const rows = assertUsable(await fetchNode(node))
+  if (rows.length === 0) {
+    // Not an error: N10 legitimately holds no components (documentation is MDX).
+    console.log(`N${node}: no components in the registry — nothing to extract.`)
+    return
+  }
+
+  const dir = join(ROOT, `n${node}-${NODE_LABELS[node] ?? node}`)
+  const drift: string[] = []
+
+  for (const row of rows) {
+    const path = fileFor(node, row.name)
+    const next = row.source_code!.trimEnd() + "\n"
+    const current = existsSync(path) ? readFileSync(path, "utf8") : null
+
+    if (check) {
+      if (current === null) drift.push(`${row.name}: missing on disk`)
+      else if (current !== next) drift.push(`${row.name}: differs from the registry`)
+      continue
+    }
+    if (dryRun) {
+      console.log(
+        `${current === null ? "create" : current === next ? "unchanged" : "update"}  ${path}`
+      )
+      continue
+    }
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(path, next)
+  }
+
+  if (check) {
+    // A file on disk with no registry row is drift too — otherwise a deleted
+    // component lingers as a file nobody serves.
+    const known = new Set(rows.map((r) => `${r.name}.tsx`))
+    if (existsSync(dir)) {
+      for (const f of readdirSync(dir)) {
+        if (!known.has(f)) drift.push(`${f}: on disk but not in the registry`)
+      }
+    }
+    if (drift.length > 0) {
+      console.error(`✖ N${node} drift (${drift.length}):`)
+      for (const d of drift) console.error(`  - ${d}`)
+      process.exit(1)
+    }
+    console.log(`✔ N${node}: ${rows.length} component(s) on disk match the registry.`)
+    return
+  }
+
+  if (dryRun) return
+  console.log(`✔ N${node}: extracted ${rows.length} component(s) to ${dir}`)
+}
+
+main().catch((err) => {
+  console.error(`✖ ${err instanceof Error ? err.message : String(err)}`)
+  process.exit(1)
+})


### PR DESCRIPTION
First node of the migration in `docs/component-source-migration.md` (PR #193). **N11 `discovery` is the pilot** — one component, and the strongest reason: its covenant is *"if the machine can't see it, it doesn't exist"*, so a broken discovery component should fail the build rather than be served to a crawler.

## The migration paid for itself on the first component

The moment `nyuchi-seo` hit disk and `tsc` could see it:

```
components/registry/n11-discovery/nyuchi-seo.tsx(46,5): error TS2322
Type '"product"' is not assignable to type '"website" | "article" | "profile" | undefined'
```

`nyuchi-seo` is marked **stable** and is installed by consumers. It accepted `ogType: "product"` and passed it straight to Next.js's `openGraph.type`, whose union doesn't include it — so **every consumer building a product page with this component got a type error**, and had for as long as the source lived in a JSON column where no typechecker could reach it.

**Fixed rather than narrowed.** `product` *is* a real og:type (ogp.me/ns/product) and commerce pages need it, so the prop stays. Next receives a value it accepts, and the true `og:type` is emitted through `other`, which Next renders verbatim. Dropping `"product"` from the prop would have silently downgraded every product page's metadata to fit the type instead of fixing it.

Also corrected the file's header, which read **"Layer 6 Page Composition"** — wrong twice over: the layer/axis model is retired, and this composes nothing.

## The machinery every later node PR uses

```
pnpm components:extract --node <n>   # pull source to disk
pnpm components:verify  --node <n>   # non-mutating drift gate
```

- Reads through PostgREST with the **anon** key — the registry is RLS public-read and extraction is a read, so there is deliberately **no service-role path**.
- Refuses to write an empty file for a component with no source (an empty `.tsx` typechecks and silently serves nothing).
- `--check` treats *a file with no registry row* as drift too, so a deleted component can't linger.
- Files land at `components/registry/n<N>-<label>/<name>.tsx` so a directory listing teaches the helix. **This is not the registry's `files[].path`** — that stays the consumer-side placement the shadcn CLI uses, and the two are free to differ.

## What the first run taught, and the honest gap

The pre-commit hook ran prettier + eslint over the extracted file, so **disk and registry diverged on the very first commit**. That isn't a bug — it's the pipeline saying *formatting belongs to the repo*, so the disk→DB projection has to run **after** the formatter, never before.

**The missing half is `components:sync` (disk → DB).** It needs write credentials — an M2M-minted `authenticated` JWT, the `mzizi-skills` pattern — which aren't available in this environment, so it isn't built here.

Current state, stated precisely:

- ✅ The **functional** fix (the og:type bug) **is** in the registry — migration `nyuchi_seo_fix_og_product_type_error`, so consumers already have it.
- ⚠️ The registry is behind disk by **prettier formatting + the header comment** only. Both cosmetic; neither changes behaviour.
- ⚠️ So `pnpm components:verify --node 11` currently reports drift **by design**, and must not gate CI until `components:sync` exists.

## Review focus

The `og:type` fix is the part with real consequences for consumers. The extraction script's failure modes (empty source, orphan files) are the part that has to be right before 318 more components go through it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_