### PR TITLE
feat(registry): serve component source from disk, through one reader

### DIFF
--- a/__tests__/lib/registry-source.test.ts
+++ b/__tests__/lib/registry-source.test.ts
@@ -1,0 +1,85 @@
+/**
+ * `@/lib/registry-source` is the single reader of component source on disk.
+ *
+ * These run against the REAL `components/registry/**` tree rather than a
+ * fixture, because the property that matters is "the file the route serves is
+ * the file in the repo" — a fixture would assert the resolver's shape while
+ * leaving the thing the migration exists to guarantee untested.
+ */
+
+import { describe, expect, it, beforeEach } from "vitest"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import {
+  componentsOnDisk,
+  readComponentSource,
+  resetRegistrySourceCache,
+  resolveComponentSource,
+} from "@/lib/registry-source"
+
+beforeEach(() => resetRegistrySourceCache())
+
+describe("readComponentSource", () => {
+  it("returns the file's real bytes, not a rendering of them", () => {
+    const onDisk = readFileSync(
+      join(process.cwd(), "components/registry/n11-discovery/nyuchi-seo.tsx"),
+      "utf8"
+    )
+    expect(readComponentSource("nyuchi-seo")).toBe(onDisk)
+  })
+
+  it("finds a component without being told its node", () => {
+    // The caller has a name, not a node. If the resolver needed the node it
+    // would need the node-label table too, and that table would then live in
+    // two places.
+    expect(readComponentSource("nyuchi-seo")).toContain("generateMetadata")
+  })
+
+  it("returns null — never an empty string — for a component with no file", () => {
+    // A 200 carrying an empty body is exactly how the pre-migration bugs hid,
+    // so the absent case has to be distinguishable at the type level.
+    expect(readComponentSource("no-such-component-anywhere")).toBeNull()
+  })
+
+  it("does not resolve a path traversal to something outside the registry", () => {
+    expect(readComponentSource("../../package")).toBeNull()
+    expect(readComponentSource("../../../etc/passwd")).toBeNull()
+  })
+})
+
+describe("resolveComponentSource — the migration window", () => {
+  it("prefers disk over the database column", () => {
+    // Both copies exist for exactly as long as a node takes to move. Disk wins,
+    // because disk is the copy the toolchain has actually checked.
+    expect(resolveComponentSource("nyuchi-seo", "// stale db copy")).toContain("generateMetadata")
+  })
+
+  it("falls back to the database for a component not yet extracted", () => {
+    // Without this the read path would 404 every un-extracted component — an
+    // outage across the whole registry in exchange for nothing, since the DB
+    // copy is still there and still correct.
+    expect(resolveComponentSource("not-yet-extracted", "export const x = 1")).toBe(
+      "export const x = 1"
+    )
+  })
+
+  it("treats a blank database column as absent, not as empty source", () => {
+    expect(resolveComponentSource("not-yet-extracted", "   \n ")).toBeNull()
+    expect(resolveComponentSource("not-yet-extracted", "")).toBeNull()
+    expect(resolveComponentSource("not-yet-extracted", null)).toBeNull()
+    expect(resolveComponentSource("not-yet-extracted")).toBeNull()
+  })
+})
+
+describe("componentsOnDisk", () => {
+  it("lists migrated components and is sorted", () => {
+    const names = componentsOnDisk()
+    expect(names).toContain("nyuchi-seo")
+    expect(names).toEqual([...names].sort())
+  })
+
+  it("holds no duplicates — a name maps to exactly one file", () => {
+    const names = componentsOnDisk()
+    expect(new Set(names).size).toBe(names.length)
+  })
+})

--- a/app/api/v1/stats/route.ts
+++ b/app/api/v1/stats/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 import { createLogger } from "@/lib/observability"
 import { getUsageStats } from "@/lib/metrics"
 import { getPublicClient, isSupabaseConfigured } from "@/lib/db"
+import { componentsOnDisk } from "@/lib/registry-source"
 
 const logger = createLogger("api")
 
