### PR TITLE
fix(registry): index every language, not an allow-list of four extensions

### DIFF
--- a/__tests__/lib/registry-source.test.ts
+++ b/__tests__/lib/registry-source.test.ts
@@ -92,3 +92,51 @@ describe("componentsOnDisk", () => {
     expect(new Set(names).size).toBe(names.length)
   })
 })
+
+/**
+ * The reader took an ALLOW-list of extensions — `.tsx`, `.ts`, `.css`, `.json` —
+ * and the registry is multi-language. Five components fell outside it: N8's
+ * `accessibility-audit` (`.md`, a documented SQL pipeline) and N1's Kotlin,
+ * Swift, Python and ArkTS token targets.
+ *
+ * Nothing looked broken, because `resolveComponentSource` fell back to the
+ * database column and served them from there. The defect was invisible until
+ * the column was dropped — at which point all five would have 404'd in
+ * production, past the point of no return. An allow-list fails closed on a
+ * language nobody anticipated, and it fails silently.
+ */
+describe("multi-language components", () => {
+  it("reads the five non-TypeScript components an allow-list dropped", () => {
+    for (const name of [
+      "accessibility-audit", // .md    — N8 assurance
+      "nyuchi-tokens-kotlin", // .kt    — N1
+      "nyuchi-tokens-swift", // .swift — N1
+      "nyuchi-tokens-python", // .py    — N1
+      "nyuchi-tokens-arkts", // .ets   — N1
+    ]) {
+      const source = readComponentSource(name)
+      expect(source, `${name} must resolve on disk, not via a database fallback`).not.toBeNull()
+      expect(source!.length).toBeGreaterThan(0)
+    }
+  })
+
+  it("indexes every non-hidden file in the registry tree", () => {
+    const indexed = new Set(componentsOnDisk())
+    const root = join(process.cwd(), "components/registry")
+
+    const missing: string[] = []
+    for (const dir of readdirSync(root, { withFileTypes: true })) {
+      if (!dir.isDirectory()) continue
+      for (const entry of readdirSync(join(root, dir.name))) {
+        if (entry.startsWith(".")) continue
+        const name = entry.replace(/\.[^.]+$/, "")
+        if (!indexed.has(name)) missing.push(`${dir.name}/${entry}`)
+      }
+    }
+
+    // Anything here is a file the routes cannot serve, which after the database
+    // drop means a 404 for a component the registry still advertises.
+    expect(missing).toEqual([])
+    expect(indexed.size).toBeGreaterThan(500)
+  })
+})

--- a/lib/registry-source.ts
+++ b/lib/registry-source.ts
@@ -27,8 +27,24 @@ import { basename, extname, join } from "node:path"
  */
 const REGISTRY_ROOT = join(process.cwd(), "components", "registry")
 
-/** Extensions a component's single source file may carry. */
-const SOURCE_EXTENSIONS = new Set([".tsx", ".ts", ".css", ".json"])
+/**
+ * Files that are never a component's source, whatever directory they land in.
+ *
+ * This is an EXCLUDE list, deliberately, where an allow-list of `.tsx / .ts /
+ * .css / .json` stood before. The registry is multi-language: N8's
+ * `accessibility-audit` ships as `.md` (a documented SQL pipeline) and N1's
+ * token targets ship as `.kt`, `.swift`, `.py`, `.ets` and `.rs`. An allow-list
+ * silently returned `null` for all five — they resolved through the database
+ * fallback instead, so nothing looked wrong until the fallback was removed, at
+ * which point they would have 404'd in production.
+ *
+ * An allow-list fails closed on a language nobody thought of, and it fails
+ * INVISIBLY: the reader returns null, the ramp covers it, and the defect only
+ * surfaces at the drop. Excluding known non-source instead means a new language
+ * works the day it lands, and a genuine mistake shows up as a duplicate-name
+ * error rather than a silent 404.
+ */
+const NOT_SOURCE = new Set([".ds_store", ".map", ".snap", ".log"])
 
 interface RegistryIndex {
   /** component name → absolute path of its source file */
@@ -48,8 +64,9 @@ function buildIndex(): RegistryIndex {
       if (!dir.isDirectory()) continue
       const nodeDir = join(REGISTRY_ROOT, dir.name)
       for (const entry of readdirSync(nodeDir)) {
+        if (entry.startsWith(".")) continue
         const ext = extname(entry)
-        if (!SOURCE_EXTENSIONS.has(ext)) continue
+        if (NOT_SOURCE.has(ext.toLowerCase())) continue
         const name = basename(entry, ext)
         const path = join(nodeDir, entry)
         seen.set(name, [...(seen.get(name) ?? []), path])


### PR DESCRIPTION
A blocker for dropping `source_code`, found while preparing that drop.

## The defect

`readComponentSource` selected files by an **allow-list** of extensions — `.tsx`, `.ts`, `.css`, `.json`. The registry is multi-language, and five components fall outside it:

| Component | Ext | Node |
| --- | --- | --- |
| `accessibility-audit` | `.md` | N8 — a documented SQL pipeline |
| `nyuchi-tokens-kotlin` | `.kt` | N1 |
| `nyuchi-tokens-swift` | `.swift` | N1 |
| `nyuchi-tokens-python` | `.py` | N1 |
| `nyuchi-tokens-arkts` | `.ets` | N1 |

The reader returned `null` for all five. **Nothing looked broken**, because `resolveComponentSource` fell back to the `source_code` column and served them from the database — the exact ramp #204 was built to let us remove. The index held **566** names where the registry has **571**.

The gap was invisible by construction. It would first have surfaced as five 404s in production, immediately after an irreversible drop.

## The fix

An allow-list fails closed on a language nobody anticipated, and it fails *silently*. It is now an **exclude** list of things that are never source (`.ds_store`, `.map`, `.snap`, `.log`, plus dotfiles), so a new language works the day it lands and a genuine mistake surfaces as the existing duplicate-name error rather than a silent null.

Cross-checked against the live registry: **all 571 names now resolve on disk, none missing.** The one file on disk without a registry row is `nyuchi-tokens-rust`, the newly generated Rust token target from #204.

## Tests

Two specs, reading the **real** `components/registry/**` tree rather than a fixture — a fixture would keep passing while production 404s, which is the failure mode being guarded. One asserts the five non-TypeScript components resolve; one asserts every non-hidden file in the tree is indexed.

Verified they bite: re-excluding `.md` and `.kt` fails them 2/110. Restored, 110/110 pass.

## Sequencing

**This must deploy before `source_code` is cleared.** Production is currently running the allow-list, so those five still resolve through the database there. Dropping the column before this ships would 404 them.

Order from here:

1. Merge + deploy this.
2. Confirm the five serve from production.
3. Then clear `document.source_code` across all 571 rows **and** `versions[].sourceCode` plus the two nested `snapshot` blobs across the 556 `versions` rows.
4. Then delete the `resolveComponentSource` ramp (six callers revert to `readComponentSource`) and the `components:verify` `--check` mode.

## Verification

`pnpm typecheck` 0 · `pnpm lint` 0 · `pnpm test` 110/110 · `pnpm build` · `format:check` — all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_