### PR TITLE
feat(n9): move fundi component source onto disk — and it found two more bugs

### DIFF
--- a/components/registry/n9-fundi/nyuchi-fundi-learning.tsx
+++ b/components/registry/n9-fundi/nyuchi-fundi-learning.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+export interface HealingOutcome {
+  issueId: number
+  component: string
+  node: number
+  errorType: string
+  severity: string
+  planActions: string[]
+  actualFix: string
+  fundiWasCorrect: boolean
+  timeToResolveMinutes: number
+  recurred: boolean
+  resolvedBy: "fundi" | "human" | "both"
+  timestamp: string
+}
+
+export interface LearningStats {
+  totalIssues: number
+  autoFixed: number
+  humanFixed: number
+  accuracy: number
+  avgTimeToResolve: number
+  topFailingComponents: { name: string; count: number }[]
+  topErrorTypes: { type: string; count: number }[]
+  recurrenceRate: number
+}
+
+// DB PERSISTENCE: In production, outcomes are stored in fundi_healing_log table
+// and stats are computed from fundi_issues + fundi_healing_log via SQL.
+// This in-memory implementation is for client-side quick access;
+// the edge function (fundi-webhook) handles the DB persistence server-side.
+//
+// To query learning stats from DB:
+// SELECT COUNT(*) as total, COUNT(*) FILTER (WHERE resolved_by = 'fundi') as auto_fixed,
+//   AVG(EXTRACT(EPOCH FROM resolved_at - created_at)/60) as avg_ttr_minutes
+// FROM fundi_issues WHERE status = 'resolved';
+
+class FundiLearningCore {
+  private outcomes: HealingOutcome[] = []
+
+  record(outcome: HealingOutcome) {
+    this.outcomes.push(outcome)
+  }
+
+  getStats(): LearningStats {
+    const total = this.outcomes.length
+    if (total === 0)
+      return {
+        totalIssues: 0,
+        autoFixed: 0,
+        humanFixed: 0,
+        accuracy: 0,
+        avgTimeToResolve: 0,
+        topFailingComponents: [],
+        topErrorTypes: [],
+        recurrenceRate: 0,
+      }
+
+    const autoFixed = this.outcomes.filter((o) => o.resolvedBy === "fundi").length
+    const correct = this.outcomes.filter((o) => o.fundiWasCorrect).length
+    const avgTTR = this.outcomes.reduce((s, o) => s + o.timeToResolveMinutes, 0) / total
+    const recurred = this.outcomes.filter((o) => o.recurred).length
+
+    const compCounts = new Map<string, number>()
+    const typeCounts = new Map<string, number>()
+    this.outcomes.forEach((o) => {
+      compCounts.set(o.component, (compCounts.get(o.component) || 0) + 1)
+      typeCounts.set(o.errorType, (typeCounts.get(o.errorType) || 0) + 1)
+    })
+
+    return {
+      totalIssues: total,
+      autoFixed,
+      humanFixed: total - autoFixed,
+      accuracy: correct / total,
+      avgTimeToResolve: Math.round(avgTTR),
+      topFailingComponents: [...compCounts.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 10)
+        .map(([name, count]) => ({ name, count })),
+      topErrorTypes: [...typeCounts.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 5)
+        .map(([type, count]) => ({ type, count })),
+      recurrenceRate: recurred / total,
+    }
+  }
+
+  getComponentHistory(component: string): HealingOutcome[] {
+    return this.outcomes.filter((o) => o.component === component)
+  }
+
+  suggestSeverity(component: string, errorType: string): string {
+    const history = this.outcomes.filter(
+      (o) => o.component === component && o.errorType === errorType
+    )
+    if (history.length === 0) return "medium"
+    const lastSeverity = history[history.length - 1].severity
+    const recurrenceCount = history.filter((o) => o.recurred).length
+    if (recurrenceCount > 2) return "high"
+    return lastSeverity
+  }
+}
+
+let _learning: FundiLearningCore | null = null
+export function getFundiLearning(): FundiLearningCore {
+  if (!_learning) _learning = new FundiLearningCore()
+  return _learning
+}
+export type { FundiLearningCore }