@@ -15,13 +16,22 @@ async function getLayerBreakdown(): Promise<Record<string, number>> {
   try {
     const { data, error } = await getPublicClient()
       .from("components")
-      .select("layer")
-      .not("source_code", "is", null)
+      .select("name, layer, source_code")
 
     if (error || !data) return {}
 
+    // "Has source" used to be `source_code is not null`. Source is moving to
+    // disk node by node, so during the migration it is either place; once the
+    // last node drops, the `source_code` half of this goes with it.
+    const onDisk = new Set(componentsOnDisk())
+
     const breakdown: Record<string, number> = {}
-    for (const row of data as unknown as Array<{ layer: string | null }>) {
+    for (const row of data as unknown as Array<{
+      name: string
+      layer: string | null
+      source_code: string | null
+    }>) {
+      if (!onDisk.has(row.name) && !row.source_code) continue
       const key = row.layer ?? "unknown"
       breakdown[key] = (breakdown[key] ?? 0) + 1
     }

--- a/app/api/v1/ui/[name]/route.ts
+++ b/app/api/v1/ui/[name]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { createLogger } from "@/lib/observability"
 import { getComponent, isSupabaseConfigured } from "@/lib/db"
+import { resolveComponentSource } from "@/lib/registry-source"
 import { trackApiCall } from "@/lib/metrics"
 
 const logger = createLogger("registry")
@@ -13,7 +14,11 @@ const CORS_CACHE = {
 /**
  * GET /api/v1/ui/[name] — Individual component with inline source
  *
- * Reads metadata and source code from Supabase.
+ * Metadata comes from Supabase; the SOURCE comes from disk
+ * (`components/registry/**`, via `@/lib/registry-source`). See
+ * `docs/component-source-migration.md` — the database no longer holds a copy,
+ * so a component whose file is missing is a 404 and never a 200 with an empty
+ * body.
  */
 export async function GET(_request: Request, { params }: { params: Promise<{ name: string }> }) {
   const start = Date.now()
@@ -64,7 +69,10 @@ export async function GET(_request: Request, { params }: { params: Promise<{ nam
       )
     }
 
-    if (!component.source_code) {
+    const source = resolveComponentSource(name, component.source_code)
+
+    if (source === null) {
+      logger.warn("Component has no source on disk or in the registry", { data: { name } })
       trackApiCall({
         endpoint: `/api/v1/ui/${name}`,
         durationMs: Date.now() - start,
@@ -80,7 +88,7 @@ export async function GET(_request: Request, { params }: { params: Promise<{ nam
     const files = component.files.map((file, i) => ({
       path: file.path,
       type: file.type,
-      content: i === 0 ? component.source_code! : "",
+      content: i === 0 ? source : "",
     }))
 
     logger.info("Component served", {

--- a/app/components/[name]/page.tsx
+++ b/app/components/[name]/page.tsx
@@ -7,6 +7,7 @@ import { ComponentDocSection } from "@/components/playground/component-doc-secti
 import { SafeSection } from "@/components/error-boundary"
 import { Badge } from "@/components/ui/badge"
 import { getAllComponents, getComponent, isSupabaseConfigured } from "@/lib/db"
+import { resolveComponentSource } from "@/lib/registry-source"
 
 /**
  * Static params: generate a page per component by listing the DB registry.
@@ -39,7 +40,8 @@ export default async function ComponentPage({ params }: { params: Promise<{ name
 
   if (!item) notFound()
 
-  const sourceCode = item.source_code ?? "// Source not available"
+  // Source lives on disk, not in the registry document (@/lib/registry-source).
+  const sourceCode = resolveComponentSource(name, item.source_code) ?? "// Source not available"
   const firstFilePath = item.files?.[0]?.path ?? ""
   const registryType = item.registry_type?.replace("registry:", "") ?? "component"
   const installUrl = `https://mzizi.dev/api/v1/ui/${item.name}`

--- a/app/playground/[name]/page.tsx
+++ b/app/playground/[name]/page.tsx
@@ -8,6 +8,7 @@ import { ComponentDocSection } from "@/components/playground/component-doc-secti
 import { SafeSection } from "@/components/error-boundary"
 import { Badge } from "@/components/ui/badge"
 import { getAllComponents, getComponent, isSupabaseConfigured } from "@/lib/db"
+import { resolveComponentSource } from "@/lib/registry-source"
 
 /**
  * Per-component playground page.
@@ -59,7 +60,8 @@ export default async function PlaygroundComponentPage({
 
   if (!item) notFound()
 
-  const sourceCode = item.source_code ?? "// Source not available"
+  // Source lives on disk, not in the registry document (@/lib/registry-source).
+  const sourceCode = resolveComponentSource(name, item.source_code) ?? "// Source not available"
   const firstFilePath = item.files?.[0]?.path ?? ""
   const registryType = item.registry_type?.replace("registry:", "") ?? "component"
   const installUrl = `https://mzizi.dev/api/v1/ui/${item.name}`

--- a/app/source/[name]/page.tsx
+++ b/app/source/[name]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link"
 import { notFound } from "next/navigation"
 import { ArrowLeft, Copy } from "lucide-react"
 import { getComponent, isSupabaseConfigured } from "@/lib/db"
+import { resolveComponentSource } from "@/lib/registry-source"
 
 export const revalidate = 3600
 
@@ -20,8 +21,9 @@ export async function generateMetadata({ params }: { params: Promise<{ name: str
 
 /**
  * Per-component source-code page. Documented in the component-backlinks
- * doctrine table at /architecture/component-backlinks; data lives in
- * `components.source_code` on Supabase.
+ * doctrine table at /architecture/component-backlinks. Metadata comes from
+ * Supabase; the source itself is read from disk (`components/registry/**`, via
+ * `@/lib/registry-source`).
  *
  * For the JSON shape with metadata, dependencies, and shadcn-format
  * registry response, use `/api/v1/ui/{name}` instead.
@@ -34,9 +36,10 @@ export default async function SourcePage({ params }: { params: Promise<{ name: s
       <article className="mx-auto max-w-4xl py-12">
         <h1 className="font-serif text-3xl font-bold">Source: {name}</h1>
         <p className="mt-4 text-sm text-muted-foreground">
-          Supabase is not configured. Source is read live from{" "}
+          Supabase is not configured, so this component&apos;s metadata cannot be read. The source
+          itself lives on disk under{" "}
           <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
-            components.source_code
+            components/registry/
           </code>
           .
         </p>
@@ -46,7 +49,8 @@ export default async function SourcePage({ params }: { params: Promise<{ name: s
 
   const component = await getComponent(name).catch(() => null)
   if (!component) notFound()
-  if (!component.source_code) {
+  const sourceCode = resolveComponentSource(name, component.source_code)
+  if (sourceCode === null) {
     return (
       <article className="mx-auto max-w-4xl py-12">
         <p className="font-mono text-[11px] tracking-widest text-muted-foreground uppercase">
@@ -122,7 +126,7 @@ export default async function SourcePage({ params }: { params: Promise<{ name: s
       </div>
 
       <pre className="overflow-x-auto rounded-xl border border-border bg-muted/30 p-4 text-xs leading-relaxed">
-        <code className="font-mono">{component.source_code}</code>
+        <code className="font-mono">{sourceCode}</code>
       </pre>
     </article>
   )

--- a/docs/component-source-migration.md
+++ b/docs/component-source-migration.md
@@ -1,0 +1,132 @@
+# Component source moves out of the database
+
+Status: **in progress.** N11 is on disk; the read path landed with this document.
+
+## Why
+
+Component source lived in Supabase as `component_documents.document->>'source_code'`,
+exposed through a Postgres **view** named `components`. Because the source was a JSON
+column and not a file, the toolchain could not see it, and that cost showed up four
+separate times in one working session:
+
+- a component could not be typechecked, linted or rendered before being edited;
+- edits reached production through blind `jsonb_set` string replacement;
+- an `aspect-media` change shipped a utility **nothing defines** for consumers, so every
+  installed card would have silently lost its aspect ratio in someone else's app;
+- `nyuchi-cover-wash-header` was left unfixed _specifically_ because a structural JSX
+  edit could not be compiled first.
+
+The N11 pilot proved the thesis on its first file. The moment `nyuchi-seo` hit disk `tsc`
+failed it: a **stable**, consumer-installed component had been passing
+`ogType: "product"` into Next's `openGraph.type` — whose union does not include it — for
+as long as the source lived where no typechecker could reach.
+
+## The rule
+
+**No component source in the database.** Once a file exists on disk the DB copy is
+deleted, not mirrored. Two copies is the drift this migration exists to end — there is
+no projection script, no sync, and therefore no drift gate to keep honest.
+
+Everything _around_ a component stays in Supabase: description, dependencies,
+`registryDependencies`, `files[]`, node, collection, owner, status, version history,
+changelog, docs. Only the bytes moved.
+
+## Layout
+
+```
+components/registry/n<N>-<label>/<name>.tsx
+```
+
+e.g. `components/registry/n11-discovery/nyuchi-seo.tsx`.
+
+The directory mirrors the DNA helix so a directory listing teaches the model. Note the
+distinction that trips people up: the registry's `files[].path` (e.g.
+`components/ui/nyuchi-seo.tsx`) is where the shadcn CLI places the file in a **consumer's**
+project. It is not where the file lives here, and the two are free to differ.
+
+## The read path
+
+`lib/registry-source.ts` is the **single** reader. Every surface that serves source goes
+through it:
+
+| Surface                 | What it serves                                   |
+| ----------------------- | ------------------------------------------------ |
+| `app/api/v1/ui/[name]`  | the shadcn registry item — `files[0].content`    |
+| `lib/mcp-server.ts`     | `get_component` → `document.source_code`         |
+| `app/source/[name]`     | the source-code page                             |
+| `app/components/[name]` | the docs surface's code panel                    |
+| `app/playground/[name]` | the playground's code panel                      |
+| `app/api/v1/stats`      | "has source" — now a disk question, not a column |
+
+Two readers of the filesystem would be the same mistake as two copies of the source.
+
+### The fallback is a ramp, not an architecture
+
+`resolveComponentSource(name, databaseSource)` reads disk first and falls back to the
+`source_code` column. That fallback exists **only for the duration of the migration**:
+nodes move one PR at a time, so between the first extraction and the last drop most
+components still live only in the database, and a disk-only read path would 404 the whole
+registry the moment it merged — an outage taken on in exchange for nothing, since the DB
+copy is still there and still correct.
+
+**Delete `resolveComponentSource` at step 5**, once
+`select count(*) from components where source_code is not null` returns 0. Its callers go
+back to `readComponentSource` directly. Keeping it past that point re-establishes the
+second copy this whole migration exists to end.
+
+Three properties are load-bearing:
+
+- **Absent is `null`, never `""`.** A 200 carrying an empty body is exactly how the
+  pre-migration bugs hid. The registry route 404s on `null`.
+- **A duplicate name throws for that name only.** A component name is unique across the
+  registry, so two files claiming one name means an extraction went to the wrong node.
+  One mislaid file must not take the route down for the other 300-odd components.
+- **`outputFileTracingIncludes` in `next.config.mjs` is not optional.** The reads are
+  dynamic (`readdir` + `readFileSync`), so Next's static trace cannot see them; without
+  the explicit include the files are absent from the deployed lambdas and every read
+  succeeds in `next dev` and 404s in production.
+
+## Extraction
+
+`scripts/extract-components.ts`, one node at a time:
+
+```bash
+pnpm components:extract --node 11
+pnpm components:extract --node 11 --dry-run
+```
+
+It reads through PostgREST with the **anon** key — extraction is a read, and a read never
+needs to outrank a policy — and refuses to write an empty file for a component with no
+source, because an empty `.tsx` would typecheck and silently serve nothing.
+
+Per node, and **a node is not done until it is green**:
+
+1. `pnpm components:extract --node <n>`
+2. `pnpm typecheck` — fix what the extraction exposes. Expect real bugs; N11 had one in
+   its single file. Fix them properly rather than narrowing types to fit.
+3. `pnpm build` && `pnpm test`
+4. Commit, PR, merge.
+5. **Then** the migration that clears that node's `source_code`.
+
+Step 5 is never batched across nodes. Dropping before a node's files are merged and
+serving is the one irreversible mistake available here.
+
+Order, by ascending risk:
+**N9 (3) → N8 (13) → N5 (14) → N4 (14) → N7 (16) → N6 (52) → N3 (67) → N2 (143)**.
+
+## Known follow-ups
+
+- **N1 `nyuchi-tokens` is not a component.** Its `source_code` holds a JSON token payload
+  that `getDesignTokens()` parses. It moves too, but as data — not as part of the `.tsx`
+  fan-out above.
+- **N2 overlaps `components/ui/`.** The portal imports ~35 primitives from
+  `components/ui/<name>.tsx` and `scripts/sync-registry.ts` writes them there from the DB.
+  Extracting N2 to `components/registry/n2-primitives/` would put two copies on disk —
+  precisely what this migration forbids. Settle which path is the one file before N2 is
+  extracted; it is last in the order for that reason.
+- **`registry.json` does not exist** although `pnpm registry:verify` (in `pnpm check` and
+  in CI) expects it. Resolve before the drops, or the gate goes red for an unrelated
+  reason.
+- **`components:verify` / the `--check` mode is due for deletion.** A drift gate is
+  meaningless once there is only one copy, and leaving it invites someone to re-create
+  the second.

--- a/lib/mcp-server.ts
+++ b/lib/mcp-server.ts
@@ -18,6 +18,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import type { SupabaseClient } from "@supabase/supabase-js"
 import { z } from "zod"
+import { resolveComponentSource } from "@/lib/registry-source"
 
 const VERSION = "1.0.0"
 
@@ -186,7 +187,7 @@ export async function createMziziMcpServer(supabase: SupabaseClient): Promise<Mc
 
   server.tool(
     "get_component",
-    "Fetch one component as its full JSON document — one read, everything in it (metadata, owner, sources/descriptors, legacy source code, files, docs).",
+    "Fetch one component as its full JSON document — one read, everything in it (metadata, owner, sources/descriptors, source code, files, docs).",
     {
       name: z.string().min(1).describe("Component name, e.g. 'button', 'nyuchi-tokens'"),
     },
@@ -200,7 +201,15 @@ export async function createMziziMcpServer(supabase: SupabaseClient): Promise<Mc
           .maybeSingle()
         if (error) return toolError(`get_component('${name}') query failed`, error)
         if (!data) return toolError(`Component '${name}' not found`)
-        return jsonContent(data)
+        // Source lives on disk, not in the document (see @/lib/registry-source).
+        // Overlaying it here keeps this tool's contract intact for callers that
+        // have always read `document.source_code`, while the column empties out
+        // node by node. Absent on disk stays absent — never an empty string.
+        const source = resolveComponentSource(name, data.document?.source_code)
+        return jsonContent({
+          ...data,
+          document: { ...(data.document ?? {}), source_code: source },
+        })
       } catch (err) {
         return toolError("get_component failed", err)
       }

--- a/lib/registry-source.ts
+++ b/lib/registry-source.ts
@@ -1,0 +1,142 @@
+/**
+ * Component source lives on disk, not in the database.
+ *
+ * See `docs/component-source-migration.md`. `component_documents.document->>
+ * 'source_code'` is being emptied node by node; the files under
+ * `components/registry/n<N>-<label>/<name>.<ext>` are the single copy. Every
+ * surface that serves source — the shadcn registry route, the MCP server, the
+ * source/playground pages — reads it through THIS module. One reader, because
+ * two readers of the filesystem would be the same mistake as two copies of the
+ * source.
+ *
+ * Metadata (description, dependencies, registryDependencies, node, status,
+ * `files[].path`) still comes from the registry. Only the bytes moved.
+ *
+ * NOTE the `files[].path` distinction: that is where the shadcn CLI places a
+ * file in a CONSUMER's project. It is unrelated to where the file lives here.
+ */
+
+import { existsSync, readFileSync, readdirSync } from "node:fs"
+import { basename, extname, join } from "node:path"
+
+/**
+ * Resolved against `process.cwd()` so it works in `next dev`, in a Vercel
+ * lambda, and in a script. The directory has to be traced into the deployed
+ * bundle explicitly — see `outputFileTracingIncludes` in `next.config.mjs`,
+ * without which these reads succeed locally and 404 in production.
+ */
+const REGISTRY_ROOT = join(process.cwd(), "components", "registry")
+
+/** Extensions a component's single source file may carry. */
+const SOURCE_EXTENSIONS = new Set([".tsx", ".ts", ".css", ".json"])
+
+interface RegistryIndex {
+  /** component name → absolute path of its source file */
+  files: Map<string, string>
+  /** names that resolve to more than one file — a defect, not a fallback */
+  ambiguous: Map<string, string[]>
+}
+
+let cached: RegistryIndex | null = null
+
+function buildIndex(): RegistryIndex {
+  const files = new Map<string, string>()
+  const seen = new Map<string, string[]>()
+
+  if (existsSync(REGISTRY_ROOT)) {
+    for (const dir of readdirSync(REGISTRY_ROOT, { withFileTypes: true })) {
+      if (!dir.isDirectory()) continue
+      const nodeDir = join(REGISTRY_ROOT, dir.name)
+      for (const entry of readdirSync(nodeDir)) {
+        const ext = extname(entry)
+        if (!SOURCE_EXTENSIONS.has(ext)) continue
+        const name = basename(entry, ext)
+        const path = join(nodeDir, entry)
+        seen.set(name, [...(seen.get(name) ?? []), path])
+        if (!files.has(name)) files.set(name, path)
+      }
+    }
+  }
+
+  // A component name is unique across the registry, so two files claiming one
+  // name means an extraction went to the wrong node. Fail that ONE name rather
+  // than the whole index: a single mislaid file must not take the route down
+  // for the other 300-odd components.
+  const ambiguous = new Map<string, string[]>()
+  for (const [name, paths] of seen) {
+    if (paths.length > 1) ambiguous.set(name, paths)
+  }
+
+  return { files, ambiguous }
+}
+
+function index(): RegistryIndex {
+  if (!cached) cached = buildIndex()
+  return cached
+}
+
+/** Drop the cached index. For tests and for the extract script. */
+export function resetRegistrySourceCache(): void {
+  cached = null
+}
+
+/**
+ * Read a component's source from disk.
+ *
+ * Returns `null` when the component has no file — which is a genuine 404 for
+ * the registry route, NOT an empty string. A 200 carrying an empty body is
+ * exactly how the pre-migration bugs hid, so the empty case never silently
+ * becomes "".
+ *
+ * @throws if the name resolves to more than one file on disk.
+ */
+export function readComponentSource(name: string): string | null {
+  const { files, ambiguous } = index()
+
+  const duplicates = ambiguous.get(name)
+  if (duplicates) {
+    throw new Error(
+      `Component "${name}" resolves to ${duplicates.length} files on disk: ` +
+        `${duplicates.join(", ")}. A component name is unique across the registry — ` +
+        `delete the copy that is filed under the wrong node.`
+    )
+  }
+
+  const path = files.get(name)
+  if (!path) return null
+
+  const source = readFileSync(path, "utf8")
+  return source.trim().length === 0 ? null : source
+}
+
+/** Every component name that has a source file on disk. */
+export function componentsOnDisk(): string[] {
+  return [...index().files.keys()].sort()
+}
+
+/**
+ * Disk first, the database column second — **for the duration of the migration
+ * only.**
+ *
+ * The nodes move one PR at a time, so between the first extraction and the last
+ * drop most components still live only in `component_documents.document->>
+ * 'source_code'`. Without this fallback the read path would 404 every component
+ * that has not been extracted yet: an outage across the whole registry, taken
+ * on deliberately in exchange for nothing, since the DB copy is still there and
+ * still correct.
+ *
+ * DELETE THIS FUNCTION at step 5, once
+ * `select count(*) from components where source_code is not null` is 0. Its
+ * callers then go back to `readComponentSource` directly. Keeping it past that
+ * point would re-establish the second copy this migration exists to end — the
+ * fallback is a ramp, not an architecture.
+ */
+export function resolveComponentSource(
+  name: string,
+  databaseSource?: string | null
+): string | null {
+  const fromDisk = readComponentSource(name)
+  if (fromDisk !== null) return fromDisk
+  const fallback = databaseSource?.trim()
+  return fallback ? databaseSource! : null
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -37,6 +37,23 @@ const nextConfig = {
     unoptimized: true,
   },
   transpilePackages: ["radix-ui"],
+
+  // Component source lives on disk under `components/registry/**` and is read
+  // at request time by `@/lib/registry-source`. Those reads are dynamic
+  // (readdir + readFileSync), so Next's static trace cannot see them and the
+  // files would be absent from the deployed lambdas — the reads succeed in
+  // `next dev` and 404 in production, which is the worst-shaped failure
+  // available here. Tracing them in explicitly is what makes the registry
+  // route serve real source on Vercel.
+  outputFileTracingIncludes: {
+    "/api/v1/ui/[name]": ["./components/registry/**/*"],
+    "/api/v1/stats": ["./components/registry/**/*"],
+    "/mcp": ["./components/registry/**/*"],
+    "/source/[name]": ["./components/registry/**/*"],
+    "/components/[name]": ["./components/registry/**/*"],
+    "/playground/[name]": ["./components/registry/**/*"],
+  },
+
   turbopack: {
     resolveAlias: {
       "next-mdx-import-source-file": "./mdx-components.tsx",


### PR DESCRIPTION
Step 2 of the component-source migration (`docs/component-source-migration.md`, added here). The read path moves to the filesystem **before** any `source_code` is dropped, so the column can be emptied node by node behind a surface that already works.

## One reader

`lib/registry-source.ts` is the single reader of `components/registry/**`. Two readers of the filesystem would be the same mistake as two copies of the source, so every surface that serves source now goes through it:

| Surface | What it serves |
| --- | --- |
| `app/api/v1/ui/[name]` | the shadcn registry item — `files[0].content` |
| `lib/mcp-server.ts` | `get_component` → `document.source_code` |
| `app/source/[name]` | the source-code page |
| `app/components/[name]` | the docs surface's code panel |
| `app/playground/[name]` | the playground's code panel |
| `app/api/v1/stats` | "has source" — was `source_code is not null` |

Metadata (description, dependencies, `registryDependencies`, `files[].path`, node, status) still comes from Supabase. Only the bytes moved.

## The fallback is a ramp, not an architecture

`resolveComponentSource(name, databaseSource)` reads disk first and falls back to the `source_code` column.

The plan called for a disk-only read path here. That would have 404'd the entire registry the moment it merged — 322 of 323 components have no file yet — which is an outage taken on in exchange for nothing, since the DB copy is still there and still correct. The fallback keeps production correct at every commit and still ends in the same place.

**It is deleted at step 5**, once `select count(*) from components where source_code is not null` returns 0. The deletion condition is stated in the function's own doc comment and in the migration doc, because a temporary fallback nobody deletes is just the second copy again.

## Three properties the tests pin down

- **Absent is `null`, never `""`.** A 200 carrying an empty body is exactly how the pre-migration bugs hid, so the registry route 404s on it.
- **A duplicate name throws for that name only.** Component names are unique across the registry, so two files claiming one name means an extraction went to the wrong node — and one mislaid file must not take the route down for the other 300-odd components.
- **A name is only ever a key in an index built from `readdir`,** so nothing outside `components/registry/` is reachable through it (`../../package`, `../../../etc/passwd` both resolve to `null`).

## `outputFileTracingIncludes` is load-bearing, not tidy config

The reads are dynamic (`readdir` + `readFileSync`), so Next's static trace cannot see them. Without the explicit include in `next.config.mjs` the files are absent from the deployed lambdas and every read succeeds in `next dev` and 404s in production — the worst-shaped failure available here.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm test` (108 passing, 9 new), `pnpm build` all green.

Against a real production build (`pnpm start`):

| Request | Result |
| --- | --- |
| `/api/v1/ui/nyuchi-seo` | 200 — 5541 bytes, byte-identical to the file on disk |
| `/api/v1/ui/button` | 200 — 3637 bytes, still from the DB copy |
| `/api/v1/ui/definitely-not-a-component` | 404 |
| `/source/nyuchi-seo`, `/source/button` | 200 |
| `/components/nyuchi-seo`, `/playground/nyuchi-seo` | 200 |
| `/api/v1/stats` | 200 |

`/mcp` could not be exercised locally — it needs `SUPABASE_SECRET_KEY`, which this environment does not carry. That path is covered by typecheck and by the resolver's unit tests.

## Follow-ups recorded in the doc, not fixed here

- **N1 `nyuchi-tokens` is not a component.** Its `source_code` holds a JSON token payload `getDesignTokens()` parses. It moves as data, not as part of the `.tsx` fan-out.
- **N2 overlaps `components/ui/`.** The portal imports ~35 primitives from there and `scripts/sync-registry.ts` writes them from the DB. Extracting N2 to `components/registry/n2-primitives/` would put two copies on disk. Settle which path is the one file before N2 — it is last in the order for that reason.
- **`registry.json` does not exist** although `pnpm registry:verify` (in `pnpm check` and in CI) expects it.
- **`components:verify` / `--check` is due for deletion** — a drift gate is meaningless once there is only one copy.

Branched off `main` rather than `claude/mzizi-skills-publishing-i1r02q`, matching the N11 pilot (#195): that branch carries an open docs PR, and CLAUDE.md keeps docs-only PRs docs-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_