### PR TITLE
fix(api): /api/v1/ui/{name}/versions 500s on a column that does not exist

### DIFF
--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -1150,7 +1150,13 @@ export async function getComponentVersions(componentName: string): Promise<Compo
     .from("component_versions")
     .select("*")
     .eq("component_name", componentName)
-    .order("released_at", { ascending: false })
+    // `component_versions` has no `released_at` — it is a VIEW whose timestamp
+    // column is `created_at`. Ordering by a column that does not exist made
+    // PostgREST error, `getComponentVersions` throw, and
+    // `/api/v1/ui/{name}/versions` answer 500 for every component in the
+    // registry. `changelog` does have `released_at`, which is why the two other
+    // call sites in this file are correct and only this one was wrong.
+    .order("created_at", { ascending: false })
 
   if (error) throw new Error(error.message)
   return (data ?? []) as unknown as ComponentVersionRow[]


### PR DESCRIPTION
One of five documented v1 endpoints currently returning 500 in production. This fixes the one with an isolated cause; the other four share a different one, documented below.

## This fix

`getComponentVersions` (`lib/db/index.ts`) ordered `component_versions` by **`released_at`**. That column does not exist — `component_versions` is a view whose columns are `component_name, version, version_number, change_type, comment, source_code, description, status, ecosystem_node, category, subcategory, tags, changed_by, created_at`.

PostgREST rejected the order, the helper threw, the route answered 500 — for **every** component, not just some.

`changelog` *does* have `released_at`, which is why the other two `.order("released_at")` call sites in the same file are correct and only this one was wrong. Confirmed against live PostgREST: `order=created_at.desc` returns rows; `order=released_at.desc` is a 400.

## Production probe — the full picture

Every documented `/api/v1` endpoint, cache-busted:

| Endpoint | Status |
| --- | --- |
| `ui/{name}/versions` | **500** ← fixed here |
| `ecosystem` | **500** |
| `data-layer` | **500** |
| `pipeline` | **500** |
| `sovereignty` | **500** |
| `architecture`, `brand`, `ui`, `ui/{name}/docs`, `changelog`, `skills`, `stats`, `health` | 200 |

## The other four — diagnosed, not fixed here

`lib/db` queries **ten relations that do not exist.** Eight are the `architecture_*` tables behind those four routes. The data was never lost — it migrated into `component_documents` as `documentation-architecture-*` collections and the old tables were dropped, but `lib/db` was never repointed:

| `lib/db` queries (missing) | Actual collection | Rows |
| --- | --- | --- |
| `architecture_principles` | `documentation-architecture-principles` | 6 |
| `architecture_framework` | `documentation-architecture-framework` | 1 |
| `architecture_data_layer` | `documentation-architecture-data` | 4 |
| `architecture_cloud_layer` | `documentation-architecture-cloud` | 5 |
| `architecture_data_ownership` | `documentation-architecture-data-ownership` | 4 |
| `architecture_pipeline` | `documentation-architecture-pipeline` | 4 |
| `architecture_sovereignty` | `documentation-architecture-sovereignty` | 16 |
| `architecture_removed` | `documentation-architecture-removed` | 6 |

The remaining two missing relations are `component_docs` and `component_demos`. `component_docs` is interesting: `/api/v1/ui/{name}/docs` returns **200** despite the table being absent, so that path swallows the error — worth confirming it isn't silently serving an empty payload.

Repointing eight helpers at the document store means mapping each collection's `document->>` fields onto the existing `Row` types, and that deserves its own PR with per-route verification rather than being bundled behind a one-line ordering fix. CLAUDE.md §6.1 also still lists `architecture_*` as live tables and needs correcting with it.

## Verification

`pnpm typecheck` 0 · `pnpm lint` 0 · `pnpm test` 110/110. After deploy: `curl https://mzizi.dev/api/v1/ui/button/versions` should return 200 with a `data` array.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_