--- a/components/registry/n9-fundi/nyuchi-fundi-reporter.tsx
+++ b/components/registry/n9-fundi/nyuchi-fundi-reporter.tsx
@@ -1,0 +1,120 @@
+"use client"
+
+const GITHUB_REPO = "nyuchi/design-portal"
+
+export interface FundiReport {
+  component: string
+  node: number
+  severity: "low" | "medium" | "high" | "critical"
+  errorType:
+    | "render"
+    | "network"
+    | "data"
+    | "auth"
+    | "chain"
+    | "crypto"
+    | "timeout"
+    | "a11y"
+    | "perf"
+    | "conformity"
+    | "slo"
+  source: string
+  title: string
+  description: string
+  portalUrl?: string
+  diagnostic?: Record<string, unknown>
+  affectedMiniApps?: string[]
+  blastRadius?: string[]
+}
+
+export interface ReporterConfig {
+  githubToken?: string
+  fundiEndpoint?: string
+  cooldownSeconds?: number
+  onReported?: (report: FundiReport, issueUrl?: string) => void
+}
+
+class FundiReporterCore {
+  private config: ReporterConfig
+  private cooldowns = new Map<string, number>()
+
+  constructor(config: ReporterConfig = {}) {
+    this.config = { cooldownSeconds: config.cooldownSeconds ?? 300, ...config }
+  }
+
+  async report(report: FundiReport): Promise<{ issueUrl?: string; queued: boolean }> {
+    const lastReport = this.cooldowns.get(report.component)
+    if (lastReport && Date.now() - lastReport < (this.config.cooldownSeconds ?? 300) * 1000) {
+      return { queued: false }
+    }
+    this.cooldowns.set(report.component, Date.now())
+
+    const labels = [
+      `fundi:severity/${report.severity}`,
+      `fundi:node/${report.node}`,
+      `fundi:type/${report.errorType}`,
+      `fundi:source/${report.source}`,
+    ]
+
+    const body = this.buildIssueBody(report)
+
+    if (this.config.githubToken) {
+      const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/issues`, {
+        method: "POST",
+        headers: {
+          Authorization: `token ${this.config.githubToken}`,
+          "Content-Type": "application/json",
+          Accept: "application/vnd.github.v3+json",
+        },
+        body: JSON.stringify({ title: `[${report.component}] ${report.title}`, body, labels }),
+      })
+      const data = await res.json()
+      this.config.onReported?.(report, data.html_url)
+      return { issueUrl: data.html_url, queued: true }
+    }
+
+    if (this.config.fundiEndpoint) {
+      await fetch(this.config.fundiEndpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ report, labels }),
+      })
+      this.config.onReported?.(report)
+      return { queued: true }
+    }
+
+    console.warn("[nyuchi:fundi-reporter] No endpoint configured.", report)
+    return { queued: false }
+  }
+
+  private buildIssueBody(r: FundiReport): string {
+    let b = "## Component Failure Report\n\n"
+    b += `| Field | Value |\n|---|---|\n`
+    b += `| Component | \`${r.component}\` |\n`
+    b += `| Node | ${r.node} |\n`
+    b += `| Severity | ${r.severity} |\n`
+    b += `| Error Type | ${r.errorType} |\n`
+    b += `| Source | ${r.source} |\n`
+    if (r.portalUrl) b += `| Portal | [View](${r.portalUrl}) |\n`
+    b += `\n### Description\n\n${r.description}\n`
+    if (r.affectedMiniApps?.length)
+      b += `\n### Affected Mini-Apps\n\n${r.affectedMiniApps.join(", ")}\n`
+    if (r.blastRadius?.length)
+      b += `\n### Blast Radius\n\n${r.blastRadius.map((c) => `\`${c}\``).join(", ")}\n`
+    if (r.diagnostic)
+      b += `\n### Diagnostic\n\n\`\`\`json\n${JSON.stringify(r.diagnostic, null, 2)}\n\`\`\`\n`
+    b += "\n---\n*Filed by nyuchi-fundi-reporter (the N8 assurance to N9 fundi bridge)*\n"
+    return b
+  }
+}
+
+let _reporter: FundiReporterCore | null = null
+export function getFundiReporter(config?: ReporterConfig): FundiReporterCore {
+  if (!_reporter) _reporter = new FundiReporterCore(config)
+  return _reporter
+}
+export function initFundiReporter(config: ReporterConfig): FundiReporterCore {
+  _reporter = new FundiReporterCore(config)
+  return _reporter
+}
+export type { FundiReporterCore }

