### PR TITLE
feat(n6): move page-composition source onto disk

### DIFF
--- a/components/registry/n6-pages/admin-page.tsx
+++ b/components/registry/n6-pages/admin-page.tsx
@@ -1,0 +1,105 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+interface AdminNavItem {
+  key: string
+  label: string
+  icon?: React.ReactNode
+  badge?: number
+}
+interface AdminPageProps {
+  title?: string
+  navItems?: AdminNavItem[]
+  activeNav?: string
+  onNavChange?: (key: string) => void
+  actions?: React.ReactNode
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+export function AdminPage({
+  title = "Admin",
+  navItems,
+  activeNav,
+  onNavChange,
+  actions,
+  children,
+  loading = false,
+  className,
+}: AdminPageProps) {
+  const { motion } = useNyuchiHarness("admin-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="admin-page"
+        data-portal="https://mzizi.dev/components/admin-page"
+        data-loading
+        role="main"
+        className="flex h-screen animate-pulse"
+      >
+        <div className="w-56 bg-muted" />
+        <div className="flex-1 space-y-4 p-6">
+          <div className="h-8 w-1/3 rounded bg-muted" />
+          <div className="h-64 rounded-[var(--radius-lg,14px)] bg-muted" />
+        </div>
+      </main>
+    )
+  return (
+    <main
+      data-slot="admin-page"
+      role="main"
+      aria-label={title}
+      style={animStyle}
+      className={cn("flex h-screen overflow-hidden", className)}
+    >
+      {navItems && (
+        <aside className="w-56 shrink-0 overflow-y-auto border-r border-border p-3">
+          <p className="mb-3 px-2 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+            {title}
+          </p>
+          {navItems.map((item) => (
+            <button
+              key={item.key}
+              onClick={() => onNavChange?.(item.key)}
+              className={cn(
+                "flex min-h-[44px] w-full items-center justify-between rounded-[var(--radius-sm,7px)] px-3 py-2 text-sm transition-colors",
+                activeNav === item.key
+                  ? "bg-muted font-medium text-foreground"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
+              )}
+            >
+              <div className="flex items-center gap-2">
+                {item.icon}
+                <span>{item.label}</span>
+              </div>
+              {item.badge != null && item.badge > 0 && (
+                <span className="rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-bold text-white">
+                  {item.badge}
+                </span>
+              )}
+            </button>
+          ))}
+        </aside>
+      )}
+      <div className="flex flex-1 flex-col overflow-y-auto">
+        {actions && (
+          <header className="flex items-center justify-between border-b border-border px-6 py-3">
+            {actions}
+          </header>
+        )}
+        <div className="flex-1 p-6">{children}</div>
+      </div>
+    </main>
+  )
+}
+export type { AdminNavItem, AdminPageProps }

--- a/components/registry/n6-pages/analytics-dashboard-page.tsx
+++ b/components/registry/n6-pages/analytics-dashboard-page.tsx
@@ -1,0 +1,118 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+
+interface KPICard {
+  label: string
+  value: string | number
+  change?: number
+  trend?: "up" | "down" | "flat"
+}
+interface AnalyticsDashboardPageProps {
+  title?: string
+  dateRange?: React.ReactNode
+  kpis?: KPICard[]
+  exportAction?: () => void
+  filters?: React.ReactNode
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+
+export function AnalyticsDashboardPage({
+  title = "Analytics",
+  dateRange,
+  kpis,
+  exportAction,
+  filters,
+  children,
+  loading = false,
+  className,
+}: AnalyticsDashboardPageProps) {
+  const { motion } = useNyuchiHarness("analytics-dashboard-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="analytics-dashboard-page"
+        data-portal="https://mzizi.dev/components/analytics-dashboard-page"
+        data-loading
+        role="main"
+        className="animate-pulse space-y-4 p-4"
+      >
+        <div className="h-8 w-1/3 rounded bg-muted" />
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-24 rounded-[var(--radius-lg,14px)] bg-muted" />
+          ))}
+        </div>
+        <div className="h-72 rounded-[var(--radius-lg,14px)] bg-muted" />
+      </main>
+    )
+  return (
+    <main
+      data-slot="analytics-dashboard-page"
+      role="main"
+      aria-label={title}
+      style={animStyle}
+      className={cn("flex flex-col gap-6 p-4 lg:p-6", className)}
+    >
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h1 className="text-xl font-bold">{title}</h1>
+        <div className="flex items-center gap-2">
+          {dateRange}
+          {exportAction && (
+            <button
+              onClick={exportAction}
+              className="min-h-[48px] rounded-[var(--radius-lg,14px)] border border-border px-4 text-sm font-medium transition-colors hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+            >
+              Export
+            </button>
+          )}
+        </div>
+      </header>
+      {kpis && kpis.length > 0 && (
+        <section aria-label="Key metrics" className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          {kpis.map((kpi, i) => (
+            <div
+              key={i}
+              className="rounded-[var(--radius-lg,14px)] border border-border bg-card p-4"
+            >
+              <p className="text-xs text-muted-foreground">{kpi.label}</p>
+              <p className="mt-1 text-2xl font-bold">
+                {typeof kpi.value === "number" ? kpi.value.toLocaleString() : kpi.value}
+              </p>
+              {kpi.change != null && (
+                <p
+                  className={cn(
+                    "mt-0.5 text-xs font-medium",
+                    kpi.change >= 0
+                      ? "text-[var(--status-success,var(--color-malachite,#64FFDA))]"
+                      : "text-[var(--status-error,var(--destructive,#FF5252))]"
+                  )}
+                >
+                  {kpi.change >= 0 ? "+" : ""}
+                  {kpi.change}%
+                </p>
+              )}
+            </div>
+          ))}
+        </section>
+      )}
+      {filters && <section aria-label="Filters">{filters}</section>}
+      <section aria-label="Charts and data" className="flex flex-col gap-4">
+        {children}
+      </section>
+    </main>
+  )
+}
+export type { KPICard, AnalyticsDashboardPageProps }

--- a/components/registry/n6-pages/api-explorer-page.tsx
+++ b/components/registry/n6-pages/api-explorer-page.tsx
@@ -1,0 +1,117 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+type HTTPMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+interface APIEndpoint {
+  method: HTTPMethod
+  path: string
+  description?: string
+}
+interface APIExplorerPageProps {
+  endpoints?: APIEndpoint[]
+  selectedEndpoint?: APIEndpoint
+  requestBuilder?: React.ReactNode
+  responseViewer?: React.ReactNode
+  authInput?: React.ReactNode
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+const METHOD_COLORS: Record<HTTPMethod, string> = {
+  GET: "var(--status-success, var(--color-malachite, #64FFDA))",
+  POST: "var(--status-info, var(--color-cobalt, #00B0FF))",
+  PUT: "var(--status-warning, var(--color-gold, #FFD740))",
+  PATCH: "var(--status-warning, var(--color-gold, #FFD740))",
+  DELETE: "var(--status-error, var(--destructive, #FF5252))",
+}
+export function APIExplorerPage({
+  endpoints,
+  selectedEndpoint,
+  requestBuilder,
+  responseViewer,
+  authInput,
+  children,
+  loading = false,
+  className,
+}: APIExplorerPageProps) {
+  const { motion } = useNyuchiHarness("api-explorer-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="api-explorer-page"
+        data-portal="https://mzizi.dev/components/api-explorer-page"
+        data-loading
+        role="main"
+        className="flex h-screen animate-pulse"
+      >
+        <div className="w-64 bg-muted" />
+        <div className="flex-1 space-y-4 p-4">
+          <div className="h-12 rounded bg-muted" />
+          <div className="h-96 rounded bg-muted" />
+        </div>
+      </main>
+    )
+  return (
+    <main
+      data-slot="api-explorer-page"
+      role="main"
+      aria-label="API Explorer"
+      style={animStyle}
+      className={cn("flex h-screen overflow-hidden", className)}
+    >
+      {endpoints && (
+        <aside className="w-64 shrink-0 overflow-y-auto border-r border-border p-3">
+          <p className="mb-2 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+            Endpoints
+          </p>
+          {endpoints.map((ep, i) => (
+            <button
+              key={i}
+              className={cn(
+                "flex min-h-[44px] w-full items-center gap-2 rounded-[var(--radius-sm,7px)] px-2 py-1.5 text-left text-sm transition-colors hover:bg-muted",
+                selectedEndpoint?.path === ep.path && "bg-muted"
+              )}
+            >
+              <span
+                className="shrink-0 rounded px-1 py-0.5 font-mono text-[10px] font-bold"
+                style={{ color: METHOD_COLORS[ep.method] }}
+              >
+                {ep.method}
+              </span>
+              <span className="truncate font-mono text-xs">{ep.path}</span>
+            </button>
+          ))}
+        </aside>
+      )}
+      <div className="flex flex-1 flex-col overflow-y-auto">
+        {authInput && (
+          <section aria-label="Authentication" className="border-b border-border p-3">
+            {authInput}
+          </section>
+        )}
+        {requestBuilder && (
+          <section aria-label="Request" className="border-b border-border p-4">
+            {requestBuilder}
+          </section>
+        )}
+        {responseViewer && (
+          <section aria-label="Response" className="flex-1 bg-muted/30 p-4">
+            {responseViewer}
+          </section>
+        )}
+        {children}
+      </div>
+    </main>
+  )
+}
+export type { HTTPMethod, APIEndpoint, APIExplorerPageProps }

--- a/components/registry/n6-pages/article-page.tsx
+++ b/components/registry/n6-pages/article-page.tsx
@@ -1,0 +1,94 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+
+interface ArticlePageProps {
+  title?: string
+  author?: { name: string; avatar?: string }
+  publishedAt?: string
+  readTime?: string
+  heroImage?: string
+  source?: { name: string; credibility?: string }
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+
+export function ArticlePage({
+  title,
+  author,
+  publishedAt,
+  readTime,
+  heroImage,
+  source,
+  children,
+  loading = false,
+  className,
+}: ArticlePageProps) {
+  const { motion } = useNyuchiHarness("article-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="article-page"
+        data-portal="https://mzizi.dev/components/article-page"
+        data-loading
+        role="main"
+        className="animate-pulse"
+      >
+        <div className="aspect-[var(--aspect-media,1/1)] bg-muted" />
+        <div className="space-y-3 p-4">
+          <div className="h-8 w-3/4 rounded bg-muted" />
+          <div className="h-4 w-1/2 rounded bg-muted" />
+          <div className="h-64 rounded bg-muted" />
+        </div>
+      </main>
+    )
+  return (
+    <article
+      data-slot="article-page"
+      role="article"
+      style={animStyle}
+      className={cn("mx-auto flex max-w-3xl flex-col", className)}
+    >
+      {heroImage && (
+        <img
+          src={heroImage}
+          alt=""
+          className="aspect-[var(--aspect-media,1/1)] w-full object-cover"
+        />
+      )}
+      <div className="px-4 py-6">
+        {title && <h1 className="text-2xl leading-tight font-bold sm:text-3xl">{title}</h1>}
+        <div className="mt-3 flex items-center gap-3 text-sm text-muted-foreground">
+          {author && (
+            <div className="flex items-center gap-2">
+              {author.avatar && (
+                <div className="size-6 overflow-hidden rounded-full bg-muted">
+                  <img src={author.avatar} alt="" className="size-full object-cover" />
+                </div>
+              )}
+              <span className="font-medium text-foreground">{author.name}</span>
+            </div>
+          )}
+          {publishedAt && <time>{publishedAt}</time>}
+          {readTime && <span>{readTime}</span>}
+          {source && (
+            <span className="rounded-full bg-muted px-2 py-0.5 text-xs">{source.name}</span>
+          )}
+        </div>
+        <div className="prose prose-sm mt-6 max-w-none text-foreground">{children}</div>
+      </div>
+    </article>
+  )
+}
+export type { ArticlePageProps }

--- a/components/registry/n6-pages/billing-page.tsx
+++ b/components/registry/n6-pages/billing-page.tsx
@@ -1,0 +1,136 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+interface BillingPlan {
+  name: string
+  price: string
+  period: string
+  features: string[]
+  isCurrent?: boolean
+}
+interface BillingPageProps {
+  currentPlan?: BillingPlan
+  plans?: BillingPlan[]
+  usage?: React.ReactNode
+  invoices?: React.ReactNode
+  paymentMethods?: React.ReactNode
+  onUpgrade?: (plan: string) => void
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+export function BillingPage({
+  currentPlan,
+  plans,
+  usage,
+  invoices,
+  paymentMethods,
+  onUpgrade,
+  children,
+  loading = false,
+  className,
+}: BillingPageProps) {
+  const { motion } = useNyuchiHarness("billing-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="billing-page"
+        data-portal="https://mzizi.dev/components/billing-page"
+        data-loading
+        role="main"
+        className="mx-auto max-w-4xl animate-pulse space-y-4 p-6"
+      >
+        <div className="h-8 w-1/3 rounded bg-muted" />
+        <div className="h-32 rounded-[var(--radius-lg,14px)] bg-muted" />
+        <div className="grid grid-cols-3 gap-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-48 rounded-[var(--radius-lg,14px)] bg-muted" />
+          ))}
+        </div>
+      </main>
+    )
+  return (
+    <main
+      data-slot="billing-page"
+      role="main"
+      aria-label="Billing"
+      style={animStyle}
+      className={cn("mx-auto flex max-w-4xl flex-col gap-6 p-6", className)}
+    >
+      <h1 className="text-xl font-bold">Billing & Plans</h1>
+      {currentPlan && (
+        <section
+          aria-label="Current plan"
+          className="rounded-[var(--radius-xl,17px)] border border-border bg-gradient-to-r from-[var(--status-info,var(--color-cobalt,#00B0FF))]/10 to-[var(--color-tanzanite,#B388FF)]/10 p-6"
+        >
+          <p className="text-sm text-muted-foreground">Current Plan</p>
+          <p className="mt-1 text-2xl font-bold">{currentPlan.name}</p>
+          <p className="text-sm text-muted-foreground">
+            {currentPlan.price} / {currentPlan.period}
+          </p>
+        </section>
+      )}
+      {usage && <section aria-label="Usage">{usage}</section>}
+      {plans && plans.length > 0 && (
+        <section aria-label="Available plans" className="grid grid-cols-1 gap-3 md:grid-cols-3">
+          {plans.map((plan) => (
+            <div
+              key={plan.name}
+              className={cn(
+                "rounded-[var(--radius-lg,14px)] bg-card p-5 ring-1",
+                plan.isCurrent
+                  ? "ring-2 ring-[var(--status-info,var(--color-cobalt,#00B0FF))]"
+                  : "ring-foreground/10"
+              )}
+            >
+              <p className="font-semibold">{plan.name}</p>
+              <p className="mt-1 text-2xl font-bold">
+                {plan.price}
+                <span className="text-sm font-normal text-muted-foreground"> / {plan.period}</span>
+              </p>
+              <ul className="mt-3 space-y-1 text-sm text-muted-foreground">
+                {plan.features.map((f, i) => (
+                  <li key={i} className="flex items-center gap-1.5">
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="var(--status-success,var(--color-malachite,#64FFDA))"
+                      strokeWidth="2"
+                    >
+                      <path d="M5 12l5 5L20 7" />
+                    </svg>
+                    {f}
+                  </li>
+                ))}
+              </ul>
+              {!plan.isCurrent && onUpgrade && (
+                <button
+                  onClick={() => onUpgrade(plan.name)}
+                  className="mt-4 min-h-[48px] w-full rounded-full bg-primary text-sm font-medium text-white transition-colors hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+                >
+                  Upgrade
+                </button>
+              )}
+            </div>
+          ))}
+        </section>
+      )}
+      {paymentMethods && <section aria-label="Payment methods">{paymentMethods}</section>}
+      {invoices && <section aria-label="Invoices">{invoices}</section>}
+      {children}
+    </main>
+  )
+}
+export type { BillingPlan, BillingPageProps }

--- a/components/registry/n6-pages/booking-page.tsx
+++ b/components/registry/n6-pages/booking-page.tsx
@@ -1,0 +1,79 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+type BookingStep = "select" | "schedule" | "provider" | "confirm" | "booked"
+interface BookingPageProps {
+  step?: BookingStep
+  serviceName?: string
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+export function BookingPage({
+  step = "select",
+  serviceName,
+  children,
+  loading = false,
+  className,
+}: BookingPageProps) {
+  const { motion } = useNyuchiHarness("booking-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="booking-page"
+        data-portal="https://mzizi.dev/components/booking-page"
+        data-loading
+        role="main"
+        className="mx-auto max-w-md animate-pulse space-y-4 p-4"
+      >
+        <div className="h-8 w-1/2 rounded bg-muted" />
+        <div className="h-48 rounded-[var(--radius-lg,14px)] bg-muted" />
+      </main>
+    )
+  return (
+    <main
+      data-slot="booking-page"
+      data-step={step}
+      role="main"
+      aria-label={serviceName ? `Book ${serviceName}` : "Booking"}
+      style={animStyle}
+      className={cn("mx-auto flex max-w-md flex-col gap-6 p-4", className)}
+    >
+      {step === "booked" ? (
+        <div className="flex flex-col items-center gap-4 py-12">
+          <div className="flex size-16 items-center justify-center rounded-full bg-[var(--status-success,var(--color-malachite,#64FFDA))]/15">
+            <svg
+              width="32"
+              height="32"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              aria-hidden="true"
+            >
+              <path d="M5 12l5 5L20 7" />
+            </svg>
+          </div>
+          <p className="text-xl font-bold">Booking Confirmed</p>
+          {serviceName && <p className="text-sm text-muted-foreground">{serviceName}</p>}
+        </div>
+      ) : (
+        <>
+          {serviceName && <h1 className="text-xl font-bold">{serviceName}</h1>}
+          {children}
+        </>
+      )}
+    </main>
+  )
+}
+export type { BookingStep, BookingPageProps }

--- a/components/registry/n6-pages/chat-page.tsx
+++ b/components/registry/n6-pages/chat-page.tsx
@@ -1,0 +1,98 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+
+interface ChatPageProps {
+  variant?: "list" | "conversation"
+  title?: string
+  subtitle?: string
+  showBack?: boolean
+  onBack?: () => void
+  inputArea?: React.ReactNode
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+
+export function ChatPage({
+  variant = "list",
+  title,
+  subtitle,
+  showBack,
+  onBack,
+  inputArea,
+  children,
+  loading = false,
+  className,
+}: ChatPageProps) {
+  const { motion } = useNyuchiHarness("chat-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="chat-page"
+        data-portal="https://mzizi.dev/components/chat-page"
+        data-loading
+        role="main"
+        className="flex h-full animate-pulse flex-col"
+      >
+        <div className="h-14 bg-muted" />
+        <div className="flex-1 space-y-3 p-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-16 rounded-[var(--radius-lg,14px)] bg-muted" />
+          ))}
+        </div>
+      </main>
+    )
+  return (
+    <main
+      data-slot="chat-page"
+      data-variant={variant}
+      role="main"
+      aria-label={title || "Messages"}
+      style={animStyle}
+      className={cn("flex h-full flex-col", className)}
+    >
+      {(title || showBack) && (
+        <header className="flex items-center gap-3 border-b border-border px-4 py-3">
+          {showBack && (
+            <button
+              onClick={onBack}
+              aria-label="Back"
+              className="flex min-h-[48px] min-w-[48px] items-center justify-center rounded-full transition-colors hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path d="M19 12H5M12 19l-7-7 7-7" />
+              </svg>
+            </button>
+          )}
+          <div className="min-w-0 flex-1">
+            <p className="truncate font-semibold">{title}</p>
+            {subtitle && <p className="truncate text-xs text-muted-foreground">{subtitle}</p>}
+          </div>
+        </header>
+      )}
+      <div className="flex-1 overflow-y-auto p-4">{children}</div>
+      {variant === "conversation" && inputArea && (
+        <footer className="border-t border-border p-3">{inputArea}</footer>
+      )}
+    </main>
+  )
+}
+export type { ChatPageProps }

--- a/components/registry/n6-pages/checkout-page.tsx
+++ b/components/registry/n6-pages/checkout-page.tsx
@@ -1,0 +1,91 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+type CheckoutStep = "cart" | "shipping" | "payment" | "review" | "processing" | "confirmed"
+interface CheckoutPageProps {
+  step?: CheckoutStep
+  orderSummary?: React.ReactNode
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+const STEPS: CheckoutStep[] = ["cart", "shipping", "payment", "review"]
+export function CheckoutPage({
+  step = "cart",
+  orderSummary,
+  children,
+  loading = false,
+  className,
+}: CheckoutPageProps) {
+  const { motion } = useNyuchiHarness("checkout-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  const idx = STEPS.indexOf(step)
+  if (loading)
+    return (
+      <main
+        data-slot="checkout-page"
+        data-portal="https://mzizi.dev/components/checkout-page"
+        data-loading
+        role="main"
+        className="mx-auto max-w-lg animate-pulse space-y-4 p-4"
+      >
+        <div className="h-4 rounded bg-muted" />
+        <div className="h-48 rounded-[var(--radius-lg,14px)] bg-muted" />
+        <div className="h-14 rounded-full bg-muted" />
+      </main>
+    )
+  return (
+    <main
+      data-slot="checkout-page"
+      data-step={step}
+      role="main"
+      aria-label="Checkout"
+      style={animStyle}
+      className={cn("mx-auto flex max-w-lg flex-col gap-6 p-4", className)}
+    >
+      {step !== "processing" && step !== "confirmed" && (
+        <nav aria-label="Checkout steps" className="flex gap-1">
+          {STEPS.map((s, i) => (
+            <div
+              key={s}
+              className={cn(
+                "h-1 flex-1 rounded-full transition-colors",
+                i <= idx ? "bg-primary" : "bg-muted"
+              )}
+            />
+          ))}
+        </nav>
+      )}
+      {step === "confirmed" && (
+        <div className="flex flex-col items-center gap-4 py-12">
+          <div className="flex size-16 items-center justify-center rounded-full bg-[var(--status-success,var(--color-malachite,#64FFDA))]/15">
+            <svg
+              width="32"
+              height="32"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              aria-hidden="true"
+            >
+              <path d="M5 12l5 5L20 7" />
+            </svg>
+          </div>
+          <p className="text-xl font-bold">Order Confirmed</p>
+        </div>
+      )}
+      {children}
+      {orderSummary && <aside aria-label="Order summary">{orderSummary}</aside>}
+    </main>
+  )
+}
+export type { CheckoutStep, CheckoutPageProps }

--- a/components/registry/n6-pages/console-dashboard-page.tsx
+++ b/components/registry/n6-pages/console-dashboard-page.tsx
@@ -1,0 +1,122 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+interface ConsoleProject {
+  name: string
+  status: "active" | "deploying" | "error" | "paused"
+  lastDeploy?: string
+  region?: string
+}
+interface ConsoleDashboardPageProps {
+  projects?: ConsoleProject[]
+  usage?: React.ReactNode
+  traffic?: React.ReactNode
+  quickActions?: { label: string; onClick: () => void }[]
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+export function ConsoleDashboardPage({
+  projects,
+  usage,
+  traffic,
+  quickActions,
+  children,
+  loading = false,
+  className,
+}: ConsoleDashboardPageProps) {
+  const { motion } = useNyuchiHarness("console-dashboard-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="console-dashboard-page"
+        data-portal="https://mzizi.dev/components/console-dashboard-page"
+        data-loading
+        role="main"
+        className="animate-pulse space-y-4 p-6"
+      >
+        <div className="h-8 w-1/3 rounded bg-muted" />
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-40 rounded-[var(--radius-lg,14px)] bg-muted" />
+          ))}
+        </div>
+      </main>
+    )
+  return (
+    <main
+      data-slot="console-dashboard-page"
+      role="main"
+      aria-label="Console Dashboard"
+      style={animStyle}
+      className={cn("flex flex-col gap-6 p-6", className)}
+    >
+      <header className="flex items-center justify-between">
+        <h1 className="text-xl font-bold">Dashboard</h1>
+        {quickActions && (
+          <div className="flex gap-2">
+            {quickActions.map((a, i) => (
+              <button
+                key={i}
+                onClick={a.onClick}
+                className="min-h-[48px] rounded-full bg-primary px-4 text-sm font-medium text-white transition-colors hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+              >
+                {a.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </header>
+      {projects && (
+        <section
+          aria-label="Projects"
+          className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3"
+        >
+          {projects.map((p) => (
+            <div
+              key={p.name}
+              className="rounded-[var(--radius-lg,14px)] border border-border bg-card p-4"
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-medium">{p.name}</span>
+                <div
+                  className="size-2 rounded-full"
+                  style={{
+                    backgroundColor:
+                      p.status === "active"
+                        ? "var(--health-operational, var(--status-success, var(--color-malachite, #64FFDA)))"
+                        : p.status === "error"
+                          ? "var(--health-outage, var(--destructive, #FF5252))"
+                          : p.status === "deploying"
+                            ? "var(--health-maintenance, var(--status-info, var(--color-cobalt, #00B0FF)))"
+                            : "var(--color-muted-foreground)",
+                  }}
+                />
+              </div>
+              <div className="mt-2 flex items-center gap-3 text-xs text-muted-foreground">
+                {p.region && <span>{p.region}</span>}
+                {p.lastDeploy && <span>{p.lastDeploy}</span>}
+              </div>
+            </div>
+          ))}
+        </section>
+      )}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {usage && <section aria-label="Usage">{usage}</section>}
+        {traffic && <section aria-label="Traffic">{traffic}</section>}
+      </div>
+      {children}
+    </main>
+  )
+}
+export type { ConsoleProject, ConsoleDashboardPageProps }

--- a/components/registry/n6-pages/data-explorer-page.tsx
+++ b/components/registry/n6-pages/data-explorer-page.tsx
@@ -1,0 +1,89 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+interface DataExplorerPageProps {
+  datasetName?: string
+  description?: string
+  queryBuilder?: React.ReactNode
+  columns?: React.ReactNode
+  exportFormats?: ("csv" | "json" | "xlsx" | "parquet")[]
+  onExport?: (format: string) => void
+  totalRows?: number
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+export function DataExplorerPage({
+  datasetName,
+  description,
+  queryBuilder,
+  columns,
+  exportFormats = ["csv", "json"],
+  onExport,
+  totalRows,
+  children,
+  loading = false,
+  className,
+}: DataExplorerPageProps) {
+  const { motion } = useNyuchiHarness("data-explorer-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="data-explorer-page"
+        data-portal="https://mzizi.dev/components/data-explorer-page"
+        data-loading
+        role="main"
+        className="animate-pulse space-y-4 p-4"
+      >
+        <div className="h-8 w-1/2 rounded bg-muted" />
+        <div className="h-12 rounded-[var(--radius-lg,14px)] bg-muted" />
+        <div className="h-96 rounded-[var(--radius-lg,14px)] bg-muted" />
+      </main>
+    )
+  return (
+    <main
+      data-slot="data-explorer-page"
+      role="main"
+      aria-label={datasetName || "Data Explorer"}
+      style={animStyle}
+      className={cn("flex flex-col gap-4 p-4 lg:p-6", className)}
+    >
+      <header>
+        {datasetName && <h1 className="text-xl font-bold">{datasetName}</h1>}
+        {description && <p className="mt-1 text-sm text-muted-foreground">{description}</p>}
+        <div className="mt-2 flex items-center gap-3 text-xs text-muted-foreground">
+          {totalRows != null && <span>{totalRows.toLocaleString()} rows</span>}
+          {exportFormats.length > 0 && (
+            <div className="flex gap-1">
+              {exportFormats.map((f) => (
+                <button
+                  key={f}
+                  onClick={() => onExport?.(f)}
+                  className="min-h-[44px] rounded bg-muted px-2 py-1 font-mono text-xs transition-colors hover:bg-foreground/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+                >
+                  {f.toUpperCase()}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </header>
+      {queryBuilder && <section aria-label="Query">{queryBuilder}</section>}
+      {columns && <section aria-label="Columns">{columns}</section>}
+      <section aria-label="Data" className="overflow-x-auto">
+        {children}
+      </section>
+    </main>
+  )
+}
+export type { DataExplorerPageProps }

--- a/components/registry/n6-pages/health-dashboard-page.tsx
+++ b/components/registry/n6-pages/health-dashboard-page.tsx
@@ -1,0 +1,68 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+interface HealthDashboardPageProps {
+  vitals?: React.ReactNode
+  activity?: React.ReactNode
+  medications?: React.ReactNode
+  appointments?: React.ReactNode
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+export function HealthDashboardPage({
+  vitals,
+  activity,
+  medications,
+  appointments,
+  children,
+  loading = false,
+  className,
+}: HealthDashboardPageProps) {
+  const { motion } = useNyuchiHarness("health-dashboard-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="health-dashboard-page"
+        data-portal="https://mzizi.dev/components/health-dashboard-page"
+        data-loading
+        role="main"
+        className="animate-pulse space-y-4 p-4"
+      >
+        <div className="h-8 w-1/3 rounded bg-muted" />
+        <div className="grid grid-cols-2 gap-3">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-24 rounded-[var(--radius-lg,14px)] bg-muted" />
+          ))}
+        </div>
+        <div className="h-48 rounded-[var(--radius-lg,14px)] bg-muted" />
+      </main>
+    )
+  return (
+    <main
+      data-slot="health-dashboard-page"
+      role="main"
+      aria-label="Health Dashboard"
+      style={animStyle}
+      className={cn("flex flex-col gap-4 p-4", className)}
+    >
+      <h1 className="text-xl font-bold">Health</h1>
+      {vitals && <section aria-label="Vitals">{vitals}</section>}
+      {activity && <section aria-label="Activity">{activity}</section>}
+      {medications && <section aria-label="Medications">{medications}</section>}
+      {appointments && <section aria-label="Appointments">{appointments}</section>}
+      {children}
+    </main>
+  )
+}
+export type { HealthDashboardPageProps }

--- a/components/registry/n6-pages/individual-profile-page.tsx
+++ b/components/registry/n6-pages/individual-profile-page.tsx
@@ -1,0 +1,161 @@
+/* ═══════════════════════════════════════════════════════════════
+   PROFILE PAGE — Layer 6 (Page Composition)
+   
+   COMPOSITION: Should compose nyuchi-cover-header (L3) for the
+   cover image + avatar section instead of rendering inline.
+   COMPOSITION: Should compose nyuchi-profile-block (L3) for the
+   name + badge + stats section.
+   
+   Currently approved for use as-is. Refactor tracked.
+   ═══════════════════════════════════════════════════════════════ */
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+// COMPOSITION: Uses NyuchiCoverHeader from @/components/brand/nyuchi-cover-header
+// import { NyuchiCoverHeader } from "@/components/brand/nyuchi-cover-header"
+
+interface ProfileUser {
+  name: string
+  handle?: string
+  avatar?: string
+  bio?: string
+  verificationTier?: string
+  trustScore?: number
+  stats?: { label: string; value: string | number }[]
+  coverImage?: string
+}
+interface IndividualProfilePageProps {
+  user?: ProfileUser
+  tabs?: { key: string; label: string; count?: number }[]
+  activeTab?: string
+  onTabChange?: (key: string) => void
+  isOwnProfile?: boolean
+  onEdit?: () => void
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+
+export function IndividualProfilePage({
+  user,
+  tabs,
+  activeTab,
+  onTabChange,
+  isOwnProfile,
+  onEdit,
+  children,
+  loading = false,
+  className,
+}: IndividualProfilePageProps) {
+  const { motion } = useNyuchiHarness("individual-profile-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="individual-profile-page"
+        data-portal="https://mzizi.dev/components/individual-profile-page"
+        data-loading
+        role="main"
+        className="animate-pulse"
+      >
+        <div className="h-32 bg-muted" />
+        <div className="space-y-3 p-4">
+          <div className="-mt-8 h-16 w-16 rounded-full bg-muted" />
+          <div className="h-6 w-1/3 rounded bg-muted" />
+          <div className="h-4 w-2/3 rounded bg-muted" />
+        </div>
+      </main>
+    )
+  return (
+    <main
+      data-slot="individual-profile-page"
+      role="main"
+      aria-label={user?.name || "Profile"}
+      style={animStyle}
+      className={cn("flex flex-col", className)}
+    >
+      {user?.coverImage && (
+        <div
+          className="h-32 bg-cover bg-center sm:h-48"
+          style={{ backgroundImage: `url(${user.coverImage})` }}
+        />
+      )}
+      <div className="px-4 pb-4">
+        <div className="-mt-10 flex items-end justify-between">
+          <div className="size-20 overflow-hidden rounded-full border-4 border-background bg-muted">
+            {user?.avatar && <img src={user.avatar} alt="" className="size-full object-cover" />}
+          </div>
+          {isOwnProfile && onEdit && (
+            <button
+              onClick={onEdit}
+              className="min-h-[48px] rounded-full border border-border px-4 text-sm font-medium transition-colors hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+            >
+              Edit Profile
+            </button>
+          )}
+        </div>
+        <div className="mt-3">
+          <h1 className="text-xl font-bold">{user?.name}</h1>
+          {user?.handle && <p className="text-sm text-muted-foreground">@{user.handle}</p>}
+          {user?.bio && <p className="mt-2 text-sm text-foreground">{user.bio}</p>}
+          {user?.verificationTier && (
+            <span
+              className="mt-2 inline-block rounded-full px-2 py-0.5 text-xs font-medium"
+              style={{
+                backgroundColor:
+                  "var(--tier-community, var(--status-success, var(--color-malachite, #64FFDA)))",
+                color: "black",
+                opacity: 0.9,
+              }}
+            >
+              {user.verificationTier}
+            </span>
+          )}
+        </div>
+        {user?.stats && (
+          <div className="mt-3 flex gap-4">
+            {user.stats.map((s, i) => (
+              <div key={i} className="text-center">
+                <p className="text-sm font-bold">{s.value}</p>
+                <p className="text-xs text-muted-foreground">{s.label}</p>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+      {tabs && (
+        <nav aria-label="Profile sections" className="flex border-b border-border px-4">
+          {tabs.map((t) => (
+            <button
+              key={t.key}
+              onClick={() => onTabChange?.(t.key)}
+              aria-selected={activeTab === t.key}
+              className={cn(
+                "min-h-[48px] border-b-2 px-4 text-sm font-medium transition-colors",
+                activeTab === t.key
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {t.label}
+              {t.count != null && (
+                <span className="ml-1 text-xs text-muted-foreground">({t.count})</span>
+              )}
+            </button>
+          ))}
+        </nav>
+      )}
+      <div className="p-4">{children}</div>
+    </main>
+  )
+}
+export type { ProfileUser, IndividualProfilePageProps }

--- a/components/registry/n6-pages/infrastructure-page.tsx
+++ b/components/registry/n6-pages/infrastructure-page.tsx
@@ -1,0 +1,105 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+interface InfraService {
+  name: string
+  status: "operational" | "degraded" | "outage" | "maintenance"
+  uptime?: string
+  latency?: number
+}
+interface InfrastructurePageProps {
+  services?: InfraService[]
+  deployments?: React.ReactNode
+  resources?: React.ReactNode
+  incidents?: React.ReactNode
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+export function InfrastructurePage({
+  services,
+  deployments,
+  resources,
+  incidents,
+  children,
+  loading = false,
+  className,
+}: InfrastructurePageProps) {
+  const { motion } = useNyuchiHarness("infrastructure-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="infrastructure-page"
+        data-portal="https://mzizi.dev/components/infrastructure-page"
+        data-loading
+        role="main"
+        className="animate-pulse space-y-4 p-6"
+      >
+        <div className="h-8 w-1/3 rounded bg-muted" />
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-20 rounded-[var(--radius-lg,14px)] bg-muted" />
+          ))}
+        </div>
+      </main>
+    )
+  return (
+    <main
+      data-slot="infrastructure-page"
+      role="main"
+      aria-label="Infrastructure"
+      style={animStyle}
+      className={cn("flex flex-col gap-6 p-6", className)}
+    >
+      <h1 className="text-xl font-bold">Infrastructure</h1>
+      {services && (
+        <section aria-label="Service health" className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          {services.map((s) => (
+            <div
+              key={s.name}
+              className="rounded-[var(--radius-lg,14px)] border border-border bg-card p-3"
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium">{s.name}</span>
+                <div
+                  className="size-2 rounded-full"
+                  style={{
+                    backgroundColor:
+                      s.status === "operational"
+                        ? "var(--health-operational, var(--status-success, var(--color-malachite, #64FFDA)))"
+                        : s.status === "degraded"
+                          ? "var(--health-degraded, var(--status-warning, var(--color-gold, #FFD740)))"
+                          : s.status === "outage"
+                            ? "var(--health-outage, var(--destructive, #FF5252))"
+                            : "var(--health-maintenance, var(--status-info, var(--color-cobalt, #00B0FF)))",
+                  }}
+                />
+              </div>
+              <div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
+                {s.uptime && <span>{s.uptime}</span>}
+                {s.latency != null && <span>{s.latency}ms</span>}
+              </div>
+            </div>
+          ))}
+        </section>
+      )}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {resources && <section aria-label="Resources">{resources}</section>}
+        {deployments && <section aria-label="Deployments">{deployments}</section>}
+      </div>
+      {incidents && <section aria-label="Incidents">{incidents}</section>}
+      {children}
+    </main>
+  )
+}
+export type { InfraService, InfrastructurePageProps }

--- a/components/registry/n6-pages/job-board-page.tsx
+++ b/components/registry/n6-pages/job-board-page.tsx
@@ -1,0 +1,77 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+interface JobBoardPageProps {
+  search?: React.ReactNode
+  filters?: React.ReactNode
+  resultCount?: number
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+export function JobBoardPage({
+  search,
+  filters,
+  resultCount,
+  children,
+  loading = false,
+  className,
+}: JobBoardPageProps) {
+  const { motion } = useNyuchiHarness("job-board-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="job-board-page"
+        data-portal="https://mzizi.dev/components/job-board-page"
+        data-loading
+        role="main"
+        className="animate-pulse space-y-4 p-4"
+      >
+        <div className="h-12 rounded-full bg-muted" />
+        <div className="flex gap-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-8 w-20 rounded-full bg-muted" />
+          ))}
+        </div>
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-28 rounded-[var(--radius-lg,14px)] bg-muted" />
+        ))}
+      </main>
+    )
+  return (
+    <main
+      data-slot="job-board-page"
+      role="main"
+      aria-label="Job Board"
+      style={animStyle}
+      className={cn("flex flex-col gap-4 p-4", className)}
+    >
+      <h1 className="text-xl font-bold">Jobs</h1>
+      {search && <section aria-label="Job search">{search}</section>}
+      {filters && (
+        <section aria-label="Filters" className="flex gap-2 overflow-x-auto">
+          {filters}
+        </section>
+      )}
+      {resultCount != null && (
+        <p className="text-sm text-muted-foreground">
+          {resultCount.toLocaleString()} {resultCount === 1 ? "job" : "jobs"} found
+        </p>
+      )}
+      <section aria-label="Job listings" className="flex flex-col gap-3">
+        {children}
+      </section>
+    </main>
+  )
+}
+export type { JobBoardPageProps }

--- a/components/registry/n6-pages/learning-page.tsx
+++ b/components/registry/n6-pages/learning-page.tsx
@@ -1,0 +1,76 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+interface LearningPageProps {
+  courseName?: string
+  progress?: number
+  lessonTitle?: string
+  sidebar?: React.ReactNode
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+export function LearningPage({
+  courseName,
+  progress,
+  lessonTitle,
+  sidebar,
+  children,
+  loading = false,
+  className,
+}: LearningPageProps) {
+  const { motion } = useNyuchiHarness("learning-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="learning-page"
+        data-portal="https://mzizi.dev/components/learning-page"
+        data-loading
+        role="main"
+        className="animate-pulse space-y-4 p-4"
+      >
+        <div className="h-6 w-1/3 rounded bg-muted" />
+        <div className="h-2 rounded-full bg-muted" />
+        <div className="h-64 rounded-[var(--radius-lg,14px)] bg-muted" />
+      </main>
+    )
+  return (
+    <main
+      data-slot="learning-page"
+      role="main"
+      aria-label={courseName || "Learning"}
+      style={animStyle}
+      className={cn("flex flex-col lg:flex-row", className)}
+    >
+      {sidebar && (
+        <aside className="w-full border-r border-border p-4 lg:h-screen lg:w-72 lg:overflow-y-auto">
+          {sidebar}
+        </aside>
+      )}
+      <div className="flex-1 p-4">
+        {courseName && <p className="text-sm text-muted-foreground">{courseName}</p>}
+        {progress != null && (
+          <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full rounded-full bg-primary transition-all"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        )}
+        {lessonTitle && <h1 className="mt-4 text-xl font-bold">{lessonTitle}</h1>}
+        <div className="mt-6">{children}</div>
+      </div>
+    </main>
+  )
+}
+export type { LearningPageProps }

--- a/components/registry/n6-pages/login-01.tsx
+++ b/components/registry/n6-pages/login-01.tsx
@@ -1,0 +1,96 @@
+/* ═══════════════════════════════════════════════════════════════
+   AUTH BLOCK — Layer 6 (Page Composition)
+   
+   COMPOSITION PATTERN:
+   This block should compose L2 primitives (Button, Input, Card, Label)
+   and L3 brand components (nyuchi-auth-layout) rather than rendering
+   inline UI. The current implementation pre-dates the 3D architecture.
+   
+   APPROVED FOR USE: Yes, as-is. Refactor is tracked for a future pass.
+   The inline code works correctly — the refactor is for architectural
+   purity, not functionality.
+   ═══════════════════════════════════════════════════════════════ */
+"use client"
+
+import * as React from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+// ── INFRASTRUCTURE HARNESS (auto-wired) ──
+import { useNyuchiHarness } from "@/lib/harness"
+
+function Login01() {
+  const { motion, LiveRegion } = useNyuchiHarness("login-01")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+
+  return (
+    <div
+      data-slot="login-01"
+      style={animStyle}
+      data-portal="https://mzizi.dev/components/login-01"
+      role="form"
+      aria-label="Sign in"
+      className="flex min-h-screen items-center justify-center bg-background px-4"
+    >
+      {LiveRegion}
+      <Card className="w-full max-w-sm">
+        {/* Mineral accent stripe */}
+        <div className="flex h-1 w-full overflow-hidden rounded-t-2xl">
+          <div className="flex-1 bg-cobalt" />
+          <div className="flex-1 bg-tanzanite" />
+          <div className="flex-1 bg-malachite" />
+          <div className="flex-1 bg-gold" />
+          <div className="flex-1 bg-terracotta" />
+        </div>
+        <CardHeader className="text-center">
+          <CardTitle className="font-serif text-xl">Welcome back</CardTitle>
+          <CardDescription>Sign in to your mukoko account</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="login01-email">Email</Label>
+            <Input id="login01-email" type="email" placeholder="you@example.com" />
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="login01-password">Password</Label>
+              <a href="#" className="text-xs text-cobalt hover:underline">
+                Forgot password?
+              </a>
+            </div>
+            <Input id="login01-password" type="password" placeholder="Enter your password" />
+          </div>
+          <Button className="w-full">Sign in</Button>
+        </CardContent>
+        <CardFooter className="justify-center">
+          <p className="text-sm text-muted-foreground">
+            No account?{" "}
+            <a href="#" className="font-medium text-foreground hover:underline">
+              Sign up
+            </a>
+          </p>
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}
+
+export { Login01 }

--- a/components/registry/n6-pages/login-02.tsx
+++ b/components/registry/n6-pages/login-02.tsx
@@ -1,0 +1,95 @@
+/* ═══════════════════════════════════════════════════════════════
+   AUTH BLOCK — Layer 6 (Page Composition)
+   
+   COMPOSITION PATTERN:
+   This block should compose L2 primitives (Button, Input, Card, Label)
+   and L3 brand components (nyuchi-auth-layout) rather than rendering
+   inline UI. The current implementation pre-dates the 3D architecture.
+   
+   APPROVED FOR USE: Yes, as-is. Refactor is tracked for a future pass.
+   The inline code works correctly — the refactor is for architectural
+   purity, not functionality.
+   ═══════════════════════════════════════════════════════════════ */
+"use client"
+
+import * as React from "react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+import { useNyuchiHarness } from "@/lib/harness"
+
+function Login02() {
+  const { motion, LiveRegion } = useNyuchiHarness("login-02")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+
+  return (
+    <div
+      data-slot="login-02"
+      style={animStyle}
+      data-portal="https://mzizi.dev/components/login-02"
+      role="form"
+      aria-label="Sign in"
+      className="flex min-h-screen bg-background"
+    >
+      {LiveRegion}
+      {/* Left — brand image */}
+      <div className="hidden flex-1 items-center justify-center bg-muted lg:flex">
+        <div className="space-y-4 px-12 text-center">
+          <div className="mx-auto flex size-16 items-center justify-center rounded-2xl bg-cobalt/10">
+            <span className="font-serif text-2xl font-bold text-cobalt">m</span>
+          </div>
+          <h2 className="font-serif text-2xl font-semibold text-foreground">mukoko</h2>
+          <p className="max-w-xs text-sm text-muted-foreground">
+            The pan-African platform connecting communities through technology, culture, and shared
+            purpose.
+          </p>
+          <div className="flex justify-center gap-1.5 pt-2">
+            <span className="size-2 rounded-full bg-cobalt" />
+            <span className="size-2 rounded-full bg-tanzanite" />
+            <span className="size-2 rounded-full bg-malachite" />
+            <span className="size-2 rounded-full bg-gold" />
+            <span className="size-2 rounded-full bg-terracotta" />
+          </div>
+        </div>
+      </div>
+      {/* Right — form */}
+      <div className="flex flex-1 items-center justify-center px-6">
+        <div className="w-full max-w-sm space-y-6">
+          <div>
+            <h1 className="font-serif text-2xl font-semibold text-foreground">Sign in</h1>
+            <p className="mt-1 text-sm text-muted-foreground">Enter your credentials to continue</p>
+          </div>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="login02-email">Email</Label>
+              <Input id="login02-email" type="email" placeholder="you@example.com" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="login02-password">Password</Label>
+              <Input id="login02-password" type="password" placeholder="Enter your password" />
+            </div>
+            <Button className="w-full">Sign in</Button>
+          </div>
+          <p className="text-center text-sm text-muted-foreground">
+            New here?{" "}
+            <a href="#" className="font-medium text-foreground hover:underline">
+              Create an account
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export { Login02 }

--- a/components/registry/n6-pages/login-03.tsx
+++ b/components/registry/n6-pages/login-03.tsx
@@ -1,0 +1,122 @@
+/* ═══════════════════════════════════════════════════════════════
+   AUTH BLOCK — Layer 6 (Page Composition)
+   
+   COMPOSITION PATTERN:
+   This block should compose L2 primitives (Button, Input, Card, Label)
+   and L3 brand components (nyuchi-auth-layout) rather than rendering
+   inline UI. The current implementation pre-dates the 3D architecture.
+   
+   APPROVED FOR USE: Yes, as-is. Refactor is tracked for a future pass.
+   The inline code works correctly — the refactor is for architectural
+   purity, not functionality.
+   ═══════════════════════════════════════════════════════════════ */
+"use client"
+
+import * as React from "react"
+
+import { useNyuchiHarness } from "@/lib/harness"
+
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+function GithubIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  )
+}
+
+function Login03() {
+  const { motion } = useNyuchiHarness("login-03")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  return (
+    <div
+      data-slot="login-03"
+      style={animStyle}
+      data-portal="https://mzizi.dev/components/login-03"
+      role="form"
+      aria-label="Sign in"
+      className="flex min-h-screen items-center justify-center bg-background px-4"
+    >
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <CardTitle className="font-serif text-xl">Sign in</CardTitle>
+          <CardDescription>Choose your preferred sign-in method</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-2 gap-3">
+            <Button variant="outline" className="w-full gap-2">
+              <svg className="size-4" viewBox="0 0 24 24" fill="none">
+                <path
+                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                  fill="#4285F4"
+                />
+                <path
+                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                  fill="#34A853"
+                />
+                <path
+                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                  fill="#FBBC05"
+                />
+                <path
+                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                  fill="#EA4335"
+                />
+              </svg>
+              Google
+            </Button>
+            <Button variant="outline" className="w-full gap-2">
+              <GithubIcon className="size-4" />
+              GitHub
+            </Button>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <Separator className="flex-1" />
+            <span className="text-xs text-muted-foreground">or</span>
+            <Separator className="flex-1" />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="login03-email">Email</Label>
+            <Input id="login03-email" type="email" placeholder="you@example.com" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="login03-password">Password</Label>
+            <Input id="login03-password" type="password" placeholder="Enter your password" />
+          </div>
+          <Button className="w-full">Sign in with email</Button>
+        </CardContent>
+        <CardFooter className="justify-center">
+          <p className="text-sm text-muted-foreground">
+            No account?{" "}
+            <a href="#" className="font-medium text-foreground hover:underline">
+              Sign up
+            </a>
+          </p>
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}
+
+export { Login03 }

--- a/components/registry/n6-pages/login-04.tsx
+++ b/components/registry/n6-pages/login-04.tsx
@@ -1,0 +1,104 @@
+/* ═══════════════════════════════════════════════════════════════
+   AUTH BLOCK — Layer 6 (Page Composition)
+   
+   COMPOSITION PATTERN:
+   This block should compose L2 primitives (Button, Input, Card, Label)
+   and L3 brand components (nyuchi-auth-layout) rather than rendering
+   inline UI. The current implementation pre-dates the 3D architecture.
+   
+   APPROVED FOR USE: Yes, as-is. Refactor is tracked for a future pass.
+   The inline code works correctly — the refactor is for architectural
+   purity, not functionality.
+   ═══════════════════════════════════════════════════════════════ */
+"use client"
+
+import * as React from "react"
+
+import { useNyuchiHarness } from "@/lib/harness"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Mail } from "@/lib/icons"
+
+function Login04() {
+  const { motion } = useNyuchiHarness("login-04")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  const [sent, setSent] = useState(false)
+
+  return (
+    <div
+      data-slot="login-04"
+      style={animStyle}
+      data-portal="https://mzizi.dev/components/login-04"
+      role="form"
+      aria-label="Sign in"
+      className="flex min-h-screen items-center justify-center bg-background px-4"
+    >
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-tanzanite/10">
+            <Mail className="size-6 text-tanzanite" />
+          </div>
+          <CardTitle className="font-serif text-xl">
+            {sent ? "Check your email" : "Sign in with magic link"}
+          </CardTitle>
+          <CardDescription>
+            {sent
+              ? "We sent a sign-in link to your email address. Click it to continue."
+              : "Enter your email and we'll send you a one-time sign-in link."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {!sent ? (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="login04-email">Email address</Label>
+                <Input id="login04-email" type="email" placeholder="you@example.com" />
+              </div>
+              <Button className="w-full" onClick={() => setSent(true)}>
+                Send magic link
+              </Button>
+              <p className="text-center text-xs text-muted-foreground">
+                We'll email you a link for a password-free sign in.
+              </p>
+            </>
+          ) : (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="login04-otp">Or enter the 6-digit code</Label>
+                <Input
+                  id="login04-otp"
+                  type="text"
+                  inputMode="numeric"
+                  maxLength={6}
+                  placeholder="000000"
+                  className="text-center font-mono text-lg tracking-[0.5em]"
+                />
+              </div>
+              <Button className="w-full">Verify code</Button>
+              <button
+                onClick={() => setSent(false)}
+                className="w-full text-center text-sm text-muted-foreground hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+              >
+                Use a different email
+              </button>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export { Login04 }

--- a/components/registry/n6-pages/login-05.tsx
+++ b/components/registry/n6-pages/login-05.tsx
@@ -1,0 +1,126 @@
+/* ═══════════════════════════════════════════════════════════════
+   AUTH BLOCK — Layer 6 (Page Composition)
+   
+   COMPOSITION PATTERN:
+   This block should compose L2 primitives (Button, Input, Card, Label)
+   and L3 brand components (nyuchi-auth-layout) rather than rendering
+   inline UI. The current implementation pre-dates the 3D architecture.
+   
+   APPROVED FOR USE: Yes, as-is. Refactor is tracked for a future pass.
+   The inline code works correctly — the refactor is for architectural
+   purity, not functionality.
+   ═══════════════════════════════════════════════════════════════ */
+"use client"
+
+import * as React from "react"
+
+import { useNyuchiHarness } from "@/lib/harness"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Badge } from "@/components/ui/badge"
+import { Separator } from "@/components/ui/separator"
+import { Cloud, Globe, Shield, Zap } from "@/lib/icons"
+
+const features = [
+  { icon: Zap, label: "Lightning fast", description: "Built for speed across Africa" },
+  { icon: Shield, label: "Secure by default", description: "Enterprise-grade encryption" },
+  { icon: Globe, label: "Pan-African", description: "Multi-language, multi-currency" },
+  { icon: Cloud, label: "Cloud native", description: "99.9% uptime guarantee" },
+]
+
+function Login05() {
+  const { motion } = useNyuchiHarness("login-05")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  return (
+    <div
+      data-slot="login-05"
+      style={animStyle}
+      data-portal="https://mzizi.dev/components/login-05"
+      role="form"
+      aria-label="Sign in"
+      className="flex min-h-screen bg-background"
+    >
+      {/* Left — brand showcase */}
+      <div className="hidden flex-1 flex-col justify-between bg-card p-10 lg:flex">
+        <div>
+          <span className="font-serif text-xl font-semibold text-foreground">mukoko</span>
+          <Badge variant="secondary" className="ml-2">
+            ecosystem
+          </Badge>
+        </div>
+        <div className="space-y-6">
+          <h2 className="max-w-md font-serif text-3xl leading-tight font-semibold text-foreground">
+            Technology built for Africa, by Africa.
+          </h2>
+          <div className="grid grid-cols-2 gap-4">
+            {features.map((f) => (
+              <div key={f.label} className="flex items-start gap-3 rounded-xl bg-muted/50 p-4">
+                <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-cobalt/10">
+                  <f.icon className="size-4 text-cobalt" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-foreground">{f.label}</p>
+                  <p className="text-xs text-muted-foreground">{f.description}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="flex gap-1.5">
+          <span className="size-2 rounded-full bg-cobalt" />
+          <span className="size-2 rounded-full bg-tanzanite" />
+          <span className="size-2 rounded-full bg-malachite" />
+          <span className="size-2 rounded-full bg-gold" />
+          <span className="size-2 rounded-full bg-terracotta" />
+        </div>
+      </div>
+
+      {/* Right — form */}
+      <div className="flex flex-1 items-center justify-center border-l border-border px-6">
+        <div className="w-full max-w-sm space-y-6">
+          <div>
+            <h1 className="font-serif text-2xl font-semibold text-foreground">Welcome back</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Sign in to continue to your dashboard
+            </p>
+          </div>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="login05-email">Email</Label>
+              <Input id="login05-email" type="email" placeholder="you@example.com" />
+            </div>
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label htmlFor="login05-password">Password</Label>
+                <a href="#" className="text-xs text-cobalt hover:underline">
+                  Forgot?
+                </a>
+              </div>
+              <Input id="login05-password" type="password" placeholder="Enter your password" />
+            </div>
+            <Button className="w-full">Sign in</Button>
+          </div>
+          <Separator />
+          <p className="text-center text-sm text-muted-foreground">
+            New to mukoko?{" "}
+            <a href="#" className="font-medium text-foreground hover:underline">
+              Create an account
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export { Login05 }

--- a/components/registry/n6-pages/logs-page.tsx
+++ b/components/registry/n6-pages/logs-page.tsx
@@ -1,0 +1,138 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+type LogLevel = "debug" | "info" | "warn" | "error" | "fatal"
+interface LogsPageProps {
+  title?: string
+  search?: React.ReactNode
+  levelFilters?: LogLevel[]
+  activeLevel?: LogLevel | "all"
+  onLevelChange?: (level: LogLevel | "all") => void
+  timeRange?: React.ReactNode
+  isStreaming?: boolean
+  onToggleStream?: () => void
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+const LEVEL_COLORS: Record<LogLevel, string> = {
+  debug: "var(--color-muted-foreground)",
+  info: "var(--status-info, var(--color-cobalt, #00B0FF))",
+  warn: "var(--status-warning, var(--color-gold, #FFD740))",
+  error: "var(--status-error, var(--destructive, #FF5252))",
+  fatal: "var(--severity-extreme, var(--destructive, #FF5252))",
+}
+export function LogsPage({
+  title = "Logs",
+  search,
+  levelFilters = ["debug", "info", "warn", "error", "fatal"],
+  activeLevel = "all",
+  onLevelChange,
+  timeRange,
+  isStreaming,
+  onToggleStream,
+  children,
+  loading = false,
+  className,
+}: LogsPageProps) {
+  const { motion } = useNyuchiHarness("logs-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="logs-page"
+        data-portal="https://mzizi.dev/components/logs-page"
+        data-loading
+        role="main"
+        className="animate-pulse space-y-3 p-4 font-mono"
+      >
+        <div className="h-10 rounded bg-muted" />
+        {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
+          <div
+            key={i}
+            className="h-6 rounded bg-muted"
+            style={{ width: `${60 + Math.random() * 40}%` }}
+          />
+        ))}
+      </main>
+    )
+  return (
+    <main
+      data-slot="logs-page"
+      role="main"
+      aria-label={title}
+      style={animStyle}
+      className={cn("flex h-screen flex-col overflow-hidden", className)}
+    >
+      <header className="flex flex-col gap-2 border-b border-border p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <h1 className="text-lg font-bold">{title}</h1>
+          {isStreaming != null && (
+            <button
+              onClick={onToggleStream}
+              className={cn(
+                "flex min-h-[44px] items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+                isStreaming
+                  ? "bg-[var(--status-success,var(--color-malachite,#64FFDA))]/15 text-[var(--status-success,var(--color-malachite,#64FFDA))]"
+                  : "bg-muted text-muted-foreground"
+              )}
+            >
+              <div
+                className={cn(
+                  "size-1.5 rounded-full",
+                  isStreaming
+                    ? "animate-pulse bg-[var(--status-success,var(--color-malachite,#64FFDA))]"
+                    : "bg-muted-foreground"
+                )}
+              />
+              {isStreaming ? "Live" : "Paused"}
+            </button>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {search}
+          {timeRange}
+        </div>
+      </header>
+      <nav className="flex items-center gap-1 border-b border-border px-4 py-2">
+        <button
+          onClick={() => onLevelChange?.("all")}
+          className={cn(
+            "min-h-[44px] rounded px-2 py-1 text-xs font-medium transition-colors",
+            activeLevel === "all"
+              ? "bg-muted text-foreground"
+              : "text-muted-foreground hover:bg-muted"
+          )}
+        >
+          All
+        </button>
+        {levelFilters.map((l) => (
+          <button
+            key={l}
+            onClick={() => onLevelChange?.(l)}
+            className={cn(
+              "min-h-[44px] rounded px-2 py-1 font-mono text-xs font-medium transition-colors",
+              activeLevel === l ? "bg-muted" : "hover:bg-muted"
+            )}
+            style={{ color: LEVEL_COLORS[l] }}
+          >
+            {l.toUpperCase()}
+          </button>
+        ))}
+      </nav>
+      <section aria-label="Log entries" className="flex-1 overflow-y-auto p-4 font-mono text-xs">
+        {children}
+      </section>
+    </main>
+  )
+}
+export type { LogLevel, LogsPageProps }

--- a/components/registry/n6-pages/map-page.tsx
+++ b/components/registry/n6-pages/map-page.tsx
@@ -1,0 +1,54 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+interface MapPageProps {
+  mapContent?: React.ReactNode
+  searchBar?: React.ReactNode
+  bottomSheet?: React.ReactNode
+  showMyLocation?: boolean
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+export function MapPage({
+  mapContent,
+  searchBar,
+  bottomSheet,
+  children,
+  loading = false,
+  className,
+}: MapPageProps) {
+  if (loading)
+    return (
+      <main
+        data-slot="map-page"
+        data-portal="https://mzizi.dev/components/map-page"
+        data-loading
+        role="main"
+        className="relative h-screen animate-pulse"
+      >
+        <div className="h-full bg-muted" />
+        <div className="absolute top-4 right-4 left-4 h-12 rounded-full bg-card shadow" />
+      </main>
+    )
+  return (
+    <main
+      data-slot="map-page"
+      role="main"
+      aria-label="Map"
+      className={cn("relative flex h-screen flex-col", className)}
+    >
+      {searchBar && <div className="absolute top-4 right-4 left-4 z-10">{searchBar}</div>}
+      <div className="relative flex-1">
+        {mapContent || (
+          <div className="flex h-full items-center justify-center bg-muted text-sm text-muted-foreground">
+            Map loads here
+          </div>
+        )}
+        {children}
+      </div>
+      {bottomSheet && <div className="relative z-10">{bottomSheet}</div>}
+    </main>
+  )
+}
+export type { MapPageProps }

--- a/components/registry/n6-pages/marketplace-page.tsx
+++ b/components/registry/n6-pages/marketplace-page.tsx
@@ -1,0 +1,76 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+interface MarketplacePageProps {
+  search?: React.ReactNode
+  categories?: React.ReactNode
+  viewToggle?: React.ReactNode
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+export function MarketplacePage({
+  search,
+  categories,
+  viewToggle,
+  children,
+  loading = false,
+  className,
+}: MarketplacePageProps) {
+  const { motion } = useNyuchiHarness("marketplace-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="marketplace-page"
+        data-portal="https://mzizi.dev/components/marketplace-page"
+        data-loading
+        role="main"
+        className="animate-pulse space-y-4 p-4"
+      >
+        <div className="h-12 rounded-full bg-muted" />
+        <div className="flex gap-2">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-8 w-20 rounded-full bg-muted" />
+          ))}
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-48 rounded-[var(--radius-lg,14px)] bg-muted" />
+          ))}
+        </div>
+      </main>
+    )
+  return (
+    <main
+      data-slot="marketplace-page"
+      role="main"
+      aria-label="Marketplace"
+      style={animStyle}
+      className={cn("flex flex-col gap-4 p-4", className)}
+    >
+      {search && <section aria-label="Search">{search}</section>}
+      {(categories || viewToggle) && (
+        <div className="flex items-center justify-between">
+          {categories && (
+            <section aria-label="Categories" className="flex-1 overflow-x-auto">
+              {categories}
+            </section>
+          )}
+          {viewToggle}
+        </div>
+      )}
+      <section aria-label="Products">{children}</section>
+    </main>
+  )
+}
+export type { MarketplacePageProps }

--- a/components/registry/n6-pages/media-player-page.tsx
+++ b/components/registry/n6-pages/media-player-page.tsx
@@ -1,0 +1,86 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface MediaPlayerPageProps {
+  mediaType?: "video" | "audio" | "live"
+  title?: string
+  creator?: { name: string; avatar?: string }
+  player?: React.ReactNode
+  controls?: React.ReactNode
+  engagement?: React.ReactNode
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+
+export function MediaPlayerPage({
+  mediaType = "video",
+  title,
+  creator,
+  player,
+  controls,
+  engagement,
+  children,
+  loading = false,
+  className,
+}: MediaPlayerPageProps) {
+  if (loading)
+    return (
+      <main
+        data-slot="media-player-page"
+        data-portal="https://mzizi.dev/components/media-player-page"
+        data-loading
+        role="main"
+        className="animate-pulse"
+      >
+        <div className="aspect-[var(--aspect-media-wide,16/9)] bg-muted" />
+        <div className="space-y-3 p-4">
+          <div className="h-6 w-2/3 rounded bg-muted" />
+          <div className="h-4 w-1/3 rounded bg-muted" />
+        </div>
+      </main>
+    )
+  return (
+    <main
+      data-slot="media-player-page"
+      data-media={mediaType}
+      role="main"
+      aria-label={title || "Media"}
+      className={cn("flex flex-col", className)}
+    >
+      {player && (
+        <section aria-label="Player" className={mediaType === "audio" ? "p-4" : ""}>
+          {player}
+        </section>
+      )}
+      {controls && (
+        <section aria-label="Controls" className="px-4 py-2">
+          {controls}
+        </section>
+      )}
+      <div className="px-4 py-3">
+        {title && <h1 className="text-lg font-bold">{title}</h1>}
+        {creator && (
+          <div className="mt-2 flex items-center gap-2">
+            <div className="size-8 overflow-hidden rounded-full bg-muted">
+              {creator.avatar && (
+                <img src={creator.avatar} alt="" className="size-full object-cover" />
+              )}
+            </div>
+            <span className="text-sm font-medium">{creator.name}</span>
+          </div>
+        )}
+      </div>
+      {engagement && (
+        <section aria-label="Engagement" className="border-y border-border px-4 py-2">
+          {engagement}
+        </section>
+      )}
+      <section aria-label="Related content" className="p-4">
+        {children}
+      </section>
+    </main>
+  )
+}
+export type { MediaPlayerPageProps }

--- a/components/registry/n6-pages/nyuchi-auth-layout.tsx
+++ b/components/registry/n6-pages/nyuchi-auth-layout.tsx
@@ -1,0 +1,135 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+
+/* ═══════════════════════════════════════════════════════════════
+   NYUCHI AUTH LAYOUT — Layer 6 Page Composition
+   Default screen that wraps all auth flows.
+   ═══════════════════════════════════════════════════════════════ */
+
+interface NyuchiAuthLayoutProps {
+  children: React.ReactNode
+  /** Which auth step is being displayed */
+  variant?: "login" | "signup" | "onboarding" | "reset" | "verify"
+  /** Show the mineral gradient background */
+  showBackground?: boolean
+  /** Show the logo */
+  showLogo?: boolean
+  /** Show language selector */
+  showLanguage?: boolean
+  /** Show legal links (terms, privacy) */
+  showLegal?: boolean
+  /** Available languages */
+  languages?: { code: string; label: string }[]
+  onLanguageChange?: (code: string) => void
+  loading?: boolean
+  className?: string
+}
+
+const DEFAULT_LANGUAGES = [
+  { code: "en", label: "English" },
+  { code: "sn", label: "chiShona" },
+  { code: "nd", label: "isiNdebele" },
+  { code: "sw", label: "Kiswahili" },
+  { code: "fr", label: "Français" },
+  { code: "pt", label: "Português" },
+]
+
+export function NyuchiAuthLayout({
+  children,
+  variant = "login",
+  showBackground = true,
+  showLogo = true,
+  showLanguage = true,
+  showLegal = true,
+  languages = DEFAULT_LANGUAGES,
+  onLanguageChange,
+  loading = false,
+  className,
+}: NyuchiAuthLayoutProps) {
+  const { motion } = useNyuchiHarness("auth-layout")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+
+  return (
+    <div
+      data-slot="nyuchi-auth-layout"
+      data-portal="https://mzizi.dev/components/nyuchi-auth-layout"
+      data-variant={variant}
+      role="main"
+      aria-label={
+        variant === "login" ? "Sign in" : variant === "signup" ? "Create account" : variant
+      }
+      className={cn(
+        "flex min-h-screen flex-col items-center justify-center p-4",
+        showBackground && "bg-gradient-to-br from-background via-background to-primary/5",
+        className
+      )}
+    >
+      {/* Logo */}
+      {showLogo && (
+        <div className="mb-8" style={animStyle}>
+          <p className="text-2xl font-bold tracking-tight">
+            <span className="text-foreground">mukoko</span>
+          </p>
+        </div>
+      )}
+
+      {/* Auth card container */}
+      <div className="w-full max-w-md" style={animStyle}>
+        <div className="rounded-[var(--radius-xl,17px)] border border-border bg-card p-6 shadow-lg sm:p-8">
+          {loading ? (
+            <div className="animate-pulse space-y-4" role="status" aria-label="Loading">
+              <div className="h-8 w-2/3 rounded bg-muted" />
+              <div className="h-10 rounded bg-muted" />
+              <div className="h-10 rounded bg-muted" />
+              <div className="h-12 rounded-full bg-muted" />
+            </div>
+          ) : (
+            children
+          )}
+        </div>
+      </div>
+
+      {/* Language selector */}
+      {showLanguage && (
+        <div className="mt-6 flex flex-wrap justify-center gap-2" style={animStyle}>
+          {languages.map((lang) => (
+            <button
+              key={lang.code}
+              onClick={() => onLanguageChange?.(lang.code)}
+              className="min-h-[44px] rounded-full px-3 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+            >
+              {lang.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Legal links */}
+      {showLegal && (
+        <div className="mt-4 flex gap-4 text-xs text-muted-foreground/60">
+          <a href="/legal/terms" className="transition-colors hover:text-muted-foreground">
+            Terms
+          </a>
+          <a href="/legal/privacy" className="transition-colors hover:text-muted-foreground">
+            Privacy
+          </a>
+          <a href="/legal/cookies" className="transition-colors hover:text-muted-foreground">
+            Cookies
+          </a>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export type { NyuchiAuthLayoutProps }

--- a/components/registry/n6-pages/nyuchi-create-page.tsx
+++ b/components/registry/n6-pages/nyuchi-create-page.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+/* ═══════════════════════════════════════════════════════════════
+   NYUCHI CREATE PAGE — Layer 6 Page Orchestrator
+   
+   Standard creation flow. Cancel/Title/Submit header pattern.
+   Stepped or single-form layout with section cards.
+   ✅ HARNESS  ✅ TOKENS  ✅ RESPONSIVE  ✅ TOUCH 48px+
+   ═══════════════════════════════════════════════════════════════ */
+
+interface NyuchiCreatePageProps {
+  title: string
+  onCancel?: () => void
+  onSubmit?: () => void
+  submitLabel?: string
+  submitting?: boolean
+  /** Step indicator for multi-step flows */
+  currentStep?: number
+  totalSteps?: number
+  /** Cover/theme picker area */
+  coverSlot?: React.ReactNode
+  /** Form sections */
+  children: React.ReactNode
+  className?: string
+}
+
+export function NyuchiCreatePage({
+  title,
+  onCancel,
+  onSubmit,
+  submitLabel = "Publish",
+  submitting = false,
+  currentStep,
+  totalSteps,
+  coverSlot,
+  children,
+  className,
+}: NyuchiCreatePageProps) {
+  return (
+    <div
+      data-slot="nyuchi-create-page"
+      data-portal="https://mzizi.dev/components/nyuchi-create-page"
+      role="main"
+      aria-label="Create"
+      className={cn("min-h-screen bg-background pb-28", className)}
+    >
+      {/* Header bar */}
+      <div className="sticky top-0 z-50 flex h-14 items-center justify-between gap-2 border-b border-border bg-card/90 px-4 backdrop-blur-xl">
+        {onCancel && (
+          <button
+            onClick={onCancel}
+            className="min-h-[48px] px-2 text-sm font-medium text-muted-foreground hover:text-foreground"
+          >
+            Cancel
+          </button>
+        )}
+        <h2 className="flex-1 truncate text-center text-sm font-semibold text-foreground">
+          {title}
+        </h2>
+        {onSubmit && (
+          <button
+            onClick={onSubmit}
+            disabled={submitting}
+            className={cn(
+              "min-h-[48px] rounded-full px-4 py-1.5 text-sm font-semibold",
+              submitting
+                ? "text-muted-foreground"
+                : "text-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))]"
+            )}
+          >
+            {submitting ? "Saving..." : submitLabel}
+          </button>
+        )}
+      </div>
+
+      {/* Step indicator */}
+      {currentStep != null && totalSteps != null && totalSteps > 1 && (
+        <div className="flex gap-1 px-4 pt-3">
+          {Array.from({ length: totalSteps }).map((_, i) => (
+            <div
+              key={i}
+              className={cn(
+                "h-1 flex-1 rounded-full transition-colors",
+                i <= (currentStep ?? 0)
+                  ? "bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))]"
+                  : "bg-muted"
+              )}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Cover/theme picker slot */}
+      {coverSlot}
+
+      {/* Form sections */}
+      <div className="mx-auto max-w-2xl space-y-4 px-4 py-6 sm:px-6">{children}</div>
+
+      {/* Sticky bottom submit (mobile) */}
+      {onSubmit && (
+        <div className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-card/90 px-4 py-3 pb-[env(safe-area-inset-bottom,12px)] backdrop-blur-xl md:hidden">
+          <button
+            onClick={onSubmit}
+            disabled={submitting}
+            className={cn(
+              "flex h-14 w-full items-center justify-center rounded-full text-[15px] font-semibold transition-opacity",
+              submitting
+                ? "bg-muted text-muted-foreground"
+                : "bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] text-[#0A0A0A] hover:opacity-80"
+            )}
+          >
+            {submitting ? "Saving..." : submitLabel}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/registry/n6-pages/nyuchi-dashboard-layout.tsx
+++ b/components/registry/n6-pages/nyuchi-dashboard-layout.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+// ── INFRASTRUCTURE HARNESS (auto-wired) ──────────────────
+import { useNyuchiHarness } from "@/lib/harness"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar"
+import { NyuchiSidebar, type SidebarSection } from "@/components/ui/nyuchi-sidebar"
+import { NyuchiHeader, type NavItem } from "@/components/ui/nyuchi-header"
+import { NyuchiBottomNav, type BottomNavItem } from "@/components/ui/nyuchi-bottom-nav"
+
+/* ═══════════════════════════════════════════════════════════════
+   DASHBOARD LAYOUT — Brand Shell Composition (Enterprise)
+   
+   The root layout for every ecosystem dashboard/app screen.
+   Composes sidebar + header + bottom nav + main content area.
+   
+   ✅ L1 TOKENS — Spacing uses design tokens
+   ✅ L2 MOTION — Main content fade-in on route change
+   ✅ L3 A11Y — Main landmark, skip-to-content support
+   ✅ L4 OBSERVABILITY — useNyuchiHarness, page render timing
+   ✅ L5 RESILIENCE — Wraps children, guards missing props
+   ✅ L7 PLATFORM — data-slot for CSS targeting
+   ═══════════════════════════════════════════════════════════════ */
+
+interface DashboardLayoutProps {
+  appName?: string
+  sidebarSections: SidebarSection[]
+  navItems?: NavItem[]
+  headerActions?: React.ReactNode
+  bottomNav?: BottomNavItem[]
+  children: React.ReactNode
+  className?: string
+}
+
+export function DashboardLayout({
+  appName,
+  sidebarSections,
+  navItems,
+  headerActions,
+  bottomNav,
+  children,
+  className,
+}: DashboardLayoutProps) {
+  // ── L4: HARNESS — Page-level observability ──
+  const { motion, LiveRegion } = useNyuchiHarness("dashboard-layout")
+
+  // ── L2: MOTION — Content area fade-in ──
+  const contentAnimStyle = React.useMemo(() => {
+    if (motion.prefersReduced) return {}
+    return {
+      animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+    }
+  }, [motion])
+
+  return (
+    <SidebarProvider>
+      {/* L5: RESILIENCE — Guard against undefined sidebarSections */}
+      <NyuchiSidebar sections={sidebarSections ?? []} appName={appName} collapsible="icon" />
+      <SidebarInset>
+        <NyuchiHeader appName={appName} navItems={navItems} actions={headerActions} />
+
+        {/* L3: A11Y — Main landmark with skip target */}
+        <main
+          id="main-content"
+          data-slot="dashboard-layout"
+          data-portal="https://mzizi.dev/components/dashboard-layout"
+          role="main"
+          aria-label="Dashboard"
+          className={cn("flex-1 p-4 sm:p-6", className)}
+          style={contentAnimStyle}
+        >
+          {LiveRegion}
+          {children}
+        </main>
+      </SidebarInset>
+
+      {/* L5: RESILIENCE — Only render bottom nav if items exist */}
+      {bottomNav && bottomNav.length > 0 && <NyuchiBottomNav items={bottomNav} />}
+    </SidebarProvider>
+  )
+}

--- a/components/registry/n6-pages/nyuchi-detail-layout.tsx
+++ b/components/registry/n6-pages/nyuchi-detail-layout.tsx
@@ -1,0 +1,258 @@
+"use client"
+
+// ── INFRASTRUCTURE HARNESS (auto-wired) ──
+// Every brand component participates in observability, motion, a11y,
+// and health monitoring via the harness. Zero manual config.
+
+import * as React from "react"
+import { ArrowLeft, Heart, Share2 } from "@/lib/icons"
+import { cn } from "@/lib/utils"
+import { Separator } from "@/components/ui/separator"
+
+/* ═══════════════════════════════════════════════════════════════
+   MUKOKO DETAIL LAYOUT — Brand Listing Component
+   
+   The standardized detail view for any single piece of content:
+   events, articles, products, bush trade items, places, profiles.
+   
+   Two hero modes:
+   - image: Standard hero with image + gradient overlay
+   - gradient: Full-bleed mineral gradient (from nhimbe mockup)
+     with radial texture overlay and floating action buttons
+   
+   Design identity markers:
+   - Floating circular action buttons (back, like, share) with
+     frosted glass background on the hero
+   - Pill badge for category above the title
+   - Noto Serif title in hero mode, large and bold
+   - Sticky bottom CTA bar slot (for RSVP, Buy, etc.)
+   ═══════════════════════════════════════════════════════════════ */
+
+interface DetailLayoutProps {
+  /* ── Content ────────────────────────────────────────────── */
+  title: string
+  subtitle?: string
+  category?: string
+  metadata?: React.ReactNode
+  children: React.ReactNode
+  aside?: React.ReactNode
+
+  /* ── Hero ───────────────────────────────────────────────── */
+  /** Hero image URL */
+  heroImage?: string
+  /** Hero gradient — [from, to] hex colors. If set, uses gradient mode */
+  heroGradient?: [string, string]
+  /** Minimum height of hero area (default 220) */
+  heroMinHeight?: number
+
+  /* ── Actions ────────────────────────────────────────────── */
+  /** Show floating action buttons on hero (back, like, share) */
+  showHeroActions?: boolean
+  onBack?: () => void
+  onLike?: () => void
+  onShare?: () => void
+  liked?: boolean
+  /** Right-side actions slot (desktop header) */
+  actions?: React.ReactNode
+  /** Sticky bottom CTA bar content */
+  bottomCta?: React.ReactNode
+
+  /* ── Navigation ─────────────────────────────────────────── */
+  backHref?: string
+  backLabel?: string
+
+  className?: string
+}
+
+/* ── Floating glass button for hero overlay ─────────────────── */
+function HeroButton({
+  onClick,
+  children,
+  label,
+}: {
+  onClick?: () => void
+  children: React.ReactNode
+  label: string
+}) {
+  return (
+    <button
+      onClick={onClick}
+      aria-label={label}
+      className={cn(
+        "flex size-10 items-center justify-center rounded-full",
+        "bg-black/25 backdrop-blur-lg transition-colors hover:bg-black/40"
+      )}
+    >
+      {children}
+    </button>
+  )
+}
+
+export function DetailLayout({
+  title,
+  subtitle,
+  category,
+  metadata,
+  children,
+  aside,
+  heroImage,
+  heroGradient,
+  heroMinHeight = 220,
+  showHeroActions = false,
+  onBack,
+  onLike,
+  onShare,
+  liked = false,
+  actions,
+  bottomCta,
+  backHref,
+  backLabel = "Back",
+  className,
+}: DetailLayoutProps) {
+  const hasHero = !!(heroImage || heroGradient)
+  const isGradientHero = !!heroGradient
+
+  return (
+    <article
+      data-slot="detail-layout"
+      data-portal="https://mzizi.dev/components/detail-layout"
+      className={cn("relative w-full", bottomCta && "pb-24", className)}
+    >
+      {/* ═══ HERO AREA ═══════════════════════════════════════ */}
+      {hasHero && (
+        <div
+          className="relative flex flex-col justify-end overflow-hidden"
+          style={{
+            minHeight: heroMinHeight,
+            ...(isGradientHero
+              ? { background: `linear-gradient(135deg, ${heroGradient[0]}, ${heroGradient[1]})` }
+              : {}),
+          }}
+        >
+          {/* Gradient texture overlay — brand identity */}
+          {isGradientHero && (
+            <div
+              className="absolute inset-0 opacity-5"
+              style={{
+                backgroundImage:
+                  "radial-gradient(circle at 20% 80%, rgba(255,255,255,0.3) 0%, transparent 50%)",
+              }}
+            />
+          )}
+
+          {/* Image (used as bg in gradient mode, as hero in image mode) */}
+          {heroImage && !isGradientHero && (
+            <>
+              <img src={heroImage} alt="" className="absolute inset-0 size-full object-cover" />
+              <div className="absolute inset-0 bg-gradient-to-t from-background/80 to-transparent" />
+            </>
+          )}
+          {heroImage && isGradientHero && (
+            <img
+              src={heroImage}
+              alt=""
+              className="absolute inset-0 size-full object-cover opacity-30 mix-blend-overlay"
+            />
+          )}
+
+          {/* Floating action buttons */}
+          {showHeroActions && (
+            <div className="absolute inset-x-3 top-3 z-10 flex items-center justify-between">
+              <HeroButton onClick={onBack} label="Go back">
+                <ArrowLeft className="size-5 text-white" />
+              </HeroButton>
+              <div className="flex gap-2">
+                {onLike && (
+                  <HeroButton onClick={onLike} label={liked ? "Unlike" : "Like"}>
+                    <Heart
+                      className="size-5"
+                      color={liked ? "var(--status-error, #FF5252)" : "#fff"}
+                      fill={liked ? "var(--status-error, #FF5252)" : "none"}
+                    />
+                  </HeroButton>
+                )}
+                {onShare && (
+                  <HeroButton onClick={onShare} label="Share">
+                    <Share2 className="size-5 text-white" />
+                  </HeroButton>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Hero content: category badge + title */}
+          <div className="relative z-10 p-5">
+            {category && (
+              <span className="mb-2 inline-flex rounded-full bg-white/20 px-2.5 py-0.5 text-[10px] font-semibold tracking-wider text-white uppercase">
+                {category}
+              </span>
+            )}
+            <h1 className="inherit text-2xl leading-tight font-bold text-white sm:text-3xl">
+              {title}
+            </h1>
+            {subtitle && <p className="mt-1 text-sm text-white/70">{subtitle}</p>}
+          </div>
+        </div>
+      )}
+
+      {/* ═══ NON-HERO HEADER ═════════════════════════════════ */}
+      {!hasHero && (
+        <div className="px-4 py-6 sm:px-6">
+          {/* Back navigation */}
+          {(backHref || onBack) && (
+            <a
+              href={backHref}
+              onClick={
+                onBack
+                  ? (e) => {
+                      e.preventDefault()
+                      onBack()
+                    }
+                  : undefined
+              }
+              className="mb-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <ArrowLeft className="size-4" />
+              {backLabel}
+            </a>
+          )}
+          <h1 className="inherit text-3xl font-bold tracking-tight sm:text-4xl">{title}</h1>
+          {subtitle && <p className="mt-2 text-lg text-muted-foreground">{subtitle}</p>}
+        </div>
+      )}
+
+      {/* ═══ BODY ════════════════════════════════════════════ */}
+      <div className={cn("flex flex-col gap-8 px-4 py-4 sm:px-6", aside && "lg:flex-row")}>
+        <div className="min-w-0 flex-1">
+          {metadata && <div className="flex flex-wrap items-center gap-3">{metadata}</div>}
+          {actions && (
+            <>
+              <div className="mt-4 flex flex-wrap items-center gap-2">{actions}</div>
+              <Separator className="my-6" />
+            </>
+          )}
+          {!actions && metadata && <Separator className="my-6" />}
+          <div>{children}</div>
+        </div>
+        {aside && (
+          <aside className="w-full shrink-0 lg:w-72">
+            <div className="sticky top-20 space-y-4">{aside}</div>
+          </aside>
+        )}
+      </div>
+
+      {/* ═══ STICKY BOTTOM CTA ═══════════════════════════════ */}
+      {bottomCta && (
+        <div
+          data-slot="detail-cta"
+          className={cn(
+            "fixed inset-x-0 bottom-0 z-20 px-5 pt-4 pb-7",
+            "bg-gradient-to-t from-background via-background/95 to-transparent"
+          )}
+        >
+          {bottomCta}
+        </div>
+      )}
+    </article>
+  )
+}

--- a/components/registry/n6-pages/nyuchi-detail-page.tsx
+++ b/components/registry/n6-pages/nyuchi-detail-page.tsx
@@ -1,0 +1,156 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+/* ═══════════════════════════════════════════════════════════════
+   NYUCHI DETAIL PAGE — Layer 6 Page Orchestrator
+   
+   The standard detail screen for viewing any single content item.
+   Composes L3 detail-layout + brand components into a full page.
+   
+   ✅ HARNESS  ✅ TOKENS  ✅ RESPONSIVE  ✅ ERROR BOUNDARIES
+   ═══════════════════════════════════════════════════════════════ */
+
+interface NyuchiDetailPageProps {
+  /** Cover image URL */
+  coverUrl?: string
+  /** Cover gradient fallback (mineral-tinted) */
+  coverGradient?: string
+  /** Back navigation handler */
+  onBack?: () => void
+  /** Share handler */
+  onShare?: () => void
+  /** Like/save handler */
+  onSave?: () => void
+  /** Whether item is saved */
+  saved?: boolean
+  /** Main content — rendered in the body area */
+  children: React.ReactNode
+  /** Sticky bottom CTA */
+  ctaLabel?: string
+  ctaAction?: () => void
+  /** Secondary CTA */
+  secondaryLabel?: string
+  secondaryAction?: () => void
+  /** Related items section */
+  relatedTitle?: string
+  relatedItems?: React.ReactNode
+  className?: string
+}
+
+export function NyuchiDetailPage({
+  coverUrl,
+  coverGradient,
+  onBack,
+  onShare,
+  onSave,
+  saved,
+  children,
+  ctaLabel,
+  ctaAction,
+  secondaryLabel,
+  secondaryAction,
+  relatedTitle,
+  relatedItems,
+  className,
+}: NyuchiDetailPageProps) {
+  return (
+    <div
+      data-slot="nyuchi-detail-page"
+      data-portal="https://mzizi.dev/components/nyuchi-detail-page"
+      className={cn("min-h-screen bg-background pb-28", className)}
+    >
+      {/* Hero cover */}
+      <div
+        className="relative h-56 sm:h-72"
+        style={{
+          backgroundImage: coverUrl ? `url(${coverUrl})` : undefined,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          background: !coverUrl
+            ? coverGradient ||
+              "linear-gradient(135deg, var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))/20, var(--muted))"
+            : undefined,
+        }}
+      >
+        {/* Floating action buttons */}
+        <div className="absolute inset-x-0 top-0 flex items-center justify-between p-4 pt-[env(safe-area-inset-top,16px)]">
+          {onBack && (
+            <button
+              onClick={onBack}
+              className="flex size-10 items-center justify-center rounded-full bg-background/80 text-foreground backdrop-blur-sm"
+              aria-label="Go back"
+            >
+              ←
+            </button>
+          )}
+          <div className="ml-auto flex gap-2">
+            {onSave && (
+              <button
+                onClick={onSave}
+                className={cn(
+                  "flex size-10 items-center justify-center rounded-full backdrop-blur-sm",
+                  saved
+                    ? "bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] text-[#0A0A0A]"
+                    : "bg-background/80 text-foreground"
+                )}
+                aria-label={saved ? "Unsave" : "Save"}
+              >
+                {saved ? "♥" : "♡"}
+              </button>
+            )}
+            {onShare && (
+              <button
+                onClick={onShare}
+                className="flex size-10 items-center justify-center rounded-full bg-background/80 text-foreground backdrop-blur-sm"
+                aria-label="Share"
+              >
+                ↗
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Content body — overlaps hero slightly */}
+      <div className="relative -mt-6 rounded-t-[var(--radius-xl,17px)] bg-background">
+        <div className="mx-auto max-w-2xl px-4 py-6 sm:px-6">{children}</div>
+      </div>
+
+      {/* Related items */}
+      {relatedItems && (
+        <div className="mt-6 border-t border-border">
+          <div className="mx-auto max-w-2xl px-4 py-6 sm:px-6">
+            {relatedTitle && (
+              <h3 className="mb-4 text-sm font-semibold text-foreground">{relatedTitle}</h3>
+            )}
+            {relatedItems}
+          </div>
+        </div>
+      )}
+
+      {/* Sticky bottom CTA */}
+      {ctaAction && ctaLabel && (
+        <div className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-card/90 px-4 py-3 pb-[env(safe-area-inset-bottom,12px)] backdrop-blur-xl">
+          <div className="mx-auto flex max-w-2xl gap-2">
+            <button
+              onClick={ctaAction}
+              className="bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] h-14 flex-1 rounded-full text-[15px] font-semibold text-[#0A0A0A] transition-opacity hover:opacity-80"
+            >
+              {ctaLabel}
+            </button>
+            {secondaryAction && secondaryLabel && (
+              <button
+                onClick={secondaryAction}
+                className="h-14 rounded-full border border-border bg-muted px-6 text-[13px] font-medium text-foreground transition-opacity hover:opacity-80"
+              >
+                {secondaryLabel}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/registry/n6-pages/nyuchi-empty-screen.tsx
+++ b/components/registry/n6-pages/nyuchi-empty-screen.tsx
@@ -1,0 +1,72 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+
+interface NyuchiEmptyScreenProps {
+  title?: string
+  description?: string
+  icon?: React.ReactNode
+  action?: { label: string; onClick: () => void }
+  className?: string
+}
+
+export function NyuchiEmptyScreen({
+  title = "Nothing here yet",
+  description = "Content will appear here once it is available.",
+  icon,
+  action,
+  className,
+}: NyuchiEmptyScreenProps) {
+  const { motion } = useNyuchiHarness("empty-screen")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+
+  return (
+    <div
+      data-slot="nyuchi-empty-screen"
+      data-portal="https://mzizi.dev/components/nyuchi-empty-screen"
+      role="status"
+      style={animStyle}
+      className={cn("flex flex-col items-center justify-center px-6 py-16 text-center", className)}
+    >
+      <div className="flex size-16 items-center justify-center rounded-full bg-muted">
+        {icon || (
+          <svg
+            width="32"
+            height="32"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="var(--color-muted-foreground)"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="3" y="3" width="18" height="18" rx="2" />
+            <path d="M3 9h18M9 21V9" />
+          </svg>
+        )}
+      </div>
+      <h2 className="mt-4 text-lg font-semibold text-foreground">{title}</h2>
+      <p className="mt-1 max-w-sm text-sm text-muted-foreground">{description}</p>
+      {action && (
+        <button
+          onClick={action.onClick}
+          className="mt-6 min-h-[48px] rounded-full bg-primary px-6 text-sm font-medium text-white transition-colors hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  )
+}
+
+export type { NyuchiEmptyScreenProps }

--- a/components/registry/n6-pages/nyuchi-error-screen.tsx
+++ b/components/registry/n6-pages/nyuchi-error-screen.tsx
@@ -1,0 +1,101 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+
+interface NyuchiErrorScreenProps {
+  code?: 404 | 500 | 503 | number
+  title?: string
+  description?: string
+  showRetry?: boolean
+  showHome?: boolean
+  onRetry?: () => void
+  onHome?: () => void
+  className?: string
+}
+
+const ERROR_DEFAULTS: Record<number, { title: string; description: string }> = {
+  404: {
+    title: "Page not found",
+    description: "The page you are looking for does not exist or has been moved.",
+  },
+  500: {
+    title: "Something went wrong",
+    description: "We are experiencing technical difficulties. Please try again later.",
+  },
+  503: {
+    title: "Under maintenance",
+    description: "We are improving Mukoko. We will be back shortly.",
+  },
+}
+
+export function NyuchiErrorScreen({
+  code = 500,
+  title,
+  description,
+  showRetry = true,
+  showHome = true,
+  onRetry,
+  onHome,
+  className,
+}: NyuchiErrorScreenProps) {
+  const { log, motion } = useNyuchiHarness("error-screen")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  const defaults = ERROR_DEFAULTS[code] || ERROR_DEFAULTS[500]
+
+  React.useEffect(() => {
+    log.error(`error_screen: ${code}`)
+  }, [code, log])
+
+  return (
+    <div
+      data-slot="nyuchi-error-screen"
+      data-portal="https://mzizi.dev/components/nyuchi-error-screen"
+      role="alert"
+      style={animStyle}
+      className={cn(
+        "flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-background via-background to-destructive/5 p-6 text-center",
+        className
+      )}
+    >
+      <p className="font-mono text-7xl font-bold text-foreground/10">{code}</p>
+      <h1 className="mt-4 text-2xl font-bold text-foreground">{title || defaults.title}</h1>
+      <p className="mt-2 max-w-md text-sm text-muted-foreground">
+        {description || defaults.description}
+      </p>
+      <div className="mt-8 flex gap-3">
+        {showRetry && (
+          <button
+            onClick={onRetry || (() => window.location.reload())}
+            className="min-h-[48px] rounded-full bg-foreground px-6 text-sm font-medium text-background transition-colors hover:bg-foreground/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+          >
+            Try Again
+          </button>
+        )}
+        {showHome && (
+          <button
+            onClick={
+              onHome ||
+              (() => {
+                window.location.href = "/"
+              })
+            }
+            className="min-h-[48px] rounded-full bg-muted px-6 text-sm font-medium text-foreground transition-colors hover:bg-muted/80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+          >
+            Go Home
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export type { NyuchiErrorScreenProps }

--- a/components/registry/n6-pages/nyuchi-feed-page.tsx
+++ b/components/registry/n6-pages/nyuchi-feed-page.tsx
@@ -1,0 +1,198 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+/* ═══════════════════════════════════════════════════════════════
+   NYUCHI FEED PAGE — Layer 6 Page Orchestrator
+   
+   The standard feed screen. Every mini-app's primary list view
+   uses this orchestrator. Composes:
+   
+   L7 Shell: header, bottom-nav (via parent layout)
+   L5 Resilience: NyuchiSection error boundaries per section
+   L3 Brand: nyuchi-listing-card (or custom renderer), 
+             nyuchi-empty-state, nyuchi-search-view
+   L2 Primitives: filter-bar, infinite-scroll, pull-to-refresh
+   L1 Tokens: --brand-accent, responsive breakpoints
+   
+   ✅ HARNESS  ✅ TOKENS  ✅ RESPONSIVE  ✅ ERROR BOUNDARIES
+   ═══════════════════════════════════════════════════════════════ */
+
+interface FilterConfig {
+  key: string
+  label: string
+  options: { value: string; label: string }[]
+}
+
+interface NyuchiFeedPageProps<T = unknown> {
+  /** Page title shown in header area */
+  title: string
+  /** Subtitle or description */
+  subtitle?: string
+  /** Data items to render */
+  items: T[]
+  /** Render function for each item */
+  renderItem: (item: T, index: number) => React.ReactNode
+  /** Loading state */
+  loading?: boolean
+  /** Load more handler for infinite scroll */
+  onLoadMore?: () => void
+  /** Whether there are more items to load */
+  hasMore?: boolean
+  /** Pull-to-refresh handler */
+  /** Search handler */
+  onSearch?: (query: string) => void
+  /** Filter configuration */
+  filters?: FilterConfig[]
+  /** Active filters */
+  activeFilters?: Record<string, string>
+  /** Filter change handler */
+  onFilterChange?: (key: string, value: string) => void
+  /** FAB create action */
+  onCreateAction?: () => void
+  /** FAB label */
+  createLabel?: string
+  /** Empty state props */
+  emptyIcon?: React.ReactNode
+  emptyTitle?: string
+  emptyDescription?: string
+  /** Skeleton count when loading */
+  skeletonCount?: number
+  className?: string
+  children?: React.ReactNode
+}
+
+export function NyuchiFeedPage<T>({
+  title,
+  subtitle,
+  items,
+  renderItem,
+  loading = false,
+  onLoadMore,
+  hasMore = false,
+  onSearch,
+  filters,
+  activeFilters,
+  onFilterChange,
+  onCreateAction,
+  createLabel = "Create",
+  emptyIcon,
+  emptyTitle = "Nothing here yet",
+  emptyDescription,
+  skeletonCount = 5,
+  className,
+  children,
+}: NyuchiFeedPageProps<T>) {
+  return (
+    <div
+      data-slot="nyuchi-feed-page"
+      data-portal="https://mzizi.dev/components/nyuchi-feed-page"
+      className={cn("min-h-screen bg-background", className)}
+    >
+      <div className="mx-auto max-w-2xl px-4 pb-24 sm:px-6">
+        {/* Page header */}
+        <div className="sticky top-14 z-40 bg-background/80 py-4 backdrop-blur-xl">
+          <h1 className="text-xl font-bold text-foreground">{title}</h1>
+          {subtitle && <p className="mt-0.5 text-sm text-muted-foreground">{subtitle}</p>}
+        </div>
+
+        {/* Search + filters */}
+        {(onSearch || filters) && (
+          <div className="mb-4 space-y-3">
+            {onSearch && (
+              <div className="relative">
+                <span className="absolute top-1/2 left-4 -translate-y-1/2 text-sm text-muted-foreground">
+                  🔍
+                </span>
+                <input
+                  type="text"
+                  placeholder={`Search ${title.toLowerCase()}...`}
+                  onChange={(e) => onSearch(e.target.value)}
+                  className="focus:border-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] h-12 w-full rounded-full border border-border bg-muted pr-4 pl-11 text-sm text-foreground transition-colors outline-none placeholder:text-muted-foreground"
+                />
+              </div>
+            )}
+            {filters && filters.length > 0 && (
+              <div className="flex scrollbar-none gap-1.5 overflow-x-auto pb-1">
+                {filters.map((f) => (
+                  <select
+                    key={f.key}
+                    value={activeFilters?.[f.key] || ""}
+                    onChange={(e) => onFilterChange?.(f.key, e.target.value)}
+                    className="h-9 shrink-0 rounded-full border border-border bg-muted px-3 text-xs text-muted-foreground outline-none"
+                  >
+                    <option value="">{f.label}</option>
+                    {f.options.map((o) => (
+                      <option key={o.value} value={o.value}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </select>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Injected children (announcements, banners) */}
+        {children}
+
+        {/* Feed content */}
+        {loading ? (
+          <div className="space-y-3">
+            {Array.from({ length: skeletonCount }).map((_, i) => (
+              <div
+                key={i}
+                className="h-24 animate-pulse rounded-[var(--radius-lg,14px)] bg-muted"
+              />
+            ))}
+          </div>
+        ) : items.length > 0 ? (
+          <div className="space-y-3">
+            {items.map((item, i) => renderItem(item, i))}
+            {hasMore && onLoadMore && (
+              <button
+                onClick={onLoadMore}
+                className="flex h-12 w-full items-center justify-center rounded-full bg-muted text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+              >
+                Load more
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center py-16 text-center">
+            {emptyIcon && (
+              <div className="bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))]/10 mb-4 flex size-16 items-center justify-center rounded-full text-2xl">
+                {emptyIcon}
+              </div>
+            )}
+            <h3 className="text-base font-semibold text-foreground">{emptyTitle}</h3>
+            {emptyDescription && (
+              <p className="mt-2 max-w-[280px] text-sm text-muted-foreground">{emptyDescription}</p>
+            )}
+            {onCreateAction && (
+              <button
+                onClick={onCreateAction}
+                className="bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] mt-6 h-12 rounded-full px-6 text-[13px] font-medium text-[#0A0A0A] transition-opacity hover:opacity-80"
+              >
+                {createLabel}
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* FAB */}
+      {onCreateAction && items.length > 0 && (
+        <button
+          onClick={onCreateAction}
+          aria-label={createLabel}
+          className="bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] fixed right-5 bottom-24 z-40 flex size-14 items-center justify-center rounded-full text-[#0A0A0A] shadow-lg transition-opacity hover:opacity-80 md:hidden"
+        >
+          <span className="text-xl font-bold">+</span>
+        </button>
+      )}
+    </div>
+  )
+}

--- a/components/registry/n6-pages/nyuchi-grid.tsx
+++ b/components/registry/n6-pages/nyuchi-grid.tsx
@@ -1,0 +1,62 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+/* ═══════════════════════════════════════════════════════════════
+   NYUCHI GRID — Layer 6 Page Composition
+   Responsive grid with Mukoko breakpoints.
+   ═══════════════════════════════════════════════════════════════ */
+
+interface NyuchiGridProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Columns at each breakpoint. Defaults: mobile=1, tablet=2, desktop=3, wide=4 */
+  cols?: { mobile?: number; tablet?: number; desktop?: number; wide?: number }
+  /** Gap between items. Uses spacing tokens. Default: 16px */
+  gap?: "sm" | "md" | "lg" | "xl"
+  /** Max content width. Default: none (full width) */
+  maxWidth?: "sm" | "md" | "lg" | "xl" | "full"
+  children: React.ReactNode
+}
+
+const GAP_MAP = { sm: "gap-2", md: "gap-4", lg: "gap-6", xl: "gap-8" }
+const MAX_MAP = {
+  sm: "max-w-screen-sm",
+  md: "max-w-screen-md",
+  lg: "max-w-screen-lg",
+  xl: "max-w-7xl",
+  full: "max-w-full",
+}
+
+export function NyuchiGrid({
+  cols = {},
+  gap = "md",
+  maxWidth = "full",
+  children,
+  className,
+  ...props
+}: NyuchiGridProps) {
+  const { mobile = 1, tablet = 2, desktop = 3, wide = 4 } = cols
+
+  return (
+    <div
+      data-slot="nyuchi-grid"
+      data-portal="https://mzizi.dev/components/nyuchi-grid"
+      role="region"
+      className={cn(
+        "mx-auto grid w-full",
+        `grid-cols-${mobile}`,
+        `sm:grid-cols-${Math.min(tablet, 2)}`,
+        `md:grid-cols-${tablet}`,
+        `lg:grid-cols-${desktop}`,
+        `xl:grid-cols-${wide}`,
+        GAP_MAP[gap],
+        MAX_MAP[maxWidth],
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+export type { NyuchiGridProps }

--- a/components/registry/n6-pages/nyuchi-page.tsx
+++ b/components/registry/n6-pages/nyuchi-page.tsx
@@ -1,0 +1,169 @@
+"use client"
+
+/* COMPOSITION: Should compose L2 breadcrumb primitive instead of
+   rendering breadcrumbs inline. Currently approved for use as-is. */
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+
+/* ═══════════════════════════════════════════════════════════════
+   NYUCHI PAGE — Layer 6 Page Composition
+   Canonical page wrapper. SEO, metadata, layout presets.
+   ═══════════════════════════════════════════════════════════════ */
+
+type PageLayout = "feed" | "detail" | "settings" | "dashboard" | "auth" | "blank"
+
+interface SEOMetadata {
+  title: string
+  description?: string
+  canonicalUrl?: string
+  ogImage?: string
+  ogType?: "website" | "article" | "profile" | "product"
+  schemaType?: string
+  schemaData?: Record<string, unknown>
+  noIndex?: boolean
+}
+
+interface NyuchiPageProps {
+  layout?: PageLayout
+  seo?: SEOMetadata
+  /** Breadcrumb items */
+  breadcrumbs?: { label: string; href?: string }[]
+  /** Page heading */
+  heading?: string
+  /** Sub heading */
+  subheading?: string
+  /** Show back button */
+  showBack?: boolean
+  onBack?: () => void
+  /** Page-level loading state */
+  loading?: boolean
+  children: React.ReactNode
+  className?: string
+}
+
+const LAYOUT_CLASSES: Record<PageLayout, string> = {
+  feed: "max-w-2xl mx-auto",
+  detail: "max-w-4xl mx-auto",
+  settings: "max-w-2xl mx-auto",
+  dashboard: "max-w-7xl mx-auto",
+  auth: "min-h-screen flex items-center justify-center",
+  blank: "",
+}
+
+export function NyuchiPage({
+  layout = "blank",
+  seo,
+  breadcrumbs,
+  heading,
+  subheading,
+  showBack = false,
+  onBack,
+  loading = false,
+  children,
+  className,
+}: NyuchiPageProps) {
+  const { motion } = useNyuchiHarness(`page-${seo?.title || layout}`)
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+
+  React.useEffect(() => {
+    if (seo?.title) document.title = `${seo.title} — Mukoko`
+  }, [seo?.title])
+
+  if (loading) {
+    return (
+      <main
+        data-slot="nyuchi-page"
+        data-portal="https://mzizi.dev/components/nyuchi-page"
+        data-layout={layout}
+        data-loading
+        role="main"
+        className={cn("px-4 py-6", LAYOUT_CLASSES[layout], className)}
+      >
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 w-1/3 rounded bg-muted" />
+          <div className="h-64 rounded-[var(--radius-lg,14px)] bg-muted" />
+          <div className="h-32 rounded-[var(--radius-lg,14px)] bg-muted" />
+        </div>
+      </main>
+    )
+  }
+
+  return (
+    <main
+      data-slot="nyuchi-page"
+      data-layout={layout}
+      role="main"
+      style={animStyle}
+      className={cn("px-4 py-6", LAYOUT_CLASSES[layout], className)}
+    >
+      {/* Breadcrumbs */}
+      {breadcrumbs && breadcrumbs.length > 0 && (
+        <nav aria-label="Breadcrumb" className="mb-4">
+          <ol className="flex items-center gap-1.5 text-sm text-muted-foreground">
+            {breadcrumbs.map((crumb, i) => (
+              <React.Fragment key={i}>
+                {i > 0 && (
+                  <span aria-hidden="true" className="text-muted-foreground/40">
+                    /
+                  </span>
+                )}
+                <li>
+                  {crumb.href ? (
+                    <a href={crumb.href} className="transition-colors hover:text-foreground">
+                      {crumb.label}
+                    </a>
+                  ) : (
+                    <span className="text-foreground">{crumb.label}</span>
+                  )}
+                </li>
+              </React.Fragment>
+            ))}
+          </ol>
+        </nav>
+      )}
+
+      {/* Page header */}
+      {(heading || showBack) && (
+        <header className="mb-6 flex items-start gap-3">
+          {showBack && (
+            <button
+              onClick={onBack}
+              aria-label="Go back"
+              className="mt-1 flex size-10 min-h-[48px] min-w-[48px] items-center justify-center rounded-full transition-colors hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M19 12H5M12 19l-7-7 7-7" />
+              </svg>
+            </button>
+          )}
+          <div>
+            {heading && <h1 className="text-2xl font-bold text-foreground">{heading}</h1>}
+            {subheading && <p className="mt-1 text-sm text-muted-foreground">{subheading}</p>}
+          </div>
+        </header>
+      )}
+
+      {children}
+    </main>
+  )
+}
+
+export type { PageLayout, SEOMetadata, NyuchiPageProps }

--- a/components/registry/n6-pages/nyuchi-profile-page-layout.tsx
+++ b/components/registry/n6-pages/nyuchi-profile-page-layout.tsx
@@ -1,0 +1,183 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+/* ═══════════════════════════════════════════════════════════════
+   NYUCHI PROFILE PAGE LAYOUT — Layer 6 Page Orchestrator
+   
+   Standard profile screen. Cover + avatar + stats + tabs.
+   Used for users, businesses, organisations, groups, creators.
+   ✅ HARNESS  ✅ TOKENS  ✅ RESPONSIVE  ✅ TOUCH 48px+
+   ═══════════════════════════════════════════════════════════════ */
+
+interface ProfileTab {
+  id: string
+  label: string
+  count?: number
+}
+interface ProfileStat {
+  label: string
+  value: string | number
+}
+
+interface NyuchiProfilePageLayoutProps {
+  coverUrl?: string
+  avatarUrl?: string
+  name: string
+  subtitle?: string
+  verified?: boolean
+  verificationTier?: 0 | 1 | 2 | 3 | 4
+  stats?: ProfileStat[]
+  tabs: ProfileTab[]
+  activeTab?: string
+  onTabChange?: (id: string) => void
+  /** Primary action (Follow, Edit, Contact) */
+  primaryAction?: { label: string; onClick: () => void }
+  /** Secondary action (Message, Share) */
+  secondaryAction?: { label: string; onClick: () => void }
+  /** Back navigation */
+  onBack?: () => void
+  /** Tab content */
+  children: React.ReactNode
+  className?: string
+}
+
+const tierBadge = ["", "🟤", "🔵", "🟡", "🟣"] as const
+
+export function NyuchiProfilePageLayout({
+  coverUrl,
+  avatarUrl,
+  name,
+  subtitle,
+  verified,
+  verificationTier = 0,
+  stats,
+  tabs,
+  activeTab,
+  onTabChange,
+  primaryAction,
+  secondaryAction,
+  onBack,
+  children,
+  className,
+}: NyuchiProfilePageLayoutProps) {
+  const [active, setActive] = React.useState(activeTab || tabs[0]?.id)
+
+  return (
+    <div
+      data-slot="nyuchi-profile-page-layout"
+      data-portal="https://mzizi.dev/components/nyuchi-profile-page-layout"
+      className={cn("min-h-screen bg-background", className)}
+    >
+      {/* Cover */}
+      <div
+        className="from-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))]/20 relative h-40 bg-gradient-to-br to-muted sm:h-52"
+        style={
+          coverUrl
+            ? {
+                backgroundImage: `url(${coverUrl})`,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+              }
+            : undefined
+        }
+      >
+        {onBack && (
+          <button
+            onClick={onBack}
+            className="absolute top-4 left-4 flex size-10 items-center justify-center rounded-full bg-background/80 text-foreground backdrop-blur-sm"
+            aria-label="Go back"
+          >
+            ←
+          </button>
+        )}
+      </div>
+
+      {/* Avatar + name block — overlapping cover */}
+      <div className="relative -mt-12 px-4 sm:px-6">
+        <div className="mx-auto max-w-2xl">
+          <div className="flex items-end gap-4">
+            <div className="flex size-20 shrink-0 items-center justify-center overflow-hidden rounded-full border-4 border-background bg-muted text-2xl font-bold text-muted-foreground sm:size-24">
+              {avatarUrl ? (
+                <img src={avatarUrl} alt={name} className="size-full object-cover" />
+              ) : (
+                name.charAt(0).toUpperCase()
+              )}
+            </div>
+            <div className="min-w-0 flex-1 pb-1">
+              <div className="flex items-center gap-1.5">
+                <h1 className="truncate text-lg font-bold text-foreground">{name}</h1>
+                {verified && verificationTier > 0 && <span>{tierBadge[verificationTier]}</span>}
+              </div>
+              {subtitle && <p className="truncate text-sm text-muted-foreground">{subtitle}</p>}
+            </div>
+          </div>
+
+          {/* Stats */}
+          {stats && stats.length > 0 && (
+            <div className="mt-4 flex gap-6">
+              {stats.map((s) => (
+                <div key={s.label} className="text-center">
+                  <p className="text-base font-bold text-foreground">
+                    {typeof s.value === "number" ? s.value.toLocaleString() : s.value}
+                  </p>
+                  <p className="text-[11px] text-muted-foreground">{s.label}</p>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Action buttons */}
+          {(primaryAction || secondaryAction) && (
+            <div className="mt-4 flex gap-2">
+              {primaryAction && (
+                <button
+                  onClick={primaryAction.onClick}
+                  className="bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] h-12 flex-1 rounded-full text-[13px] font-medium text-[#0A0A0A] transition-opacity hover:opacity-80"
+                >
+                  {primaryAction.label}
+                </button>
+              )}
+              {secondaryAction && (
+                <button
+                  onClick={secondaryAction.onClick}
+                  className="h-12 flex-1 rounded-full border border-border bg-muted text-[13px] font-medium text-foreground transition-opacity hover:opacity-80"
+                >
+                  {secondaryAction.label}
+                </button>
+              )}
+            </div>
+          )}
+
+          {/* Tabs */}
+          <div className="mt-6 flex scrollbar-none gap-0 overflow-x-auto border-b border-border">
+            {tabs.map((t) => (
+              <button
+                key={t.id}
+                onClick={() => {
+                  setActive(t.id)
+                  onTabChange?.(t.id)
+                }}
+                className={cn(
+                  "min-h-[48px] shrink-0 border-b-2 px-4 py-3 text-sm font-medium transition-colors",
+                  active === t.id
+                    ? "border-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] text-foreground"
+                    : "border-transparent text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {t.label}
+                {t.count != null && (
+                  <span className="ml-1.5 text-xs text-muted-foreground">{t.count}</span>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Tab content */}
+      <div className="mx-auto max-w-2xl px-4 py-6 sm:px-6">{children}</div>
+    </div>
+  )
+}

--- a/components/registry/n6-pages/nyuchi-settings-page.tsx
+++ b/components/registry/n6-pages/nyuchi-settings-page.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+/* ═══════════════════════════════════════════════════════════════
+   NYUCHI SETTINGS PAGE — Layer 6 Page Orchestrator
+   
+   Standard settings layout. Sidebar nav on desktop, accordion
+   on mobile. Consistent setting row patterns.
+   ✅ HARNESS  ✅ TOKENS  ✅ RESPONSIVE  ✅ TOUCH 48px+
+   ═══════════════════════════════════════════════════════════════ */
+
+interface SettingSection {
+  id: string
+  label: string
+  icon?: React.ReactNode
+}
+interface NyuchiSettingsPageProps {
+  title?: string
+  sections: SettingSection[]
+  activeSection?: string
+  onSectionChange?: (id: string) => void
+  children: React.ReactNode
+  className?: string
+}
+
+export function NyuchiSettingsPage({
+  title = "Settings",
+  sections,
+  activeSection,
+  onSectionChange,
+  children,
+  className,
+}: NyuchiSettingsPageProps) {
+  const [active, setActive] = React.useState(activeSection || sections[0]?.id)
+
+  return (
+    <div
+      data-slot="nyuchi-settings-page"
+      data-portal="https://mzizi.dev/components/nyuchi-settings-page"
+      role="main"
+      aria-label="Settings"
+      className={cn("min-h-screen bg-background", className)}
+    >
+      <div className="mx-auto max-w-4xl px-4 py-6 sm:px-6">
+        <h1 className="mb-6 text-xl font-bold text-foreground">{title}</h1>
+        <div className="flex flex-col gap-6 md:flex-row">
+          {/* Sidebar nav (desktop) / horizontal scroll (mobile) */}
+          <nav className="shrink-0 md:w-48">
+            <div className="flex scrollbar-none gap-1 overflow-x-auto md:flex-col md:overflow-visible">
+              {sections.map((s) => (
+                <button
+                  key={s.id}
+                  onClick={() => {
+                    setActive(s.id)
+                    onSectionChange?.(s.id)
+                  }}
+                  className={cn(
+                    "flex min-h-[48px] shrink-0 items-center gap-2 rounded-[var(--radius-md,12px)] px-3 py-2.5 text-sm font-medium transition-colors",
+                    active === s.id
+                      ? "bg-muted text-foreground"
+                      : "text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                  )}
+                >
+                  {s.icon && <span className="text-base">{s.icon}</span>}
+                  {s.label}
+                </button>
+              ))}
+            </div>
+          </nav>
+          {/* Content */}
+          <div className="min-w-0 flex-1">{children}</div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/registry/n6-pages/nyuchi-splash-screen.tsx
+++ b/components/registry/n6-pages/nyuchi-splash-screen.tsx
@@ -1,0 +1,49 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface NyuchiSplashScreenProps {
+  progress?: number
+  message?: string
+  showLogo?: boolean
+  className?: string
+}
+
+export function NyuchiSplashScreen({
+  progress,
+  message,
+  showLogo = true,
+  className,
+}: NyuchiSplashScreenProps) {
+  return (
+    <div
+      data-slot="nyuchi-splash-screen"
+      data-portal="https://mzizi.dev/components/nyuchi-splash-screen"
+      role="status"
+      aria-label={message || "Loading Mukoko"}
+      className={cn(
+        "flex min-h-screen flex-col items-center justify-center gap-6 bg-background",
+        className
+      )}
+    >
+      {showLogo && (
+        <div className="animate-pulse">
+          <p className="text-3xl font-bold tracking-tight text-foreground">mukoko</p>
+        </div>
+      )}
+      <div className="flex flex-col items-center gap-3">
+        {progress != null && (
+          <div className="h-1 w-48 overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full rounded-full bg-primary transition-all duration-300"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        )}
+        {message && <p className="text-xs text-muted-foreground">{message}</p>}
+      </div>
+    </div>
+  )
+}
+
+export type { NyuchiSplashScreenProps }

--- a/components/registry/n6-pages/onboarding-flow.tsx
+++ b/components/registry/n6-pages/onboarding-flow.tsx
@@ -1,0 +1,222 @@
+"use client"
+
+import { useNyuchiHarness } from "@/lib/harness"
+
+import * as React from "react"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { ArrowLeft, ArrowRight, Check, Sparkles, Upload } from "@/lib/icons"
+
+const interests = [
+  { label: "Farming", color: "bg-malachite/15 text-malachite border-malachite/30" },
+  { label: "Mining", color: "bg-terracotta/15 text-terracotta border-terracotta/30" },
+  { label: "Travel", color: "bg-cobalt/15 text-cobalt border-cobalt/30" },
+  { label: "Tourism", color: "bg-tanzanite/15 text-tanzanite border-tanzanite/30" },
+  { label: "Sports", color: "bg-gold/15 text-gold border-gold/30" },
+  { label: "Technology", color: "bg-cobalt/15 text-cobalt border-cobalt/30" },
+  { label: "Music", color: "bg-tanzanite/15 text-tanzanite border-tanzanite/30" },
+  { label: "Food", color: "bg-malachite/15 text-malachite border-malachite/30" },
+  { label: "Business", color: "bg-terracotta/15 text-terracotta border-terracotta/30" },
+  { label: "Education", color: "bg-gold/15 text-gold border-gold/30" },
+]
+
+const steps = ["Welcome", "Profile", "Interests", "Complete"]
+
+function OnboardingFlow() {
+  const { motion } = useNyuchiHarness("onboarding-flow")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  const [step, setStep] = React.useState(0)
+  const [selected, setSelected] = React.useState<string[]>([])
+
+  const toggleInterest = (label: string) => {
+    setSelected((prev) =>
+      prev.includes(label) ? prev.filter((i) => i !== label) : [...prev, label]
+    )
+  }
+
+  return (
+    <div
+      data-slot="onboarding-flow"
+      style={animStyle}
+      data-portal="https://mzizi.dev/components/onboarding-flow"
+      role="main"
+      aria-label="Onboarding"
+      className="flex min-h-screen items-center justify-center bg-background px-4"
+    >
+      <Card className="w-full max-w-lg">
+        {/* Progress indicator */}
+        <CardHeader>
+          <div className="flex items-center justify-between gap-2">
+            {steps.map((s, i) => (
+              <div key={s} className="flex flex-1 flex-col items-center gap-1">
+                <div
+                  className={`flex size-8 items-center justify-center rounded-full text-xs font-medium transition-colors ${
+                    i < step
+                      ? "bg-malachite text-foreground"
+                      : i === step
+                        ? "bg-cobalt text-white"
+                        : "bg-muted text-muted-foreground"
+                  }`}
+                >
+                  {i < step ? <Check className="size-4" /> : i + 1}
+                </div>
+                <span className="text-[10px] text-muted-foreground">{s}</span>
+              </div>
+            ))}
+          </div>
+          {/* Progress bar */}
+          <div className="mt-3 flex h-1 gap-1 overflow-hidden rounded-full">
+            {steps.map((_, i) => (
+              <div
+                key={i}
+                className={`flex-1 rounded-full transition-colors ${
+                  i <= step ? "bg-cobalt" : "bg-muted"
+                }`}
+              />
+            ))}
+          </div>
+        </CardHeader>
+
+        <CardContent>
+          {/* Step 1: Welcome */}
+          {step === 0 && (
+            <div className="space-y-4 text-center">
+              <div className="mx-auto flex h-1 w-32 overflow-hidden rounded-full">
+                <div className="flex-1 bg-cobalt" />
+                <div className="flex-1 bg-tanzanite" />
+                <div className="flex-1 bg-malachite" />
+                <div className="flex-1 bg-gold" />
+                <div className="flex-1 bg-terracotta" />
+              </div>
+              <CardTitle className="font-serif text-2xl">Welcome to mukoko</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Your gateway to the African digital ecosystem. Let us set up your experience in a
+                few quick steps.
+              </p>
+            </div>
+          )}
+
+          {/* Step 2: Profile setup */}
+          {step === 1 && (
+            <div className="space-y-4">
+              <CardTitle className="font-serif text-lg">Set up your profile</CardTitle>
+              <div className="flex items-center gap-4">
+                <Avatar className="size-16">
+                  <AvatarFallback>
+                    <Upload className="size-5 text-muted-foreground" />
+                  </AvatarFallback>
+                </Avatar>
+                <Button variant="outline" size="sm">
+                  Upload photo
+                </Button>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="onboard-name">Display name</Label>
+                <Input id="onboard-name" placeholder="Your name" />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="onboard-bio">Bio</Label>
+                <Input id="onboard-bio" placeholder="Tell us about yourself" />
+              </div>
+            </div>
+          )}
+
+          {/* Step 3: Interests */}
+          {step === 2 && (
+            <div className="space-y-4">
+              <CardTitle className="font-serif text-lg">Pick your interests</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Choose topics you care about. This helps us personalize your feed.
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {interests.map((interest) => (
+                  <button
+                    key={interest.label}
+                    onClick={() => toggleInterest(interest.label)}
+                    className={`rounded-full border px-3 py-1.5 text-sm font-medium transition-all ${
+                      selected.includes(interest.label)
+                        ? interest.color
+                        : "border-border text-muted-foreground hover:border-foreground/20 hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+                    }`}
+                  >
+                    {selected.includes(interest.label) && <Check className="mr-1 inline size-3" />}
+                    {interest.label}
+                  </button>
+                ))}
+              </div>
+              {selected.length > 0 && (
+                <div className="flex flex-wrap gap-1">
+                  {selected.map((s) => (
+                    <Badge key={s} variant="secondary">
+                      {s}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Step 4: Complete */}
+          {step === 3 && (
+            <div className="space-y-4 text-center">
+              <div className="mx-auto flex size-16 items-center justify-center rounded-full bg-gold/15">
+                <Sparkles className="size-8 text-gold" />
+              </div>
+              <CardTitle className="font-serif text-2xl">You are all set!</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Welcome to the mukoko ecosystem. Start exploring and connecting with your community.
+              </p>
+              <div className="mx-auto flex h-1 w-32 overflow-hidden rounded-full">
+                <div className="flex-1 bg-cobalt" />
+                <div className="flex-1 bg-tanzanite" />
+                <div className="flex-1 bg-malachite" />
+                <div className="flex-1 bg-gold" />
+                <div className="flex-1 bg-terracotta" />
+              </div>
+            </div>
+          )}
+        </CardContent>
+
+        <CardFooter className="justify-between gap-2">
+          {step > 0 && step < 3 ? (
+            <Button variant="ghost" size="sm" onClick={() => setStep((s) => s - 1)}>
+              <ArrowLeft className="size-4" />
+              Back
+            </Button>
+          ) : (
+            <div />
+          )}
+          <div className="flex gap-2">
+            {step < 3 && step > 0 && (
+              <Button variant="ghost" size="sm" onClick={() => setStep((s) => s + 1)}>
+                Skip
+              </Button>
+            )}
+            {step < 3 ? (
+              <Button size="sm" onClick={() => setStep((s) => s + 1)}>
+                {step === 0 ? "Get started" : "Next"}
+                <ArrowRight className="size-4" />
+              </Button>
+            ) : (
+              <Button size="sm">Go to dashboard</Button>
+            )}
+          </div>
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}
+
+export { OnboardingFlow }

--- a/components/registry/n6-pages/onboarding-tour.tsx
+++ b/components/registry/n6-pages/onboarding-tour.tsx
@@ -1,0 +1,154 @@
+"use client"
+
+import { useNyuchiHarness } from "@/lib/harness"
+
+import * as React from "react"
+import { X } from "@/lib/icons"
+
+import { cn } from "@/lib/utils"
+
+interface TourStep {
+  target: string
+  title: string
+  description: string
+  position?: "top" | "bottom" | "left" | "right"
+}
+
+function OnboardingTour({
+  steps,
+  active,
+  onNext,
+  onSkip,
+  className,
+  ...props
+}: {
+  steps: TourStep[]
+  active: number
+  onNext: () => void
+  onSkip: () => void
+} & React.ComponentProps<"div">) {
+  const { motion } = useNyuchiHarness("onboarding-tour")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+
+  const [rect, setRect] = React.useState<DOMRect | null>(null)
+  const step = steps[active]
+
+  React.useEffect(() => {
+    if (!step) return
+    const el = document.querySelector(step.target)
+    if (el) {
+      const r = el.getBoundingClientRect()
+      setRect(r)
+      el.scrollIntoView({ behavior: "smooth", block: "center" })
+    } else {
+      setRect(null)
+    }
+  }, [step])
+
+  if (!step || active >= steps.length) return null
+
+  const position = step.position ?? "bottom"
+  const padding = 8
+
+  const tooltipStyle: React.CSSProperties = rect
+    ? {
+        position: "fixed",
+        ...(position === "bottom" && {
+          top: rect.bottom + padding,
+          left: rect.left + rect.width / 2,
+          transform: "translateX(-50%)",
+        }),
+        ...(position === "top" && {
+          bottom: window.innerHeight - rect.top + padding,
+          left: rect.left + rect.width / 2,
+          transform: "translateX(-50%)",
+        }),
+        ...(position === "left" && {
+          top: rect.top + rect.height / 2,
+          right: window.innerWidth - rect.left + padding,
+          transform: "translateY(-50%)",
+        }),
+        ...(position === "right" && {
+          top: rect.top + rect.height / 2,
+          left: rect.right + padding,
+          transform: "translateY(-50%)",
+        }),
+      }
+    : { position: "fixed", top: "50%", left: "50%", transform: "translate(-50%, -50%)" }
+
+  return (
+    <div
+      data-slot="onboarding-tour"
+      style={animStyle}
+      data-portal="https://mzizi.dev/components/onboarding-tour"
+      className={cn("", className)}
+      {...props}
+    >
+      {/* Overlay */}
+      <div className="fixed inset-0 z-[9998] bg-foreground/40" onClick={onSkip} />
+
+      {/* Spotlight cutout */}
+      {rect && (
+        <div
+          className="fixed z-[9999] rounded-lg ring-[9999px] ring-foreground/40"
+          style={{
+            top: rect.top - padding,
+            left: rect.left - padding,
+            width: rect.width + padding * 2,
+            height: rect.height + padding * 2,
+          }}
+        />
+      )}
+
+      {/* Tooltip */}
+      <div
+        className="z-[10000] w-72 rounded-xl border border-border bg-card p-4 shadow-lg"
+        style={tooltipStyle}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <h4 className="text-sm font-medium text-foreground">{step.title}</h4>
+          <button
+            type="button"
+            onClick={onSkip}
+            className="shrink-0 p-0.5 text-muted-foreground transition-colors hover:text-foreground"
+            aria-label="Skip tour"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">{step.description}</p>
+        <div className="mt-3 flex items-center justify-between">
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {active + 1} of {steps.length}
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={onSkip}
+              className="rounded-lg px-3 py-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Skip
+            </button>
+            <button
+              type="button"
+              onClick={onNext}
+              className="bg-[var(--color-primary, var(--color-cobalt, #00B0FF))] hover:bg-[var(--color-primary, var(--color-cobalt, #00B0FF))]/90 rounded-4xl px-3 py-1 text-xs font-medium text-white transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+            >
+              {active === steps.length - 1 ? "Done" : "Next"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export { OnboardingTour, type TourStep }

--- a/components/registry/n6-pages/org-profile-page.tsx
+++ b/components/registry/n6-pages/org-profile-page.tsx
@@ -1,0 +1,160 @@
+/* ═══════════════════════════════════════════════════════════════
+   PROFILE PAGE — Layer 6 (Page Composition)
+   
+   COMPOSITION: Should compose nyuchi-cover-header (L3) for the
+   cover image + avatar section instead of rendering inline.
+   COMPOSITION: Should compose nyuchi-profile-block (L3) for the
+   name + badge + stats section.
+   
+   Currently approved for use as-is. Refactor tracked.
+   ═══════════════════════════════════════════════════════════════ */
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+// COMPOSITION: Uses NyuchiCoverHeader from @/components/brand/nyuchi-cover-header
+// import { NyuchiCoverHeader } from "@/components/brand/nyuchi-cover-header"
+
+interface OrgProfile {
+  name: string
+  logo?: string
+  cover?: string
+  description?: string
+  category?: string
+  verified?: boolean
+  location?: string
+  memberCount?: number
+  website?: string
+}
+interface OrgProfilePageProps {
+  org?: OrgProfile
+  tabs?: { key: string; label: string }[]
+  activeTab?: string
+  onTabChange?: (key: string) => void
+  isAdmin?: boolean
+  onManage?: () => void
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+
+export function OrgProfilePage({
+  org,
+  tabs,
+  activeTab,
+  onTabChange,
+  isAdmin,
+  onManage,
+  children,
+  loading = false,
+  className,
+}: OrgProfilePageProps) {
+  const { motion } = useNyuchiHarness("org-profile-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="org-profile-page"
+        data-portal="https://mzizi.dev/components/org-profile-page"
+        data-loading
+        role="main"
+        className="animate-pulse"
+      >
+        <div className="h-40 bg-muted" />
+        <div className="space-y-3 p-4">
+          <div className="h-8 w-1/2 rounded bg-muted" />
+          <div className="h-4 w-full rounded bg-muted" />
+        </div>
+      </main>
+    )
+  return (
+    <main
+      data-slot="org-profile-page"
+      role="main"
+      aria-label={org?.name || "Organization"}
+      style={animStyle}
+      className={cn("flex flex-col", className)}
+    >
+      {org?.cover && (
+        <div
+          className="h-40 bg-cover bg-center sm:h-56"
+          style={{ backgroundImage: `url(${org.cover})` }}
+        />
+      )}
+      <div className="px-4 pb-4">
+        <div className="-mt-8 flex items-end justify-between">
+          <div className="size-16 overflow-hidden rounded-[var(--radius-lg,14px)] border border-4 border-background border-border bg-card">
+            {org?.logo && <img src={org.logo} alt="" className="size-full object-cover" />}
+          </div>
+          {isAdmin && onManage && (
+            <button
+              onClick={onManage}
+              className="min-h-[48px] rounded-full bg-primary px-4 text-sm font-medium text-white transition-colors hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+            >
+              Manage
+            </button>
+          )}
+        </div>
+        <div className="mt-3">
+          <div className="flex items-center gap-2">
+            <h1 className="text-xl font-bold">{org?.name}</h1>
+            {org?.verified && (
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="var(--tier-licensed, var(--status-warning, var(--color-gold, #FFD740)))"
+                aria-label="Verified"
+              >
+                <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            )}
+          </div>
+          {org?.category && <p className="text-sm text-muted-foreground">{org.category}</p>}
+          {org?.description && <p className="mt-2 text-sm text-foreground">{org.description}</p>}
+          <div className="mt-3 flex flex-wrap gap-3 text-xs text-muted-foreground">
+            {org?.location && <span>{org.location}</span>}
+            {org?.memberCount && <span>{org.memberCount} members</span>}
+            {org?.website && (
+              <a href={org.website} className="text-primary hover:underline">
+                {org.website}
+              </a>
+            )}
+          </div>
+        </div>
+      </div>
+      {tabs && (
+        <nav
+          aria-label="Organization sections"
+          className="flex overflow-x-auto border-b border-border px-4"
+        >
+          {tabs.map((t) => (
+            <button
+              key={t.key}
+              onClick={() => onTabChange?.(t.key)}
+              aria-selected={activeTab === t.key}
+              className={cn(
+                "min-h-[48px] shrink-0 border-b-2 px-4 text-sm font-medium transition-colors",
+                activeTab === t.key
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {t.label}
+            </button>
+          ))}
+        </nav>
+      )}
+      <div className="p-4">{children}</div>
+    </main>
+  )
+}
+export type { OrgProfile, OrgProfilePageProps }

--- a/components/registry/n6-pages/payment-page.tsx
+++ b/components/registry/n6-pages/payment-page.tsx
@@ -1,0 +1,115 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+
+type PaymentStep = "amount" | "recipient" | "method" | "confirm" | "processing" | "complete"
+
+interface PaymentPageProps {
+  step?: PaymentStep
+  recipient?: { name: string; avatar?: string; address?: string }
+  amount?: number
+  currency?: string
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+
+const STEPS: PaymentStep[] = ["amount", "recipient", "method", "confirm"]
+
+export function PaymentPage({
+  step = "amount",
+  recipient,
+  amount,
+  currency = "USD",
+  children,
+  loading = false,
+  className,
+}: PaymentPageProps) {
+  const { motion } = useNyuchiHarness("payment-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  const currentIdx = STEPS.indexOf(step)
+
+  if (loading)
+    return (
+      <main
+        data-slot="payment-page"
+        data-portal="https://mzizi.dev/components/payment-page"
+        data-loading
+        role="main"
+        className="animate-pulse space-y-4 p-4"
+      >
+        <div className="h-8 w-1/2 rounded bg-muted" />
+        <div className="h-48 rounded-[var(--radius-lg,14px)] bg-muted" />
+        <div className="h-14 rounded-full bg-muted" />
+      </main>
+    )
+
+  return (
+    <main
+      data-slot="payment-page"
+      data-step={step}
+      role="main"
+      aria-label="Payment"
+      style={animStyle}
+      className={cn("mx-auto flex max-w-md flex-col gap-6 p-4", className)}
+    >
+      {/* Progress */}
+      {step !== "processing" && step !== "complete" && (
+        <nav aria-label="Payment steps" className="flex gap-1">
+          {STEPS.map((s, i) => (
+            <div
+              key={s}
+              className={cn(
+                "h-1 flex-1 rounded-full transition-colors",
+                i <= currentIdx ? "bg-primary" : "bg-muted"
+              )}
+            />
+          ))}
+        </nav>
+      )}
+      {/* Processing state */}
+      {step === "processing" && (
+        <div className="flex flex-col items-center gap-4 py-16" role="status">
+          <div className="size-16 animate-spin rounded-full border-4 border-muted border-t-[var(--status-info,var(--color-cobalt,#00B0FF))]" />
+          <p className="text-sm text-muted-foreground">Processing payment...</p>
+        </div>
+      )}
+      {/* Complete state */}
+      {step === "complete" && (
+        <div className="flex flex-col items-center gap-4 py-16">
+          <div className="flex size-16 items-center justify-center rounded-full bg-[var(--status-success,var(--color-malachite,#64FFDA))]/15">
+            <svg
+              width="32"
+              height="32"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="var(--status-success, var(--color-malachite, #64FFDA))"
+              strokeWidth="2"
+              aria-hidden="true"
+            >
+              <path d="M5 12l5 5L20 7" />
+            </svg>
+          </div>
+          <p className="text-lg font-semibold">Payment Sent</p>
+          {amount && (
+            <p className="text-2xl font-bold">
+              {new Intl.NumberFormat(undefined, { style: "currency", currency }).format(amount)}
+            </p>
+          )}
+          {recipient && <p className="text-sm text-muted-foreground">to {recipient.name}</p>}
+        </div>
+      )}
+      {children}
+    </main>
+  )
+}
+export type { PaymentStep, PaymentPageProps }

--- a/components/registry/n6-pages/report-page.tsx
+++ b/components/registry/n6-pages/report-page.tsx
@@ -1,0 +1,110 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+interface ReportPageProps {
+  title?: string
+  subtitle?: string
+  date?: string
+  author?: string
+  status?: "draft" | "published" | "archived"
+  onPrint?: () => void
+  onExport?: () => void
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+export function ReportPage({
+  title,
+  subtitle,
+  date,
+  author,
+  status,
+  onPrint,
+  onExport,
+  children,
+  loading = false,
+  className,
+}: ReportPageProps) {
+  const { motion } = useNyuchiHarness("report-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="report-page"
+        data-portal="https://mzizi.dev/components/report-page"
+        data-loading
+        role="main"
+        className="mx-auto max-w-4xl animate-pulse space-y-4 p-6"
+      >
+        <div className="h-10 w-2/3 rounded bg-muted" />
+        <div className="h-4 w-1/3 rounded bg-muted" />
+        <div className="h-96 rounded-[var(--radius-lg,14px)] bg-muted" />
+      </main>
+    )
+  return (
+    <main
+      data-slot="report-page"
+      data-status={status}
+      role="main"
+      aria-label={title || "Report"}
+      style={animStyle}
+      className={cn("mx-auto max-w-4xl p-6 print:p-0", className)}
+    >
+      <header className="mb-8 border-b border-border pb-6 print:border-0">
+        <div className="flex items-start justify-between">
+          <div>
+            {title && <h1 className="text-2xl font-bold sm:text-3xl">{title}</h1>}
+            {subtitle && <p className="mt-1 text-sm text-muted-foreground">{subtitle}</p>}
+            <div className="mt-2 flex items-center gap-3 text-xs text-muted-foreground">
+              {date && <time>{date}</time>}
+              {author && <span>by {author}</span>}
+              {status && (
+                <span
+                  className={cn(
+                    "rounded-full px-2 py-0.5 font-medium",
+                    status === "published"
+                      ? "bg-[var(--status-success,var(--color-malachite,#64FFDA))]/15 text-[var(--status-success,var(--color-malachite,#64FFDA))]"
+                      : status === "draft"
+                        ? "bg-[var(--status-warning,var(--color-gold,#FFD740))]/15 text-[var(--status-warning,var(--color-gold,#FFD740))]"
+                        : "bg-muted text-muted-foreground"
+                  )}
+                >
+                  {status}
+                </span>
+              )}
+            </div>
+          </div>
+          <div className="flex gap-2 print:hidden">
+            {onPrint && (
+              <button
+                onClick={onPrint}
+                className="min-h-[48px] rounded-[var(--radius-lg,14px)] border border-border px-3 text-sm transition-colors hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+              >
+                Print
+              </button>
+            )}
+            {onExport && (
+              <button
+                onClick={onExport}
+                className="min-h-[48px] rounded-[var(--radius-lg,14px)] border border-border px-3 text-sm transition-colors hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+              >
+                Export
+              </button>
+            )}
+          </div>
+        </div>
+      </header>
+      <article className="prose prose-sm max-w-none text-foreground">{children}</article>
+    </main>
+  )
+}
+export type { ReportPageProps }

--- a/components/registry/n6-pages/signup-01.tsx
+++ b/components/registry/n6-pages/signup-01.tsx
@@ -1,0 +1,91 @@
+/* ═══════════════════════════════════════════════════════════════
+   AUTH BLOCK — Layer 6 (Page Composition)
+   
+   COMPOSITION PATTERN:
+   This block should compose L2 primitives (Button, Input, Card, Label)
+   and L3 brand components (nyuchi-auth-layout) rather than rendering
+   inline UI. The current implementation pre-dates the 3D architecture.
+   
+   APPROVED FOR USE: Yes, as-is. Refactor is tracked for a future pass.
+   The inline code works correctly — the refactor is for architectural
+   purity, not functionality.
+   ═══════════════════════════════════════════════════════════════ */
+"use client"
+
+import * as React from "react"
+
+import { useNyuchiHarness } from "@/lib/harness"
+
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+function Signup01() {
+  const { motion } = useNyuchiHarness("signup-01")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  return (
+    <div
+      data-slot="signup-01"
+      style={animStyle}
+      data-portal="https://mzizi.dev/components/signup-01"
+      role="form"
+      aria-label="Create account"
+      className="flex min-h-screen items-center justify-center bg-background px-4"
+    >
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <CardTitle className="font-serif text-xl">Create your account</CardTitle>
+          <CardDescription>Get started with mukoko in seconds</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="signup01-first">First name</Label>
+              <Input id="signup01-first" placeholder="Tanya" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="signup01-last">Last name</Label>
+              <Input id="signup01-last" placeholder="Moyo" />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="signup01-email">Email</Label>
+            <Input id="signup01-email" type="email" placeholder="you@example.com" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="signup01-password">Password</Label>
+            <Input id="signup01-password" type="password" placeholder="Create a password" />
+            <p className="text-xs text-muted-foreground">Must be at least 8 characters</p>
+          </div>
+          <Button className="w-full">Create account</Button>
+        </CardContent>
+        <CardFooter className="justify-center">
+          <p className="text-sm text-muted-foreground">
+            Already have an account?{" "}
+            <a href="#" className="font-medium text-foreground hover:underline">
+              Sign in
+            </a>
+          </p>
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}
+
+export { Signup01 }

--- a/components/registry/n6-pages/signup-02.tsx
+++ b/components/registry/n6-pages/signup-02.tsx
@@ -1,0 +1,142 @@
+/* ═══════════════════════════════════════════════════════════════
+   AUTH BLOCK — Layer 6 (Page Composition)
+   
+   COMPOSITION PATTERN:
+   This block should compose L2 primitives (Button, Input, Card, Label)
+   and L3 brand components (nyuchi-auth-layout) rather than rendering
+   inline UI. The current implementation pre-dates the 3D architecture.
+   
+   APPROVED FOR USE: Yes, as-is. Refactor is tracked for a future pass.
+   The inline code works correctly — the refactor is for architectural
+   purity, not functionality.
+   ═══════════════════════════════════════════════════════════════ */
+"use client"
+
+import * as React from "react"
+
+import { useNyuchiHarness } from "@/lib/harness"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Check } from "@/lib/icons"
+
+const steps = ["Account", "Profile", "Confirm"]
+
+function Signup02() {
+  const { motion } = useNyuchiHarness("signup-02")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  const [step, setStep] = useState(0)
+
+  return (
+    <div
+      data-slot="signup-02"
+      style={animStyle}
+      data-portal="https://mzizi.dev/components/signup-02"
+      role="form"
+      aria-label="Create account"
+      className="flex min-h-screen items-center justify-center bg-background px-4"
+    >
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          {/* Progress */}
+          <div className="mb-2 flex items-center gap-2">
+            {steps.map((s, i) => (
+              <div key={s} className="flex flex-1 items-center gap-2">
+                <div
+                  className={`flex size-7 shrink-0 items-center justify-center rounded-full text-xs font-medium ${
+                    i < step
+                      ? "bg-malachite/20 text-malachite"
+                      : i === step
+                        ? "bg-cobalt text-white"
+                        : "bg-muted text-muted-foreground"
+                  }`}
+                >
+                  {i < step ? <Check className="size-3.5" /> : i + 1}
+                </div>
+                {i < steps.length - 1 && (
+                  <div className={`h-px flex-1 ${i < step ? "bg-malachite/40" : "bg-border"}`} />
+                )}
+              </div>
+            ))}
+          </div>
+          <CardTitle className="font-serif text-xl">{steps[step]}</CardTitle>
+          <CardDescription>
+            {step === 0 && "Set up your credentials"}
+            {step === 1 && "Tell us about yourself"}
+            {step === 2 && "Review and confirm your details"}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {step === 0 && (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="signup02-email">Email</Label>
+                <Input id="signup02-email" type="email" placeholder="you@example.com" />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="signup02-password">Password</Label>
+                <Input
+                  id="signup02-password"
+                  type="password"
+                  placeholder="Create a strong password"
+                />
+              </div>
+            </>
+          )}
+          {step === 1 && (
+            <>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label htmlFor="signup02-first">First name</Label>
+                  <Input id="signup02-first" placeholder="Tanya" />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="signup02-last">Last name</Label>
+                  <Input id="signup02-last" placeholder="Moyo" />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="signup02-org">Organization (optional)</Label>
+                <Input id="signup02-org" placeholder="Nyuchi Africa" />
+              </div>
+            </>
+          )}
+          {step === 2 && (
+            <div className="rounded-xl bg-muted p-4 text-sm text-muted-foreground">
+              <p>
+                Review your information and click{" "}
+                <span className="font-medium text-foreground">Create account</span> to finish.
+              </p>
+            </div>
+          )}
+          <div className="flex gap-3">
+            {step > 0 && (
+              <Button variant="outline" className="flex-1" onClick={() => setStep(step - 1)}>
+                Back
+              </Button>
+            )}
+            <Button
+              className="flex-1"
+              onClick={() => (step < steps.length - 1 ? setStep(step + 1) : undefined)}
+            >
+              {step === steps.length - 1 ? "Create account" : "Continue"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export { Signup02 }

--- a/components/registry/n6-pages/signup-03.tsx
+++ b/components/registry/n6-pages/signup-03.tsx
@@ -1,0 +1,105 @@
+/* ═══════════════════════════════════════════════════════════════
+   AUTH BLOCK — Layer 6 (Page Composition)
+   
+   COMPOSITION PATTERN:
+   This block should compose L2 primitives (Button, Input, Card, Label)
+   and L3 brand components (nyuchi-auth-layout) rather than rendering
+   inline UI. The current implementation pre-dates the 3D architecture.
+   
+   APPROVED FOR USE: Yes, as-is. Refactor is tracked for a future pass.
+   The inline code works correctly — the refactor is for architectural
+   purity, not functionality.
+   ═══════════════════════════════════════════════════════════════ */
+"use client"
+
+import * as React from "react"
+
+import { useNyuchiHarness } from "@/lib/harness"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Check } from "@/lib/icons"
+
+const features = [
+  "82 production-ready components",
+  "Five African Minerals design system",
+  "Accessible and theme-aware",
+  "Install via shadcn CLI",
+]
+
+function Signup03() {
+  const { motion } = useNyuchiHarness("signup-03")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  return (
+    <div
+      data-slot="signup-03"
+      style={animStyle}
+      data-portal="https://mzizi.dev/components/signup-03"
+      role="form"
+      aria-label="Create account"
+      className="flex min-h-screen bg-background"
+    >
+      {/* Left — features */}
+      <div className="hidden flex-1 flex-col justify-center bg-card p-12 lg:flex">
+        <h2 className="mb-2 font-serif text-3xl font-semibold text-foreground">
+          Build faster with mukoko
+        </h2>
+        <p className="mb-8 max-w-md text-sm text-muted-foreground">
+          Join thousands of developers building pan-African products with our design system.
+        </p>
+        <ul className="space-y-4">
+          {features.map((f) => (
+            <li key={f} className="flex items-center gap-3">
+              <div className="flex size-6 shrink-0 items-center justify-center rounded-full bg-malachite/15">
+                <Check className="size-3.5 text-malachite" />
+              </div>
+              <span className="text-sm text-foreground">{f}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Right — form */}
+      <div className="flex flex-1 items-center justify-center border-l border-border px-6">
+        <div className="w-full max-w-sm space-y-6">
+          <div>
+            <h1 className="font-serif text-2xl font-semibold text-foreground">Create an account</h1>
+            <p className="mt-1 text-sm text-muted-foreground">Start building in minutes</p>
+          </div>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="signup03-name">Full name</Label>
+              <Input id="signup03-name" placeholder="Tanya Moyo" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="signup03-email">Email</Label>
+              <Input id="signup03-email" type="email" placeholder="you@example.com" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="signup03-password">Password</Label>
+              <Input id="signup03-password" type="password" placeholder="8+ characters" />
+            </div>
+            <Button className="w-full">Get started</Button>
+          </div>
+          <p className="text-center text-sm text-muted-foreground">
+            Already registered?{" "}
+            <a href="#" className="font-medium text-foreground hover:underline">
+              Sign in
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export { Signup03 }

--- a/components/registry/n6-pages/signup-04.tsx
+++ b/components/registry/n6-pages/signup-04.tsx
@@ -1,0 +1,95 @@
+/* ═══════════════════════════════════════════════════════════════
+   AUTH BLOCK — Layer 6 (Page Composition)
+   
+   COMPOSITION PATTERN:
+   This block should compose L2 primitives (Button, Input, Card, Label)
+   and L3 brand components (nyuchi-auth-layout) rather than rendering
+   inline UI. The current implementation pre-dates the 3D architecture.
+   
+   APPROVED FOR USE: Yes, as-is. Refactor is tracked for a future pass.
+   The inline code works correctly — the refactor is for architectural
+   purity, not functionality.
+   ═══════════════════════════════════════════════════════════════ */
+"use client"
+
+import * as React from "react"
+
+import { useNyuchiHarness } from "@/lib/harness"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+import { Lock } from "@/lib/icons"
+
+function Signup04() {
+  const { motion } = useNyuchiHarness("signup-04")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  return (
+    <div
+      data-slot="signup-04"
+      style={animStyle}
+      data-portal="https://mzizi.dev/components/signup-04"
+      role="form"
+      aria-label="Create account"
+      className="flex min-h-screen items-center justify-center bg-background px-4"
+    >
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-gold/10">
+            <Lock className="size-6 text-gold" />
+          </div>
+          <CardTitle className="font-serif text-xl">Invite only</CardTitle>
+          <CardDescription>Enter your invitation code to create an account</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="signup04-code">Invitation code</Label>
+            <Input
+              id="signup04-code"
+              placeholder="XXXX-XXXX-XXXX"
+              className="text-center font-mono tracking-wider"
+            />
+          </div>
+          <Separator />
+          <div className="space-y-2">
+            <Label htmlFor="signup04-email">Email</Label>
+            <Input id="signup04-email" type="email" placeholder="you@example.com" />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="signup04-first">First name</Label>
+              <Input id="signup04-first" placeholder="Tanya" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="signup04-last">Last name</Label>
+              <Input id="signup04-last" placeholder="Moyo" />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="signup04-password">Password</Label>
+            <Input id="signup04-password" type="password" placeholder="Create a password" />
+          </div>
+          <Button className="w-full">Activate account</Button>
+          <p className="text-center text-xs text-muted-foreground">
+            Need an invite?{" "}
+            <a href="#" className="text-cobalt hover:underline">
+              Request access
+            </a>
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export { Signup04 }

--- a/components/registry/n6-pages/signup-05.tsx
+++ b/components/registry/n6-pages/signup-05.tsx
@@ -1,0 +1,151 @@
+/* ═══════════════════════════════════════════════════════════════
+   AUTH BLOCK — Layer 6 (Page Composition)
+   
+   COMPOSITION PATTERN:
+   This block should compose L2 primitives (Button, Input, Card, Label)
+   and L3 brand components (nyuchi-auth-layout) rather than rendering
+   inline UI. The current implementation pre-dates the 3D architecture.
+   
+   APPROVED FOR USE: Yes, as-is. Refactor is tracked for a future pass.
+   The inline code works correctly — the refactor is for architectural
+   purity, not functionality.
+   ═══════════════════════════════════════════════════════════════ */
+"use client"
+
+import * as React from "react"
+
+import { useNyuchiHarness } from "@/lib/harness"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+function GithubIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  )
+}
+
+function Signup05() {
+  const { motion } = useNyuchiHarness("signup-05")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  const [agreed, setAgreed] = useState(false)
+
+  return (
+    <div
+      data-slot="signup-05"
+      style={animStyle}
+      data-portal="https://mzizi.dev/components/signup-05"
+      role="form"
+      aria-label="Create account"
+      className="flex min-h-screen items-center justify-center bg-background px-4"
+    >
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <CardTitle className="font-serif text-xl">Join mukoko</CardTitle>
+          <CardDescription>Create a free account to get started</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-2 gap-3">
+            <Button variant="outline" className="w-full gap-2">
+              <svg className="size-4" viewBox="0 0 24 24" fill="none">
+                <path
+                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                  fill="#4285F4"
+                />
+                <path
+                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                  fill="#34A853"
+                />
+                <path
+                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                  fill="#FBBC05"
+                />
+                <path
+                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                  fill="#EA4335"
+                />
+              </svg>
+              Google
+            </Button>
+            <Button variant="outline" className="w-full gap-2">
+              <GithubIcon className="size-4" />
+              GitHub
+            </Button>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <Separator className="flex-1" />
+            <span className="text-xs text-muted-foreground">or continue with email</span>
+            <Separator className="flex-1" />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="signup05-name">Full name</Label>
+            <Input id="signup05-name" placeholder="Tanya Moyo" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="signup05-email">Email</Label>
+            <Input id="signup05-email" type="email" placeholder="you@example.com" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="signup05-password">Password</Label>
+            <Input id="signup05-password" type="password" placeholder="8+ characters" />
+          </div>
+
+          <label className="flex items-start gap-2">
+            <input
+              type="checkbox"
+              checked={agreed}
+              onChange={(e) => setAgreed(e.target.checked)}
+              className="mt-0.5 size-4 rounded border-border accent-cobalt"
+            />
+            <span className="text-xs text-muted-foreground">
+              I agree to the{" "}
+              <a href="#" className="text-foreground underline">
+                Terms of Service
+              </a>{" "}
+              and{" "}
+              <a href="#" className="text-foreground underline">
+                Privacy Policy
+              </a>
+            </span>
+          </label>
+
+          <Button className="w-full" disabled={!agreed}>
+            Create account
+          </Button>
+        </CardContent>
+        <CardFooter className="justify-center">
+          <p className="text-sm text-muted-foreground">
+            Have an account?{" "}
+            <a href="#" className="font-medium text-foreground hover:underline">
+              Sign in
+            </a>
+          </p>
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}
+
+export { Signup05 }

--- a/components/registry/n6-pages/social-feed-page.tsx
+++ b/components/registry/n6-pages/social-feed-page.tsx
@@ -1,0 +1,94 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+
+interface SocialFeedPageProps {
+  stories?: React.ReactNode
+  createAction?: () => void
+  filters?: React.ReactNode
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+
+export function SocialFeedPage({
+  stories,
+  createAction,
+  filters,
+  children,
+  loading = false,
+  className,
+}: SocialFeedPageProps) {
+  const { motion } = useNyuchiHarness("social-feed-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="social-feed-page"
+        data-portal="https://mzizi.dev/components/social-feed-page"
+        data-loading
+        role="main"
+        className="animate-pulse space-y-4 p-4"
+      >
+        <div className="flex gap-3 overflow-hidden">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div key={i} className="size-16 shrink-0 rounded-full bg-muted" />
+          ))}
+        </div>
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-64 rounded-[var(--radius-lg,14px)] bg-muted" />
+        ))}
+      </main>
+    )
+  return (
+    <main
+      data-slot="social-feed-page"
+      role="main"
+      aria-label="Feed"
+      style={animStyle}
+      className={cn("flex flex-col", className)}
+    >
+      {stories && (
+        <section aria-label="Stories" className="border-b border-border px-4 py-3">
+          {stories}
+        </section>
+      )}
+      {filters && (
+        <section aria-label="Feed filters" className="border-b border-border px-4 py-2">
+          {filters}
+        </section>
+      )}
+      <section aria-label="Posts" className="flex flex-col gap-4 p-4">
+        {children}
+      </section>
+      {createAction && (
+        <button
+          onClick={createAction}
+          aria-label="Create post"
+          className="fixed right-4 bottom-20 z-40 flex size-14 items-center justify-center rounded-full bg-primary text-white shadow-lg transition-transform hover:scale-105 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+        >
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path d="M12 5v14M5 12h14" />
+          </svg>
+        </button>
+      )}
+    </main>
+  )
+}
+export type { SocialFeedPageProps }

--- a/components/registry/n6-pages/team-management-page.tsx
+++ b/components/registry/n6-pages/team-management-page.tsx
@@ -1,0 +1,138 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+interface TeamMember {
+  name: string
+  email: string
+  role: string
+  avatar?: string
+  status?: "active" | "invited" | "suspended"
+}
+interface TeamManagementPageProps {
+  teamName?: string
+  members?: TeamMember[]
+  inviteAction?: () => void
+  tabs?: { key: string; label: string }[]
+  activeTab?: string
+  onTabChange?: (key: string) => void
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+export function TeamManagementPage({
+  teamName,
+  members,
+  inviteAction,
+  tabs,
+  activeTab,
+  onTabChange,
+  children,
+  loading = false,
+  className,
+}: TeamManagementPageProps) {
+  const { motion } = useNyuchiHarness("team-management-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="team-management-page"
+        data-portal="https://mzizi.dev/components/team-management-page"
+        data-loading
+        role="main"
+        className="animate-pulse space-y-4 p-6"
+      >
+        <div className="h-8 w-1/3 rounded bg-muted" />
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-16 rounded-[var(--radius-lg,14px)] bg-muted" />
+        ))}
+      </main>
+    )
+  return (
+    <main
+      data-slot="team-management-page"
+      role="main"
+      aria-label={teamName ? `${teamName} Team` : "Team"}
+      style={animStyle}
+      className={cn("flex flex-col gap-6 p-6", className)}
+    >
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold">{teamName || "Team"}</h1>
+          {members && (
+            <p className="text-sm text-muted-foreground">
+              {members.length} member{members.length !== 1 ? "s" : ""}
+            </p>
+          )}
+        </div>
+        {inviteAction && (
+          <button
+            onClick={inviteAction}
+            className="min-h-[48px] rounded-full bg-primary px-4 text-sm font-medium text-white transition-colors hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+          >
+            Invite Member
+          </button>
+        )}
+      </header>
+      {tabs && (
+        <nav aria-label="Team sections" className="flex border-b border-border">
+          {tabs.map((t) => (
+            <button
+              key={t.key}
+              onClick={() => onTabChange?.(t.key)}
+              className={cn(
+                "min-h-[48px] border-b-2 px-4 text-sm font-medium transition-colors",
+                activeTab === t.key
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {t.label}
+            </button>
+          ))}
+        </nav>
+      )}
+      {members && (
+        <section
+          aria-label="Members"
+          className="divide-y divide-border rounded-[var(--radius-lg,14px)] border border-border bg-card"
+        >
+          {members.map((m, i) => (
+            <div key={i} className="flex items-center justify-between px-4 py-3">
+              <div className="flex items-center gap-3">
+                <div className="size-9 overflow-hidden rounded-full bg-muted">
+                  {m.avatar && <img src={m.avatar} alt="" className="size-full object-cover" />}
+                </div>
+                <div>
+                  <p className="text-sm font-medium">{m.name}</p>
+                  <p className="text-xs text-muted-foreground">{m.email}</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="rounded-full bg-muted px-2 py-0.5 text-xs">{m.role}</span>
+                {m.status === "invited" && (
+                  <span
+                    className="text-xs"
+                    style={{ color: "var(--status-warning, var(--color-gold, #FFD740))" }}
+                  >
+                    Pending
+                  </span>
+                )}
+              </div>
+            </div>
+          ))}
+        </section>
+      )}
+      {children}
+    </main>
+  )
+}
+export type { TeamMember, TeamManagementPageProps }

--- a/components/registry/n6-pages/transaction-history-page.tsx
+++ b/components/registry/n6-pages/transaction-history-page.tsx
@@ -1,0 +1,59 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+
+interface TransactionHistoryPageProps {
+  filters?: React.ReactNode
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+
+export function TransactionHistoryPage({
+  filters,
+  children,
+  loading = false,
+  className,
+}: TransactionHistoryPageProps) {
+  const { motion } = useNyuchiHarness("transaction-history-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="transaction-history-page"
+        data-portal="https://mzizi.dev/components/transaction-history-page"
+        data-loading
+        role="main"
+        className="animate-pulse space-y-3 p-4"
+      >
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="h-16 rounded-[var(--radius-lg,14px)] bg-muted" />
+        ))}
+      </main>
+    )
+  return (
+    <main
+      data-slot="transaction-history-page"
+      role="main"
+      aria-label="Transaction History"
+      style={animStyle}
+      className={cn("flex flex-col gap-4 p-4", className)}
+    >
+      <h1 className="text-xl font-bold">Transactions</h1>
+      {filters && <section aria-label="Filters">{filters}</section>}
+      <section aria-label="Transaction list" className="flex flex-col gap-2">
+        {children}
+      </section>
+    </main>
+  )
+}
+export type { TransactionHistoryPageProps }

--- a/components/registry/n6-pages/verification-page.tsx
+++ b/components/registry/n6-pages/verification-page.tsx
@@ -1,0 +1,122 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+
+type VerificationStep =
+  "phone" | "otp" | "id-upload" | "selfie" | "biometric" | "review" | "complete"
+interface VerificationTier {
+  key: string
+  label: string
+  color: string
+  unlocks: string[]
+  completed: boolean
+}
+interface VerificationPageProps {
+  currentStep?: VerificationStep
+  tiers?: VerificationTier[]
+  currentTier?: string
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+
+export function VerificationPage({
+  tiers,
+  currentTier,
+  children,
+  loading = false,
+  className,
+}: VerificationPageProps) {
+  const { motion } = useNyuchiHarness("verification-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+  if (loading)
+    return (
+      <main
+        data-slot="verification-page"
+        data-portal="https://mzizi.dev/components/verification-page"
+        data-loading
+        role="main"
+        className="mx-auto max-w-md animate-pulse space-y-4 p-4"
+      >
+        <div className="h-8 w-1/2 rounded bg-muted" />
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-20 rounded-[var(--radius-lg,14px)] bg-muted" />
+        ))}
+      </main>
+    )
+  return (
+    <main
+      data-slot="verification-page"
+      role="main"
+      aria-label="Verification"
+      style={animStyle}
+      className={cn("mx-auto flex max-w-md flex-col gap-6 p-4", className)}
+    >
+      <div>
+        <h1 className="text-xl font-bold">Verify Your Identity</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Unlock more features with higher verification
+        </p>
+      </div>
+      {tiers && (
+        <section aria-label="Verification tiers" className="flex flex-col gap-2">
+          {tiers.map((t) => (
+            <div
+              key={t.key}
+              className={cn(
+                "rounded-[var(--radius-lg,14px)] p-4 ring-1 transition-colors",
+                t.key === currentTier
+                  ? "bg-card ring-2"
+                  : t.completed
+                    ? "bg-card/50 ring-foreground/10"
+                    : "bg-muted/50 ring-foreground/5"
+              )}
+              style={t.key === currentTier ? { borderColor: t.color } : undefined}
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <div className="size-2 rounded-full" style={{ backgroundColor: t.color }} />
+                  <span className="text-sm font-medium">{t.label}</span>
+                </div>
+                {t.completed && (
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="var(--status-success,var(--color-malachite,#64FFDA))"
+                    strokeWidth="2"
+                    aria-label="Completed"
+                  >
+                    <path d="M5 12l5 5L20 7" />
+                  </svg>
+                )}
+              </div>
+              <div className="mt-1 flex flex-wrap gap-1">
+                {t.unlocks.map((u, i) => (
+                  <span
+                    key={i}
+                    className="rounded-full bg-foreground/5 px-2 py-0.5 text-xs text-muted-foreground"
+                  >
+                    {u}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </section>
+      )}
+      <section aria-label="Current step">{children}</section>
+    </main>
+  )
+}
+export type { VerificationStep, VerificationTier, VerificationPageProps }

--- a/components/registry/n6-pages/wallet-page.tsx
+++ b/components/registry/n6-pages/wallet-page.tsx
@@ -1,0 +1,124 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useNyuchiHarness } from "@/lib/harness"
+
+interface WalletPageProps {
+  balance?: { amount: number; currency: string; change?: number }
+  tokens?: { symbol: string; balance: number; value?: number }[]
+  actions?: { label: string; icon: React.ReactNode; onClick: () => void }[]
+  children?: React.ReactNode
+  loading?: boolean
+  className?: string
+}
+
+export function WalletPage({
+  balance,
+  tokens,
+  actions,
+  children,
+  loading = false,
+  className,
+}: WalletPageProps) {
+  const { motion } = useNyuchiHarness("wallet-page")
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+          },
+    [motion]
+  )
+
+  if (loading)
+    return (
+      <main
+        data-slot="wallet-page"
+        data-portal="https://mzizi.dev/components/wallet-page"
+        data-loading
+        role="main"
+        className="animate-pulse space-y-4 p-4"
+      >
+        <div className="h-32 rounded-[var(--radius-xl,17px)] bg-muted" />
+        <div className="flex gap-3">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-16 flex-1 rounded-[var(--radius-lg,14px)] bg-muted" />
+          ))}
+        </div>
+        <div className="h-64 rounded-[var(--radius-lg,14px)] bg-muted" />
+      </main>
+    )
+
+  return (
+    <main
+      data-slot="wallet-page"
+      role="main"
+      style={animStyle}
+      className={cn("flex flex-col gap-4 p-4", className)}
+    >
+      {/* Balance card */}
+      {balance && (
+        <section
+          aria-label="Balance"
+          className="rounded-[var(--radius-xl,17px)] bg-gradient-to-br from-primary to-primary/60 p-6 text-white"
+        >
+          <p className="text-sm opacity-80">Total Balance</p>
+          <p className="mt-1 text-3xl font-bold">
+            {new Intl.NumberFormat(undefined, {
+              style: "currency",
+              currency: balance.currency,
+            }).format(balance.amount)}
+          </p>
+          {balance.change != null && (
+            <p
+              className={cn(
+                "mt-1 text-sm",
+                balance.change >= 0 ? "text-[var(--status-success,#64FFDA)]" : "text-red-300"
+              )}
+            >
+              {balance.change >= 0 ? "+" : ""}
+              {balance.change.toFixed(2)}%
+            </p>
+          )}
+        </section>
+      )}
+      {/* Quick actions */}
+      {actions && actions.length > 0 && (
+        <section aria-label="Quick actions" className="flex gap-3 overflow-x-auto">
+          {actions.map((a, i) => (
+            <button
+              key={i}
+              onClick={a.onClick}
+              className="flex min-h-[48px] min-w-[72px] flex-1 flex-col items-center gap-1 rounded-[var(--radius-lg,14px)] border border-border bg-card p-3 text-xs font-medium transition-colors hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+            >
+              {a.icon}
+              <span>{a.label}</span>
+            </button>
+          ))}
+        </section>
+      )}
+      {/* Token portfolio */}
+      {tokens && tokens.length > 0 && (
+        <section
+          aria-label="Token portfolio"
+          className="divide-y divide-border rounded-[var(--radius-lg,14px)] border border-border bg-card"
+        >
+          {tokens.map((t) => (
+            <div key={t.symbol} className="flex items-center justify-between px-4 py-3">
+              <span className="text-sm font-medium">{t.symbol}</span>
+              <div className="text-right">
+                <p className="text-sm font-medium">{t.balance.toLocaleString()}</p>
+                {t.value != null && (
+                  <p className="text-xs text-muted-foreground">${t.value.toFixed(2)}</p>
+                )}
+              </div>
+            </div>
+          ))}
+        </section>
+      )}
+      {children}
+    </main>
+  )
+}
+export type { WalletPageProps }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,13 @@
     ],
     "paths": {
       "@/*": ["./*"],
-      "@/components/brand/*": ["./components/layout/*"]
+      "@/components/brand/*": ["./components/layout/*"],
+      "@/components/ui/*": [
+        "./components/ui/*",
+        "./components/registry/n7-shell/*",
+        "./components/registry/n3-brand/*",
+        "./components/registry/n2-primitives/*"
+      ]
     }
   },
   "include": [


### PR DESCRIPTION
Step 3 of the component-source migration, fifth batch (`docs/component-source-migration.md`). N6 pages — **52 components**.

Cleaner than N3, and the failures are the same families.

## Ten files never imported React

Every `login-0*` and `signup-0*` screen used `React.useState` with **no React import at all** — TS2686 in each. Ten auth screens no consumer could build.

## A third import path for the shell

`nyuchi-dashboard-layout` imported the sidebar, header and bottom nav from `@/components/nyuchi/*`. The registry declares those three at `components/ui/<name>.tsx` — where the shadcn CLI actually installs them — so `@/components/nyuchi/` matched **neither the registry nor this repo**, and the import was unsatisfiable everywhere.

Repointed to the registry's own declared path, with a `tsconfig` mapping so registry source resolves here without forking it. That is the second such drift this migration has surfaced, after `@/components/brand/*` in #200.

## A `loading` prop in two opposite states

Six layout components destructure `loading` without declaring it **and never read it** — the prop does nothing, so it is removed.

The auth screens are the same story with a twist: `Login01` and friends accept `loading` and render identical markup either way, so no spinner was ever wired. Two of them even put `loading` on an **icon** component.

In #201 (N3) the identical symptom meant the opposite — those components had a written, styled skeleton branch and only lacked the declaration, so there it was **declared**, not deleted. The fix follows the body, not the symptom.

## The rest

- **51 files** carried harness bindings nothing read.
- **12** computed `animStyle` and applied it to nothing, so the entrance animation never played — applied now.
- `nyuchi-feed-page` accepted `onRefresh` and **never called it** (pull-to-refresh that never refreshes), and defaulted its generic to `any`, erasing every element type the page renders — now `unknown`.
- `payment-page` accepted a `fee` it never displayed.
- Two `STEPS.indexOf(step as any)` casts asserted nothing — `step` is already the union `STEPS` holds.

## Verification

`pnpm typecheck`, `pnpm lint` (**0 warnings**), `pnpm test` (108 passing), `pnpm build` all green.

Trace manifest lists **112** registry files:

```
n4-safety 14 · n5-resilience 14 · n6-pages 52 · n7-shell 16 · n8-assurance 12 · n9-fundi 3 · n11-discovery 1
```

## Ordering

Branched after #200 merged, since the shell import mapping needs `components/registry/n7-shell/` to exist. Independent of #201 (N3). The N6 `source_code` drop happens after this merges and serves.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_