--- a/components/registry/n9-fundi/nyuchi-fundi.tsx
+++ b/components/registry/n9-fundi/nyuchi-fundi.tsx
@@ -1,0 +1,291 @@
+"use client"
+import * as React from "react"
+
+/* ═══════════════════════════════════════════════════════════════
+   NYUCHI FUNDI — N9 self-healing intelligence (a rung)
+   Swahili: fixer, mechanic, technician
+
+   N8 assurance observes and finds problems; N9 fundi receives those
+   observations and acts on them. Two rungs, one loop: observe, then heal.
+
+   Was written against the axis model — "the 3D architecture", "the depth
+   dimension", "Z-observe", "Z-act". That model is retired. Nodes sit on two
+   backbones held by cross-cutting rungs; there are no axes and no X/Y/Z, so
+   absence is the correct state for anything axis-shaped rather than a
+   relabelling of it.
+   ═══════════════════════════════════════════════════════════════ */
+
+// ── Remediation Actions ─────────────────────────────────────────
+
+// ARCHITECTURE NOTE: This client-side decision engine works in two contexts:
+// 1. CLIENT-SIDE: FundiProvider wraps the app, catches errors, creates healing plans in-memory
+// 2. SERVER-SIDE: fundi-webhook edge function receives GitHub issues, runs the same
+//    decision logic, writes to fundi_issues table, comments on GitHub
+// The client-side and server-side share the same healing plan logic.
+// GitHub issues are the source of truth — the human-in-the-loop interface.
+
+export type RemediationAction =
+  | { type: "circuit-break"; service: string; durationMs: number }
+  | { type: "fallback-switch"; from: string; to: string }
+  | { type: "cache-clear"; scope: "local" | "edge" | "all" }
+  | { type: "reroute"; fromNode: string; toNode: string }
+  | { type: "retry-with-backoff"; service: string; maxRetries: number }
+  | { type: "degrade-feature"; feature: string; level: "partial" | "static" | "disabled" }
+  | { type: "scale-request"; direction: "up" | "down"; resource: string }
+  | { type: "escalate"; severity: "low" | "medium" | "high" | "critical"; message: string }
+
+// ── Healing Decision Engine ─────────────────────────────────────
+
+export interface DiagnosticInput {
+  blastRadius: "isolated" | "partial" | "systemic"
+  failedComponent: string
+  failedNode: number
+  errorType: "render" | "network" | "data" | "auth" | "chain" | "crypto" | "timeout"
+  errorCount: number
+  timeSinceFirstError: number
+  probeResults: { target: string; status: "healthy" | "degraded" | "error" | "timeout" }[]
+}
+
+export interface HealingPlan {
+  id: string
+  timestamp: string
+  diagnostic: DiagnosticInput
+  actions: RemediationAction[]
+  confidence: number
+  reasoning: string
+  requiresHumanApproval: boolean
+}
+
+/**
+ * The fundi decision engine. Takes a diagnostic report from N8 assurance
+ * and produces a healing plan with remediation actions.
+ *
+ * Decision tree:
+ * 1. Isolated + render error → retry + cache-clear
+ * 2. Isolated + network error → circuit-break + fallback-switch
+ * 3. Partial blast radius → degrade affected features + reroute
+ * 4. Systemic → escalate to human + emergency degradation
+ * 5. Chain/crypto errors → fallback to classical + notify
+ * 6. Repeated errors (>3 in 60s) → circuit-break
+ */
+export function createHealingPlan(input: DiagnosticInput): HealingPlan {
+  const actions: RemediationAction[] = []
+  let confidence = 0.8
+  let reasoning = ""
+  let requiresHumanApproval = false
+
+  // Rule 1: Repeated errors → circuit-break
+  if (input.errorCount > 3 && input.timeSinceFirstError < 60000) {
+    actions.push({ type: "circuit-break", service: input.failedComponent, durationMs: 30000 })
+    reasoning += "Repeated failures detected — circuit-breaking to prevent cascade. "
+  }
+
+  // Rule 2: Blast radius determines severity of response
+  if (input.blastRadius === "systemic") {
+    actions.push({ type: "degrade-feature", feature: "non-critical", level: "disabled" })
+    actions.push({
+      type: "escalate",
+      severity: "critical",
+      message: `Systemic failure: ${input.failedComponent} on N${input.failedNode}. ${input.errorCount} errors in ${Math.round(input.timeSinceFirstError / 1000)}s.`,
+    })
+    confidence = 0.6
+    reasoning += "Systemic outage — disabling non-critical features, escalating to ops. "
+    requiresHumanApproval = true
+  } else if (input.blastRadius === "partial") {
+    const healthyNodes = input.probeResults.filter((p) => p.status === "healthy")
+    if (healthyNodes.length > 0) {
+      actions.push({
+        type: "reroute",
+        fromNode: input.failedComponent,
+        toNode: healthyNodes[0].target,
+      })
+      reasoning += `Partial failure — rerouting to healthy node: ${healthyNodes[0].target}. `
+    }
+    actions.push({ type: "degrade-feature", feature: input.failedComponent, level: "partial" })
+    reasoning += "Degrading affected feature to partial mode. "
+  } else {
+    // Isolated failure
+    if (input.errorType === "network" || input.errorType === "timeout") {
+      actions.push({ type: "retry-with-backoff", service: input.failedComponent, maxRetries: 3 })
+      actions.push({ type: "fallback-switch", from: "cloud", to: "edge" })
+      reasoning += "Isolated network issue — retrying with backoff, switching to edge. "
+    } else if (input.errorType === "data" || input.errorType === "render") {
+      actions.push({ type: "cache-clear", scope: "local" })
+      actions.push({ type: "retry-with-backoff", service: input.failedComponent, maxRetries: 2 })
+      reasoning += "Isolated data/render error — clearing local cache and retrying. "
+    } else if (input.errorType === "chain" || input.errorType === "crypto") {
+      actions.push({ type: "fallback-switch", from: "web3", to: "web2" })
+      actions.push({ type: "degrade-feature", feature: input.failedComponent, level: "partial" })
+      reasoning += "Chain/crypto failure — falling back to Web2 path. "
+      confidence = 0.7
+    } else if (input.errorType === "auth") {
+      actions.push({
+        type: "escalate",
+        severity: "high",
+        message: `Auth failure in ${input.failedComponent}`,
+      })
+      reasoning += "Auth error — escalating (never auto-fix auth). "
+      requiresHumanApproval = true
+    }
+  }
+
+  return {
+    id: `fundi-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    timestamp: new Date().toISOString(),
+    diagnostic: input,
+    actions,
+    confidence,
+    reasoning: reasoning.trim(),
+    requiresHumanApproval,
+  }
+}
+
+// ── Healing Executor ────────────────────────────────────────────
+
+export interface HealingResult {
+  planId: string
+  actionsExecuted: number
+  actionsFailed: number
+  results: { action: RemediationAction; success: boolean; error?: string }[]
+  healedAt: string
+}
+
+/**
+ * An executor per remediation action, keyed by the action's own `type`. Mapped
+ * over the union rather than `Record<type, (a: any) => …>` so a `cache-clear`
+ * executor is handed a `cache-clear` action and nothing else — with `any` every
+ * executor silently accepted every action shape.
+ */
+export type RemediationExecutors = {
+  [K in RemediationAction["type"]]?: (
+    action: Extract<RemediationAction, { type: K }>
+  ) => Promise<boolean>
+}
+
+/**
+ * Execute a healing plan. Each action is attempted in order.
+ * Failed actions don't block subsequent actions.
+ * Returns a structured result for logging and learning.
+ */
+export async function executeHealingPlan(
+  plan: HealingPlan,
+  executors: RemediationExecutors
+): Promise<HealingResult> {
+  const results: HealingResult["results"] = []
+
+  for (const action of plan.actions) {
+    // TypeScript cannot correlate `action.type` with the executor it just
+    // selected, so the union has to be widened back here. Sound by
+    // construction: the key that chose the executor came off this action.
+    const executor = executors[action.type] as
+      ((a: RemediationAction) => Promise<boolean>) | undefined
+    if (!executor) {
+      results.push({ action, success: false, error: "No executor registered" })
+      continue
+    }
+    try {
+      const success = await executor(action)
+      results.push({ action, success })
+    } catch (e) {
+      results.push({ action, success: false, error: (e as Error).message })
+    }
+  }
+
+  const result: HealingResult = {
+    planId: plan.id,
+    actionsExecuted: results.filter((r) => r.success).length,
+    actionsFailed: results.filter((r) => !r.success).length,
+    results,
+    healedAt: new Date().toISOString(),
+  }
+
+  /*
+   * fundi's log IS its artifact: the healing record a human reads before
+   * deciding whether to keep the change. Downgrading it to console.warn would
+   * misreport a success as a problem, so the rule is waived here rather than
+   * the message being made dishonest.
+   */
+  // eslint-disable-next-line no-console
+  console.info(
+    `[nyuchi:fundi] Healing complete: ${result.actionsExecuted}/${plan.actions.length} actions succeeded`,
+    JSON.stringify(result, null, 2)
+  )
+  return result
+}
+
+// ── React Integration ───────────────────────────────────────────
+
+interface FundiContextValue {
+  lastPlan: HealingPlan | null
+  lastResult: HealingResult | null
+  isHealing: boolean
+  heal: (diagnostic: DiagnosticInput) => Promise<HealingResult | null>
+}
+
+const FundiContext = React.createContext<FundiContextValue>({
+  lastPlan: null,
+  lastResult: null,
+  isHealing: false,
+  heal: async () => null,
+})
+
+export function FundiProvider({
+  executors,
+  autoHeal = true,
+  onPlanCreated,
+  onHealComplete,
+  children,
+}: {
+  executors: RemediationExecutors
+  autoHeal?: boolean
+  onPlanCreated?: (plan: HealingPlan) => void
+  onHealComplete?: (result: HealingResult) => void
+  children: React.ReactNode
+}) {
+  const [lastPlan, setLastPlan] = React.useState<HealingPlan | null>(null)
+  const [lastResult, setLastResult] = React.useState<HealingResult | null>(null)
+  const [isHealing, setIsHealing] = React.useState(false)
+
+  const heal = React.useCallback(
+    async (diagnostic: DiagnosticInput): Promise<HealingResult | null> => {
+      const plan = createHealingPlan(diagnostic)
+      setLastPlan(plan)
+      onPlanCreated?.(plan)
+      // See the note in executeHealingPlan — the log is the artifact.
+      // eslint-disable-next-line no-console
+      console.info(`[nyuchi:fundi] Healing plan created: ${plan.reasoning}`)
+
+      if (plan.requiresHumanApproval && !autoHeal) {
+        console.warn("[nyuchi:fundi] Plan requires human approval — waiting")
+        return null
+      }
+
+      setIsHealing(true)
+      try {
+        const result = await executeHealingPlan(plan, executors)
+        setLastResult(result)
+        onHealComplete?.(result)
+        return result
+      } finally {
+        setIsHealing(false)
+      }
+    },
+    [executors, autoHeal, onPlanCreated, onHealComplete]
+  )
+
+  const value = React.useMemo(
+    () => ({ lastPlan, lastResult, isHealing, heal }),
+    [lastPlan, lastResult, isHealing, heal]
+  )
+  return <FundiContext.Provider value={value}>{children}</FundiContext.Provider>
+}
+
+export function useFundi(): FundiContextValue {
+  return React.useContext(FundiContext)
+}
+
+// `DiagnosticInput`, `HealingPlan` and `HealingResult` are already exported at
+// their declarations; re-listing them here was a TS2484 conflict, so this file
+// did not compile in any consumer that installed it. `FundiContextValue` is
+// declared without `export`, so this line is its only export and has to stay.
+export type { FundiContextValue }


### PR DESCRIPTION
Step 3 of the component-source migration, first node (`docs/component-source-migration.md`). Three components onto disk: `nyuchi-fundi`, `nyuchi-fundi-reporter`, `nyuchi-fundi-learning`.

Same result as the N11 pilot: contact with the toolchain failed the build immediately.

## `nyuchi-fundi.tsx` did not compile at all

```
error TS2484: Export declaration conflicts with exported declaration of 'DiagnosticInput'.
error TS2484: Export declaration conflicts with exported declaration of 'HealingPlan'.
error TS2484: Export declaration conflicts with exported declaration of 'HealingResult'.
```

The trailing `export type { DiagnosticInput, HealingPlan, HealingResult, FundiContextValue }` re-listed three types already exported at their declarations. **Anyone who installed this component got a file that would not typecheck in their app** — for as long as the source lived in a JSON column where no typechecker could reach it. Only `FundiContextValue` is declared without `export`, so that entry stays and the other three go.

## Every executor accepted every action

`executeHealingPlan` typed its executors as `Partial<Record<RemediationAction["type"], (action: any) => Promise<boolean>>>`. `RemediationAction` is an eight-member discriminated union, so the `any` meant a `cache-clear` handler would silently accept a `circuit-break` action — the exact mistake the union exists to prevent.

Now mapped over the union, so each executor is handed only its own action shape:

```ts
export type RemediationExecutors = {
  [K in RemediationAction["type"]]?: (
    action: Extract<RemediationAction, { type: K }>
  ) => Promise<boolean>
}
```

The dispatch site widens back with a single commented cast, because TypeScript cannot correlate `action.type` with the executor that key just selected. Sound by construction: the key came off the action.

## All three files still taught the retired axis model

This is the surface consumers read:

- `"L8 (Assurance) observes the 3D architecture"`, `"The depth dimension has two faces"`, `"Z-observe (L8)"`, `"Z-act (L9)"`
- `DiagnosticInput.failedLayer`, and an escalation message rendering `on L${failedLayer}`
- `FundiReport.layer`, a GitHub label `fundi:layer/${layer}`, a `| Layer |` row in the filed issue body
- `"Filed by nyuchi-fundi-reporter (L8 to L9 bridge)"`

Nodes sit on two backbones held by cross-cutting rungs; there are no axes, no 3D and no X/Y/Z (CLAUDE.md §18 — absence is the correct state for anything axis-shaped, not a relabelling). All of it is now node vocabulary.

Renaming the public fields is safe in the way that matters here: shadcn components are **copied** into a consumer's project, not resolved as a versioned dependency, so an existing install keeps its own file and only new installs see the change.

## The two `console.info` calls stay `info`

Behind a scoped `eslint-disable-next-line`, with the reason in the file. fundi's log *is* its artifact — the healing record a human reads before deciding whether to keep the change — and promoting it to `console.warn` to satisfy the linter would report a success as a problem.

## Verification

`pnpm typecheck`, `pnpm lint` (0 warnings — the pre-commit gate is `--max-warnings=0`), `pnpm test` (99 passing) and `pnpm build` all green.

## Ordering

Independent of #197 (the disk read path). #197's `resolveComponentSource` reads disk first and falls back to the DB column, so these two can merge in either order without a gap in what `/api/v1/ui/*` serves. The N9 `source_code` drop happens **after** both are on `main` and serving.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_