### PR TITLE
fix: clear the last DB source, classify the changelog by release, and fix 256 empty previews

### DIFF
--- a/__tests__/api/v1/changelog-classification.test.ts
+++ b/__tests__/api/v1/changelog-classification.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { parse } from "yaml"
+
+/**
+ * Releases are classified, and the changelog is ordered across two version eras.
+ *
+ * Three live defects motivated this, all of which left every gate green:
+ *
+ *   1. `getChangelogEntries` ordered `changelog` by `released_at DESC`. Ten of
+ *      64 rows have no `released_at`, Postgres sorts NULLS FIRST on DESC, so
+ *      the changelog opened with 4.1.8 / 4.1.1 / 4.1.2 / 4.1.0 in arbitrary
+ *      order and the current release, 1.0.0, sat at position eleven.
+ *   2. `getLatestVersion` used the same ordering and returned **4.1.8**.
+ *   3. `getChangelogByVersion` used `.single()`. PostgREST answers PGRST116 for
+ *      "more than one row" as well as "no rows", and eight versions carry two
+ *      or three entries, so `/api/v1/changelog/4.0.31` answered 404 for a
+ *      release present three times.
+ *
+ * Sorting by semver instead of by date fixes none of it — it puts 4.2.0 above
+ * 1.0.0, and the version line was deliberately reset (§14). The fix is a
+ * `releases` view carrying `line`, so these assertions pin the code to reading
+ * that view rather than re-deriving an order.
+ */
+
+const root = resolve(__dirname, "../../..")
+const db = readFileSync(resolve(root, "lib/db/index.ts"), "utf8")
+const types = readFileSync(resolve(root, "lib/db/types.ts"), "utf8")
+const spec = parse(readFileSync(resolve(root, "openapi.yaml"), "utf8"))
+
+/** The body of a named exported function in lib/db, up to the next export. */
+function fnBody(name: string): string {
+  const at = db.indexOf(`export async function ${name}`)
+  expect(at, `${name} must exist in lib/db`).toBeGreaterThan(-1)
+  const next = db.indexOf("\nexport ", at + 1)
+  return db.slice(at, next === -1 ? db.length : next)
+}
+
+describe("changelog ordering", () => {
+  it("getChangelogEntries reads the pre-sorted releases view", () => {
+    const body = fnBody("getChangelogEntries")
+    expect(body).toMatch(/\.from\((["'`])releases\1\)/)
+  })
+
+  it("getChangelogEntries does not re-order by released_at", () => {
+    // The view is sorted by (line_rank, major, minor, patch). A `.order()` here
+    // would silently override that and restore the NULLS-FIRST bug.
+    expect(fnBody("getChangelogEntries")).not.toMatch(/\.order\(/)
+  })
+
+  it("getLatestVersion reads the releases view, not released_at", () => {
+    const body = fnBody("getLatestVersion")
+    expect(body).toMatch(/\.from\((["'`])releases\1\)/)
+    expect(body).not.toMatch(/released_at/)
+  })
+})
+
+describe("a version may carry several entries", () => {
+  it("getChangelogByVersion returns an array", () => {
+    expect(db).toMatch(/getChangelogByVersion\([^)]*\): Promise<ChangelogRow\[\]>/)
+  })
+
+  it("getChangelogByVersion does not use .single()", () => {
+    // `.single()` is what turned "three entries" into 404 on eight releases.
+    expect(fnBody("getChangelogByVersion")).not.toMatch(/\.single\(\)/)
+  })
+})
+
+describe("the classification is typed and specified", () => {
+  it("ChangelogRow carries line and release_kind", () => {
+    const row = /export interface ChangelogRow \{([\s\S]*?)\n\}/.exec(types)
+    expect(row).not.toBeNull()
+    expect(row![1]).toMatch(/\bline\?:/)
+    expect(row![1]).toMatch(/\brelease_kind\?:/)
+  })
+
+  it("ComponentVersionRow carries entity_kind, change_kind and release", () => {
+    const row = /export interface ComponentVersionRow \{([\s\S]*?)\n\}/.exec(types)
+    expect(row).not.toBeNull()
+    for (const field of ["entity_kind", "change_kind", "release"]) {
+      expect(row![1]).toMatch(new RegExp(`\\b${field}:`))
+    }
+  })
+
+  it("component_name is non-nullable — it used to be null on 1,034 rows", () => {
+    const row = /export interface ComponentVersionRow \{([\s\S]*?)\n\}/.exec(types)
+    expect(row![1]).toMatch(/component_name:\s*string(?!\s*\|\s*null)/)
+  })
+
+  it("the OpenAPI ChangelogEntry schema declares the classification", () => {
+    const props = spec.components.schemas.ChangelogEntry.properties
+    expect(Object.keys(props)).toEqual(
+      expect.arrayContaining(["line", "release_kind", "components_touched"])
+    )
+    expect(props.line.enum).toEqual(expect.arrayContaining(["public", "pre-1.0"]))
+  })
+
+  it("the spec describes /changelog as returning data, matching the route", () => {
+    // It said `releases` while the route served `data` — a contract nobody could
+    // satisfy by reading the spec.
+    const ok = spec.paths["/changelog"].get.responses["200"].content["application/json"].schema
+    expect(Object.keys(ok.properties)).toContain("data")
+  })
+})

--- a/__tests__/db/no-source-in-database.test.ts
+++ b/__tests__/db/no-source-in-database.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+/**
+ * Component source lives on disk in git (§8.3) and NOWHERE in Supabase.
+ *
+ * It took five separate removals to get there, because each one only cleared
+ * the shape someone happened to look at:
+ *
+ *   1. `components.source_code`               — the original column
+ *   2. `component_versions.source_code`       — the view projected it, and
+ *                                               `select("*")` served ~10 MB of
+ *                                               stale source publicly
+ *   3. `versions[].sourceCode`                — 2,728 archive entries
+ *   4. `versions[].snapshot.source_code`      —   576 entries
+ *   5. `versions[].snapshot.versions[].sourceCode` — 556, one level deeper and
+ *                                               invisible to a structural check
+ *                                               that only read top-level keys
+ *
+ * Plus two orphaned snapshot TABLES (`components_store`,
+ * `component_versions_store`) that nothing read and anon could SELECT.
+ *
+ * These assertions are source-level rather than live queries, deliberately: a
+ * test that needs credentials is skipped in CI, which is exactly where the
+ * regression would land. What can be checked offline is that no query in
+ * `lib/db` asks for a source column and that no `select("*")` reaches a
+ * component-bearing relation — those are the two mechanisms that produced
+ * every leak above.
+ */
+
+const root = resolve(__dirname, "../..")
+const db = readFileSync(resolve(root, "lib/db/index.ts"), "utf8")
+
+/** Relations that carry component metadata, where `*` would be dangerous. */
+const COMPONENT_RELATIONS = ["components", "component_versions", "component_documents"]
+
+describe("no component source is read from the database", () => {
+  it("lib/db never selects a source column", () => {
+    // Comments explaining the removal are expected and fine; a `.select()`
+    // naming it is not.
+    const selects = [...db.matchAll(/\.select\((["'`])([\s\S]*?)\1\)/g)].map((m) => m[2])
+    for (const columns of selects) {
+      expect(columns, `select("${columns}") must not request source`).not.toMatch(
+        /\bsource_code\b|\bsourceCode\b/
+      )
+    }
+  })
+
+  it("no select(*) against a component-bearing relation", () => {
+    // `select("*")` is how the versions leak happened: the view gained a
+    // source_code column and the query silently started serving it.
+    for (const relation of COMPONENT_RELATIONS) {
+      const pattern = new RegExp(
+        `\\.from\\((["'\`])${relation}\\1\\)[\\s\\S]{0,200}?\\.select\\((["'\`])\\*\\2\\)`,
+        "g"
+      )
+      const hits = [...db.matchAll(pattern)]
+      expect(hits.length, `.from("${relation}") must not be followed by .select("*")`).toBe(0)
+    }
+  })
+
+  it("getDesignTokens is gone rather than repointed", () => {
+    // It parsed `components.source_code` into a token object — a third copy of
+    // the palette that `pnpm tokens:sync` already generates (§8.4.1).
+    expect(db).not.toMatch(/export\s+(async\s+)?function\s+getDesignTokens/)
+  })
+
+  it("the version row type carries no source field", () => {
+    const types = readFileSync(resolve(root, "lib/db/types.ts"), "utf8")
+    const row = /export interface ComponentVersionRow \{([\s\S]*?)\n\}/.exec(types)
+    expect(row).not.toBeNull()
+    expect(row![1]).not.toMatch(/\bsource_code\b|\bsourceCode\b/)
+  })
+})

--- a/__tests__/samples.test.ts
+++ b/__tests__/samples.test.ts
@@ -136,3 +136,55 @@ describe("prop resolution", () => {
     }
   })
 })
+
+describe("preview coverage", () => {
+  /**
+   * A floor, not a target.
+   *
+   * `scripts/extract-props.ts` only understood a named `interface FooProps`
+   * declaration, and most of this registry declares props INLINE on the
+   * component's parameter — either `}: React.ComponentProps<"div"> & { … }` or
+   * a bare `}: { … }`. So 256 of 572 components extracted zero props, and a
+   * component with no props resolves to no sample data, which renders the
+   * "needs props" fallback rather than the component doing its job. Nothing
+   * failed; the previews were just empty.
+   *
+   * These numbers are deliberately below the measured values so ordinary
+   * additions do not trip them. What they catch is a regression in the
+   * EXTRACTOR — the failure that is invisible because it produces a smaller
+   * object rather than an error.
+   */
+  it("extracts props for most of the registry", () => {
+    expect(Object.keys(COMPONENT_PROPS).length).toBeGreaterThanOrEqual(450)
+  })
+
+  it("resolves at least one prop for the large majority of them", () => {
+    let resolved = 0
+    for (const [name, props] of Object.entries(COMPONENT_PROPS)) {
+      if (!props.length) continue
+      if (resolvePropsFor(name).matched.length > 0) resolved++
+    }
+    expect(resolved).toBeGreaterThanOrEqual(400)
+  })
+
+  it("never extracts a prop whose type swallowed the next one", () => {
+    // The `=>` trap: counting `>` as a closing bracket drives depth negative on
+    // an arrow-function prop, and every later member collapses into the
+    // previous one's type — `onChange` came out as
+    // `"(value: AddressValue) => void className?: string"`, taking `className`
+    // with it.
+    //
+    // The tell is a member declaration following `=> void` (or `=> Promise<…>`)
+    // with NO separator. A nested object type like
+    // `{ name: string; avatar?: string }` has separators and is perfectly
+    // legitimate — an earlier version of this assertion flagged
+    // `article-page.author` for exactly that and was wrong.
+    for (const [component, props] of Object.entries(COMPONENT_PROPS)) {
+      for (const prop of props) {
+        expect(prop.type, `${component}.${prop.name} swallowed the prop after it`).not.toMatch(
+          /=>\s*[\w<>[\]|]+\s+\w+\??:/
+        )
+      }
+    }
+  })
+})

--- a/app/api/v1/changelog/[version]/route.ts
+++ b/app/api/v1/changelog/[version]/route.ts
@@ -38,9 +38,9 @@ export async function GET(_request: Request, { params }: { params: Promise<{ ver
       return NextResponse.json({ error: "Database not configured" }, { status: 503, headers: CORS })
     }
 
-    const entry = await getChangelogByVersion(version)
+    const entries = await getChangelogByVersion(version)
 
-    if (!entry) {
+    if (entries.length === 0) {
       trackApiCall({
         endpoint: `/api/v1/changelog/${version}`,
         durationMs: Date.now() - start,
@@ -58,7 +58,22 @@ export async function GET(_request: Request, { params }: { params: Promise<{ ver
       statusCode: 200,
     })
 
-    return NextResponse.json(entry, { headers: CORS_CACHE })
+    // `data` is an ARRAY, matching `/api/v1/changelog`, because a version is not
+    // unique: eight of them carry two or three entries with different titles and
+    // content. Serving the first would drop real release notes, and the previous
+    // `.single()` served none at all — PostgREST answers PGRST116 for "more than
+    // one row" as well as "no rows", so those eight versions 404'd.
+    //
+    // The first entry is also spread at the top level so a consumer written
+    // against the old single-object shape keeps working.
+    return NextResponse.json(
+      {
+        ...entries[0],
+        data: entries,
+        meta: { version, entries: entries.length },
+      },
+      { headers: CORS_CACHE }
+    )
   } catch (error) {
     logger.error("Changelog entry error", {
       error: error instanceof Error ? error : new Error(String(error)),

--- a/app/api/v1/stats/route.ts
+++ b/app/api/v1/stats/route.ts
@@ -1,44 +1,35 @@
 import { NextResponse } from "next/server"
 import { createLogger } from "@/lib/observability"
 import { getUsageStats } from "@/lib/metrics"
-import { getPublicClient, isSupabaseConfigured } from "@/lib/db"
-import { componentsOnDisk } from "@/lib/registry-source"
+import { readNodeCounts } from "@/lib/registry"
 
 const logger = createLogger("api")
 
 /**
- * Count stable components grouped by architecture_layer. Returns an empty
- * object if Supabase is unreachable or the layer column is missing — callers
- * should treat the absence of data as "don't render layer breakdown".
+ * Count components per node, from the registry on disk.
+ *
+ * This used to `select("name, layer, source_code")` from the `components` view
+ * and treat any error as "no data" by returning `{}`. Two things were wrong
+ * with that, and the second hid the first:
+ *
+ *   - The component set is not in the database. It is `registry.json` plus the
+ *     files under `components/registry/`, both of which are in the deployed
+ *     bundle. Asking Postgres how many components exist is a network round trip
+ *     to a less authoritative answer than a local read.
+ *   - The `catch`/`if (error) return {}` meant a broken query was
+ *     indistinguishable from an empty registry. `/api/v1/stats` served
+ *     `"layers": {}` and looked healthy. When `source_code` was dropped from
+ *     the view, the query started failing with 42703 and nothing changed in the
+ *     response — which is precisely the failure mode the whole extraction was
+ *     about.
+ *
+ * Keyed by node number as a string, so the shape consumers already parse is
+ * unchanged. A registry with no components yields `{}` — but now that means the
+ * registry is empty, not that a query failed.
  */
-async function getLayerBreakdown(): Promise<Record<string, number>> {
-  if (!isSupabaseConfigured()) return {}
-  try {
-    const { data, error } = await getPublicClient()
-      .from("components")
-      .select("name, layer, source_code")
-
-    if (error || !data) return {}
-
-    // "Has source" used to be `source_code is not null`. Source is moving to
-    // disk node by node, so during the migration it is either place; once the
-    // last node drops, the `source_code` half of this goes with it.
-    const onDisk = new Set(componentsOnDisk())
-
-    const breakdown: Record<string, number> = {}
-    for (const row of data as unknown as Array<{
-      name: string
-      layer: string | null
-      source_code: string | null
-    }>) {
-      if (!onDisk.has(row.name) && !row.source_code) continue
-      const key = row.layer ?? "unknown"
-      breakdown[key] = (breakdown[key] ?? 0) + 1
-    }
-    return breakdown
-  } catch {
-    return {}
-  }
+function getLayerBreakdown(): Record<string, number> {
+  const counts = readNodeCounts()
+  return Object.fromEntries(Object.entries(counts).map(([node, total]) => [node, total]))
 }
 
 const CORS = {
@@ -61,7 +52,8 @@ export async function GET(request: Request) {
     const daysParam = url.searchParams.get("days")
     const days = daysParam ? Math.min(Math.max(parseInt(daysParam, 10) || 30, 1), 90) : 30
 
-    const [stats, layers] = await Promise.all([getUsageStats(days), getLayerBreakdown()])
+    const stats = await getUsageStats(days)
+    const layers = getLayerBreakdown()
 
     logger.info("Stats served", {
       data: { days, totalCalls: stats.total_api_calls + stats.total_mcp_calls },

--- a/app/changelog/[name]/page.tsx
+++ b/app/changelog/[name]/page.tsx
@@ -131,9 +131,29 @@ export default async function ComponentChangelogPage({
                     {releasedOn(entry.created_at)}
                   </time>
                 ) : null}
-                {entry.change_type ? (
+                {/*
+                  `change_kind` is the normalised value, not the raw
+                  `change_type`. The raw set held 12 ad-hoc strings, the largest
+                  of which — `4.1.1-alignment`, on 2,132 rows — was a release
+                  marker rather than a kind of change, so rendering it read as a
+                  change type that no other row shared. The release it encodes is
+                  shown as a release instead, which is what it always was.
+                */}
+                {entry.change_kind && entry.change_kind !== "unclassified" ? (
                   <span className="font-mono text-[11px] tracking-wide text-muted-foreground uppercase">
-                    {entry.change_type}
+                    {entry.change_kind}
+                  </span>
+                ) : null}
+                {entry.release ? (
+                  <span
+                    className="rounded-full border border-border px-2 py-0.5 font-mono text-[11px] text-muted-foreground"
+                    title={
+                      entry.release_marker
+                        ? "Release recorded on the change itself"
+                        : "Newest release published on or before this change"
+                    }
+                  >
+                    {entry.release_breaking ? "breaking · " : ""}v{entry.release}
                   </span>
                 ) : null}
               </header>

--- a/docs/pulling-in-primitives.md
+++ b/docs/pulling-in-primitives.md
@@ -1,0 +1,154 @@
+# Pulling primitives into your app
+
+Where the primitives are, how to install them per target, and what to do when the
+target you want has no source yet.
+
+This is the answer to "where and how do I pull the primitives in". It is
+deliberately separate from the build-out plan (issue #222 and its waves), because
+consuming and producing are different jobs with different audiences.
+
+---
+
+## 1. First, ask which target you are on
+
+The registry serves **two different things** depending on target, and confusing
+them wastes the most time. `framework_descriptors.readiness` is the field that
+says which:
+
+| `readiness`        | What you actually get                                         |
+| ------------------ | ------------------------------------------------------------- |
+| `production`       | Real, installable component source                            |
+| `primitives_wired` | Some primitives resolve; the surface is partial               |
+| `metadata_only`    | **Instructions only** — contract, tokens and rules, no source |
+
+A `metadata_only` target is not broken and not "coming soon". It is a stated
+position: the contract exists, the source is yours to write. Do not wait for it.
+
+`readiness` is not the same question as `tier`, and you need both:
+
+| `tier`     | Meaning                                              |
+| ---------- | ---------------------------------------------------- |
+| `primary`  | Where Mzizi is heading — Rust: `dioxus`, `crates-io` |
+| `native`   | First-class native shells — swift, kotlin, arkts, RN |
+| `optional` | Supported, not the destination — `svelte`            |
+| `legacy`   | Still ships, being moved away from — `react`         |
+
+They point opposite ways today on purpose: **svelte is `production` + `optional`**
+(source exists, not the direction) while **dioxus is `metadata_only` + `primary`**
+(the direction, source not wired). One field would force a false choice between
+"has components" and "is the plan", and whichever it answered would mislead you.
+
+---
+
+## 2. Installing, per target
+
+### React — the shadcn CLI
+
+```bash
+npx shadcn@latest add https://mzizi.dev/api/v1/ui/button
+```
+
+This is the only target with a CLI that resolves the registry directly. It reads
+the item's `files[].path` for where to put the file, `dependencies` for npm
+packages, and `registryDependencies` for other components to pull in first.
+
+Two things that will bite you if the manifest is wrong, both now gate-checked by
+`pnpm registry:validate`:
+
+- A `registryDependencies` entry is a **bare name only** for components that exist
+  upstream at ui.shadcn.com. Anything Mzizi-only needs the absolute
+  `https://mzizi.dev/api/v1/ui/<name>` form, because a bare name sends the CLI to
+  the default registry, where it 404s.
+- Every npm package a component imports must be in its `dependencies`. A missing
+  one installs a file that cannot resolve its own import.
+
+### Svelte
+
+Use `shadcn-svelte` against the same registry. Source exists; it is not where the
+system is heading.
+
+### Rust / Dioxus
+
+Consumed as a **crate**, not via a CLI:
+
+```toml
+[dependencies]
+mzizi-ui     = { git = "https://github.com/nyuchi/mzizi", package = "mzizi-ui" }
+mzizi-tokens = { git = "https://github.com/nyuchi/mzizi", package = "mzizi-tokens" }
+```
+
+Check what actually exists before you plan around it:
+
+```bash
+curl https://mzizi.dev/api/v1/rs/button      # 200 — has a Dioxus implementation
+curl https://mzizi.dev/api/v1/rs/select      # 404 — TypeScript only, for now
+```
+
+A 404 there is a true answer, not an outage. Three primitives have Rust today
+(`button`, `badge`, `card`); the rest are issue #222.
+
+### Swift, Kotlin, ArkTS, React Native
+
+**No CLI, by design** — these are instruction-first. You get:
+
+- the component's contract from `/api/v1/ui/{name}/docs` (use cases, variants,
+  sizes, features, a11y notes),
+- the tokens from `components/registry/n1-tokens/nyuchi-tokens-<platform>.<ext>`,
+  which are **generated** for every target from one source,
+- the rules below.
+
+You write the component. That is the deal, and it is why the token file is
+generated rather than hand-written: adding a target means adding an emitter, never
+re-authoring values.
+
+---
+
+## 3. What does not vary, whatever target you are on
+
+These are the invariants. A target that cannot honour them is not a supported
+target:
+
+1. **N1 is the only layer allowed to define a design value.** Everything else
+   consumes — `var()` on the web, the generated token file on Swift / Kotlin /
+   ArkTS / Rust. If you find yourself typing a hex, stop.
+2. **Buttons are pill-shaped** (`rounded-full`). An executive brand decision, not
+   a radius-scale value.
+3. **The APCA contrast floor**, and the control scale. A dense control that is a
+   _touch_ target has to earn its hit area through surrounding spacing or padding
+   beyond the visual box.
+4. **The main image on a detail page is square** (`--aspect-media`), and components
+   reference it with an inline fallback — `aspect-[var(--aspect-media,1/1)]` —
+   never a bare `aspect-media` utility. Nothing distributes that utility, so a bare
+   one silently collapses the card to its content height in _your_ app.
+5. **A component that renders HTML sanitises it.** You are not the boundary; the
+   component is, because it is the last place anyone can enforce anything. Four
+   shipped without it — see §8.4.2.
+
+---
+
+## 4. When the primitive you want has no source
+
+In order of preference:
+
+1. **Check `/api/v1/rs/{name}`** (Dioxus) or the target's descriptor. It may exist.
+2. **Read the contract** — `/api/v1/ui/{name}/docs` gives use cases, variants,
+   sizes, features and a11y notes; `/api/v1/ui/{name}` gives dependencies and the
+   file layout.
+3. **Write it against the contract, not against the `.tsx`.** A mechanical
+   translation carries every defect in the original across while the compiler waves
+   it through, because a faithful port of a broken component still compiles.
+4. **Say so on issue #222** with which primitive and what you are building. Demand
+   is how the long tail (#226) gets prioritised — 284 primitives have no dependents,
+   and the one you need should stop being one of them.
+
+---
+
+## 5. Do not fork the registry
+
+Install from it. Copy-pasting component source or standing up a parallel component
+library is the thing this registry exists to prevent: the copy cannot receive a
+security fix, and the four unsanitised HTML sinks found in §8.4.2 would still be
+live in every fork made before the fix.
+
+If a component is wrong for you, open an issue or a PR against it. Changes here
+propagate to every consumer; changes in your fork propagate nowhere.

--- a/docs/sample-data-to-live-data.md
+++ b/docs/sample-data-to-live-data.md
@@ -1,0 +1,114 @@
+# From sample data to live data
+
+Sample records stay authored in git. This is the missing half: how to point a
+component that renders a sample at the real MongoDB collection behind it.
+
+---
+
+## 1. Why this is short
+
+Because the mapping is already done. `lib/samples/types.ts` mirrors the production
+MongoDB validators **field for field**, so the document a component was built
+against and the document in your cluster are the same shape:
+
+| Sample type     | Production collection | Notes                                         |
+| --------------- | --------------------- | --------------------------------------------- |
+| `SamplePlace`   | `places.places`       | Read `places_public` if the surface is public |
+| `SampleEntity`  | `entity.entities`     | Sellers, orgs, family entities                |
+| `SamplePerson`  | `identity.persons`    | `_id` IS the OIDC `sub`                       |
+| `SampleEvent`   | `events.events`       |                                               |
+| `SampleProduct` | `commerce.products`   |                                               |
+| `SampleArticle` | `news.articles`       |                                               |
+
+That correspondence is the whole point of curating the samples rather than
+generating fixtures: getting a preview working and getting an integration working
+stop being two jobs.
+
+**For actual data the platform uses MongoDB, not Supabase.**
+
+---
+
+## 2. The swap, concretely
+
+In the playground a component gets its props from `lib/samples/resolve.ts`, which
+binds prop names and declared types to records in `lib/samples/data.ts`. In your
+app you skip the resolver entirely — it exists to _guess_ a binding, and you know
+yours.
+
+```ts
+// Preview (this repo, no database):
+import { sampleData } from "@/lib/samples/data"
+<NyuchiPlaceCard {...sampleData.places[0]} />
+
+// Your app (real driver, same shape):
+const place = await db.collection("places").findOne({ _id: id })
+<NyuchiPlaceCard {...place} />
+```
+
+There is no adapter in between, and that is the deliverable. If you find yourself
+writing one, the component and the validator have drifted — say so on an issue
+rather than papering over it locally.
+
+---
+
+## 3. Querying the samples as if they were live
+
+`pnpm samples:push` projects `lib/samples/data.ts` into a MongoDB database called
+`mzizi_samples`, in the production document shape. Point a real driver at it and
+develop against real queries before you have real data:
+
+```ts
+const client = new MongoClient(process.env.MONGODB_URI!)
+const places = client.db("mzizi_samples").collection("places")
+const nearby = await places.find({ "bundu.verificationTier": { $gte: 1 } }).toArray()
+```
+
+Two rules about that database:
+
+- **Git is the source. Mongo is the projection.** Editing a document in
+  `mzizi_samples` directly works right up until the next `samples:push`
+  overwrites it. Author in `lib/samples/data.ts`.
+- **The site does not read it.** 1,179 pages prerender from the file, so a Mongo
+  outage can never empty the playground. The push exists so that _you_ can use a
+  real driver, not so that mzizi.dev can.
+
+---
+
+## 4. What changes when the data is real
+
+The samples are chosen to break things; production data is not. Four differences
+that will show up the first time you swap:
+
+1. **Most records are sparse.** Measured, not assumed: `places.places` holds 15,359
+   documents, **38** have a description and **zero** have `media`. They are bare
+   OSM name-and-geometry imports. A card that looks good in preview will render as
+   a grey box with a name. The empty-state branches exist for this — make sure you
+   are actually rendering them.
+2. **Verification tier is mostly 0.** The sample set spans 0→3 deliberately; real
+   community-reported records sit at the bottom. Tier 0 → 1 is the agent
+   write-cliff, and a UI that only ever styled tier 3 will look wrong at scale.
+3. **Some fields must not leave the cluster.** `places_public` exists as a view
+   precisely because production records are real people and unverified community
+   reports. If your surface is public, read the view, not the collection.
+4. **Dates are live.** The sample set is deliberately frozen against `SAMPLE_NOW`
+   with no clock reads, because a fixture that changes between two renders breaks
+   static prerendering and makes a failing test unreproducible. Your data has none
+   of that protection — anything relative ("2 days ago") needs a stable reference
+   passed in, not a `Date.now()` inside the component.
+
+---
+
+## 5. Which way each thing is authored
+
+The test is _who edits it_:
+
+|                                               | Where                       | Why                                                                                                                      |
+| --------------------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **Sample records**                            | git (`lib/samples/data.ts`) | Someone writes them and someone reviews them. The reason a place has no cover image is a decision recorded in a comment. |
+| **Domain data**                               | MongoDB                     | 15,359 places, 23,231 articles. Nobody hand-edits those in a pull request.                                               |
+| **Component source**                          | git                         | §8.3                                                                                                                     |
+| **Component metadata**                        | `registry.json` in git      | §15.1                                                                                                                    |
+| **Version history, telemetry, the issue log** | Supabase                    | Machine-written, append-only                                                                                             |
+
+Sample data being authored is not a reversal of "domain data lives in MongoDB".
+They are different kinds of thing, and the split holds in both directions.

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -5,9 +5,15 @@
  * serves it over `/api/v1/*`, and `mzizi-mcp` is an HTTP client of that API — so the
  * database is not in the serving path for components or doctrine.
  *
- *   Components  →  content/registry/<collection>/<name>.json  (lib/registry.ts)
+ *   Components  →  registry.json, one authored item per component (lib/registry.ts)
  *                  + source on disk under components/registry/ (lib/registry-source.ts)
  *   Doctrine    →  content/doctrine/<collection>/<slug>.mdx    (lib/doctrine.ts)
+ *
+ * This block said `content/registry/<collection>/<name>.json`. That directory
+ * does not exist and never did — `content/` holds `doctrine/` only, and
+ * `lib/registry.ts` reads a single `registry.json` at the repo root. A path in a
+ * header is the first thing someone greps for, so a plausible-but-absent one
+ * costs more than no path at all.
  *
  * What is still Supabase, and why — it is written by a machine, not a person:
  *
@@ -68,7 +74,6 @@ import type {
   ChangelogListRow,
   ComponentVersionRow,
   McpToolRegistryRow,
-  DesignTokens,
   HelixClass,
   HelixModel,
   HelixNode,
@@ -902,38 +907,27 @@ export async function getComponentVersion(
   return data as unknown as ComponentVersionRow
 }
 
-// ── Design token queries (from nyuchi-tokens component) ─────────────
-
-/**
- * Get the design tokens payload from the nyuchi-tokens component's source_code.
- *
- * In the migrated schema, design tokens (minerals, semantic colors, typography,
- * spacing, radii) live as a JSON payload in `components.source_code` where
- * `name = 'nyuchi-tokens'` — not in the legacy brand_* tables.
- *
- * Returns null if the component row is missing or source_code doesn't parse.
- */
-export async function getDesignTokens(): Promise<DesignTokens | null> {
-  const { data, error } = await getPublicClient()
-    .from("components")
-    .select("source_code")
-    .eq("name", "nyuchi-tokens")
-    .single()
-
-  if (error) {
-    if (error.code === "PGRST116") return null
-    throw new Error(error.message)
-  }
-
-  const source = (data as unknown as { source_code: string | null } | null)?.source_code
-  if (!source) return null
-
-  try {
-    return JSON.parse(source) as DesignTokens
-  } catch {
-    return null
-  }
-}
+// ── Design token queries ────────────────────────────────────────────
+//
+// `getDesignTokens()` is DELETED, not repointed.
+//
+// It selected `source_code` from the `components` view where
+// `name = 'nyuchi-tokens'` and JSON.parse'd the result. That column has been
+// null on every row since component source moved to disk (§8.3), so the
+// function could only ever return null — and it had no callers anywhere in
+// `app/`, `lib/`, `components/` or `scripts/`.
+//
+// Repointing it at the file would have been the wrong fix twice over: nothing
+// wants it, and the token pipeline already runs the other way. `pnpm
+// tokens:sync` GENERATES `lib/tokens/palette.generated.ts` and the
+// `tokens:generated` block of `app/globals.css` from the Supabase
+// `styling-minerals` / `styling-heritage-colors` collections, with
+// `pnpm tokens:verify` as the drift gate (§8.4.1). A second reader that parsed
+// a component's source back into a token object would be a third copy of the
+// palette that nothing keeps in step.
+//
+// The `components` view no longer has a `source_code` column at all, so this
+// query would now raise 42703 rather than quietly returning null.
 
 // ── Layer summary query ─────────────────────────────────────────────
 

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -776,51 +776,73 @@ export async function getAllAiInstructions(): Promise<AiInstructionRow[]> {
 // ── Changelog queries ───────────────────────────────────────────────
 
 /**
- * Get all changelog entries, most recent first.
+ * Every release, newest first, classified.
+ *
+ * Reads the `releases` view rather than `changelog` directly. Ordering the raw
+ * table by `released_at DESC` — what this did — opened the changelog with
+ * 4.1.8, 4.1.1, 4.1.2, 4.1.0 in arbitrary order and put the current release,
+ * 1.0.0, at position ELEVEN, because ten rows have no `released_at` and
+ * Postgres sorts NULLS FIRST on DESC.
+ *
+ * The view adds what a reader needs to classify a release rather than just
+ * read its title: `line` (the public 1.x line vs the pre-1.0 internal 4.x one
+ * it superseded), `release_kind` (initial / major / minor / patch, compared
+ * within its own line), and `components_touched`. It is ordered in the view, so
+ * no `.order()` here — adding one would silently override the two-era sort.
  */
 export async function getChangelogEntries(): Promise<ChangelogRow[]> {
-  const { data, error } = await getPublicClient()
-    .from("changelog")
-    .select("*")
-    .order("released_at", { ascending: false })
+  const { data, error } = await getPublicClient().from("releases").select("*")
 
   if (error) throw new Error(error.message)
   return (data ?? []) as unknown as ChangelogRow[]
 }
 
 /**
- * Get a single changelog entry by version.
+ * Every changelog entry published under a version.
+ *
+ * Returns an ARRAY because a version number is not unique here: eight of them
+ * carry two or three entries with genuinely different titles and content
+ * (4.0.31 has three — Ubuntu pillars, a documentation sweep, and an audit
+ * remediation). They are separate changesets that shared a version number, not
+ * duplicates of one another, so picking one would silently drop real release
+ * notes.
+ *
+ * This used `.single()`, and PostgREST answers PGRST116 for BOTH "no rows" and
+ * "more than one row". The `if (error.code === "PGRST116") return null` branch
+ * therefore turned "this version has three entries" into "this version does not
+ * exist", and `/api/v1/changelog/4.0.31` answered 404 for a release that is in
+ * the table three times. Eight of sixty-four releases were unreachable that way.
  */
-export async function getChangelogByVersion(version: string): Promise<ChangelogRow | null> {
+export async function getChangelogByVersion(version: string): Promise<ChangelogRow[]> {
   const { data, error } = await getPublicClient()
     .from("changelog")
     .select("*")
     .eq("version", version)
-    .single()
+    .order("created_at", { ascending: true, nullsFirst: false })
 
-  if (error) {
-    if (error.code === "PGRST116") return null
-    throw new Error(error.message)
-  }
-  return data as unknown as ChangelogRow
+  if (error) throw new Error(error.message)
+  return (data ?? []) as unknown as ChangelogRow[]
 }
 
 /**
- * Get the latest released version string.
+ * The current release version.
+ *
+ * Reads the `releases` view, which orders across both version eras. Ordering
+ * `changelog` by `released_at DESC` — what this did — is wrong twice: ten rows
+ * have no `released_at`, and Postgres sorts NULLS FIRST on DESC, so this
+ * returned **4.1.8**. That is not the current version and not even the newest
+ * of the undated rows; it was whichever null landed first.
+ *
+ * Sorting by semver instead would return 4.2.0, also wrong: the version line
+ * was deliberately reset and 1.0.0 supersedes the whole 4.x line (§14). The
+ * view carries that as `line` / `line_rank` and is already sorted, so the first
+ * row is the answer.
  */
 export async function getLatestVersion(): Promise<string | null> {
-  const { data, error } = await getPublicClient()
-    .from("changelog")
-    .select("version")
-    .order("released_at", { ascending: false })
-    .limit(1)
-    .single()
+  const { data, error } = await getPublicClient().from("releases").select("version").limit(1)
 
-  if (error) {
-    if (error.code === "PGRST116") return null
-    throw new Error(error.message)
-  }
-  return (data as unknown as { version: string } | null)?.version ?? null
+  if (error) throw new Error(error.message)
+  return (data as unknown as Array<{ version: string }>)?.[0]?.version ?? null
 }
 
 /**
@@ -855,9 +877,15 @@ export async function upsertChangelog(entry: ChangelogInsert): Promise<Changelog
  */
 const VERSION_COLUMNS = [
   "component_name",
+  "entity_name",
+  "entity_kind",
   "version",
   "version_number",
   "change_type",
+  "change_kind",
+  "release",
+  "release_marker",
+  "release_breaking",
   "comment",
   "description",
   "status",

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -546,6 +546,25 @@ export interface ChangelogRow {
   title: string
   description: string | null
   /**
+   * Which version era this release belongs to.
+   *
+   * `public` is the 1.x line; `pre-1.0` is the internal 4.x iteration that
+   * 1.0.0 superseded (§14). Both exist in the same table, which is why no
+   * single sort key orders the changelog: by date, ten undated 4.1.x rows
+   * float above everything; by semver, 4.2.0 outranks the current 1.0.0.
+   * `line_rank` puts the public line first and the view is pre-sorted.
+   */
+  line?: "public" | "pre-1.0"
+  line_rank?: number
+  major?: number | null
+  minor?: number | null
+  patch?: number | null
+  /** initial / major / minor / patch, compared to the predecessor in the SAME line. */
+  release_kind?: "initial" | "major" | "minor" | "patch"
+  breaking?: boolean | null
+  /** Components added + modified + deprecated + removed by this release. */
+  components_touched?: number
+  /**
    * Ecosystem nodes touched by this release. Rendered as pill badges
    * coloured by helix classification (strand class for a node, gold for
    * a rung) via the nyuchi-changelog-renderer. The node set is never
@@ -654,10 +673,42 @@ export interface McpToolRegistryRow {
  *    explicitly, so re-adding it takes two edits rather than none.
  */
 export interface ComponentVersionRow {
+  /**
+   * Never null. It used to be, on 1,034 of 4,889 rows, because the view read
+   * `document->>'componentName'` and 1,472 archived entities have no such key —
+   * the row's own `name` column held the identity all along.
+   */
   component_name: string
-  version: string
+  /** The archived row's own name, before the componentName fallback. */
+  entity_name: string
+  /**
+   * What is being versioned. The view is called `component_versions` but the
+   * archive covers far more: 60 MCP tools, 11 architecture nodes, documentation
+   * pages, changelog entries, design tokens (`Body Large`, `raised`,
+   * `duration-quick`) and framework descriptors (`react:badge`). Filter on
+   * `component` to get a component's history.
+   */
+  entity_kind:
+    "component" | "tool" | "architecture" | "release" | "doctrine" | "documentation" | "other"
+  version: string | null
   version_number: number | null
+  /** The raw archived value — 12 ad-hoc strings. Kept so the mapping stays auditable. */
   change_type: string | null
+  /** `change_type` normalised. `unclassified` means the raw value said WHEN, not WHAT. */
+  change_kind: "added" | "changed" | "fixed" | "moved" | "metadata" | "docs" | "unclassified"
+  /**
+   * The release this change belongs to.
+   *
+   * Taken from the marker embedded in `change_type` when it encodes one — the
+   * largest change_type value, `4.1.1-alignment` on 2,132 rows, is a release
+   * marker wearing a change type's clothes — otherwise the newest release
+   * published on or before the change's timestamp. Null for changes that
+   * predate the first dated release.
+   */
+  release: string | null
+  /** The release marker parsed out of `change_type`, when there was one. */
+  release_marker: string | null
+  release_breaking: boolean | null
   comment: string | null
   description: string | null
   status: string | null

--- a/lib/samples/props.generated.ts
+++ b/lib/samples/props.generated.ts
@@ -64,6 +64,13 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "agenda-view": [
+    {
+      "name": "events",
+      "type": "AgendaEvent[]",
+      "required": true
+    }
+  ],
   "ai-chat": [
     {
       "name": "messages",
@@ -83,6 +90,52 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "suggestedPrompts",
       "type": "string[]",
+      "required": false
+    }
+  ],
+  "ai-feedback": [
+    {
+      "name": "value",
+      "type": "FeedbackValue",
+      "required": false
+    },
+    {
+      "name": "onFeedback",
+      "type": "(value: FeedbackValue) => void",
+      "required": false
+    },
+    {
+      "name": "showTextInput",
+      "type": "boolean",
+      "required": false
+    },
+    {
+      "name": "onTextFeedback",
+      "type": "(text: string) => void",
+      "required": false
+    }
+  ],
+  "ai-response-card": [
+    {
+      "name": "content",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "sources",
+      "type": "AiSource[]",
+      "required": false
+    },
+    {
+      "name": "actions",
+      "type": "React.ReactNode",
+      "required": false
+    }
+  ],
+  "alert-dialog": [
+    {
+      "name": "size",
+      "type": "\"default\" | \"sm\"",
       "required": false
     }
   ],
@@ -243,6 +296,18 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "loading",
       "type": "boolean",
+      "required": false
+    }
+  ],
+  "api-key-display": [
+    {
+      "name": "apiKey",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "label",
+      "type": "string",
       "required": false
     }
   ],
@@ -448,6 +513,23 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "audio-player": [
+    {
+      "name": "src",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "title",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "artist",
+      "type": "string",
+      "required": false
+    }
+  ],
   "audio-waveform": [
     {
       "name": "data",
@@ -482,6 +564,38 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "onSeek",
       "type": "(position: number) => void",
+      "required": false
+    }
+  ],
+  "audit-log-entry": [
+    {
+      "name": "actor",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "action",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "target",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "timestamp",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "ip",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "severity",
+      "type": "\"info\" | \"warning\" | \"error\" | \"critical\"",
       "required": false
     }
   ],
@@ -556,6 +670,18 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "suggestions",
       "type": "string[]",
+      "required": false
+    },
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "avatar": [
+    {
+      "name": "size",
+      "type": "\"default\" | \"sm\" | \"lg\"",
       "required": false
     },
     {
@@ -738,6 +864,30 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "calendar": [
+    {
+      "name": "buttonVariant",
+      "type": "React.ComponentProps<typeof Button>[\"variant\"]",
+      "required": false
+    }
+  ],
+  "calendar-day-view": [
+    {
+      "name": "events",
+      "type": "DayEvent[]",
+      "required": true
+    },
+    {
+      "name": "date",
+      "type": "Date",
+      "required": true
+    },
+    {
+      "name": "onEventClick",
+      "type": "(event: DayEvent) => void",
+      "required": false
+    }
+  ],
   "calendar-month-view": [
     {
       "name": "year",
@@ -767,6 +917,23 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "todayHighlight",
       "type": "boolean",
+      "required": false
+    }
+  ],
+  "calendar-week-view": [
+    {
+      "name": "events",
+      "type": "WeekEvent[]",
+      "required": true
+    },
+    {
+      "name": "weekStart",
+      "type": "Date",
+      "required": true
+    },
+    {
+      "name": "onEventClick",
+      "type": "(event: WeekEvent) => void",
       "required": false
     }
   ],
@@ -859,6 +1026,18 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "card": [
+    {
+      "name": "size",
+      "type": "\"default\" | \"sm\"",
+      "required": false
+    },
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
   "carousel": [
     {
       "name": "opts",
@@ -881,6 +1060,48 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "cart-item": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    },
+    {
+      "name": "title",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "image",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "price",
+      "type": "number",
+      "required": true
+    },
+    {
+      "name": "currency",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "quantity",
+      "type": "number",
+      "required": true
+    },
+    {
+      "name": "onQuantityChange",
+      "type": "(quantity: number) => void",
+      "required": true
+    },
+    {
+      "name": "onRemove",
+      "type": "() => void",
+      "required": true
+    }
+  ],
   "category-browser": [
     {
       "name": "categories",
@@ -891,6 +1112,23 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "name": "onSelect",
       "type": "(name: string) => void",
       "required": false
+    }
+  ],
+  "changelog-entry": [
+    {
+      "name": "version",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "date",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "changes",
+      "type": "ChangeGroup[]",
+      "required": true
     }
   ],
   "chapter-list": [
@@ -984,6 +1222,13 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": true
     }
   ],
+  "chart-area-axes": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
   "chart-area-default": [
     {
       "name": "data",
@@ -1028,6 +1273,69 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "ariaLabel",
       "type": "string",
+      "required": false
+    }
+  ],
+  "chart-area-gradient": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-area-icons": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-area-interactive": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-area-legend": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-area-linear": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-area-stacked": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-area-stacked-expand": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-area-step": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-bar-active": [
+    {
+      "name": "loading",
+      "type": "boolean",
       "required": false
     }
   ],
@@ -1078,6 +1386,13 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "chart-bar-horizontal": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
   "chart-bar-interactive": [
     {
       "name": "data",
@@ -1120,6 +1435,27 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "chart-bar-label": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-bar-label-custom": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-bar-mixed": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
   "chart-bar-multiple": [
     {
       "name": "data",
@@ -1154,6 +1490,20 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "ariaLabel",
       "type": "string",
+      "required": false
+    }
+  ],
+  "chart-bar-negative": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-bar-stacked": [
+    {
+      "name": "loading",
+      "type": "boolean",
       "required": false
     }
   ],
@@ -1204,6 +1554,55 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "chart-line-dots": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-line-dots-colors": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-line-dots-custom": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-line-interactive": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-line-label": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-line-label-custom": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-line-linear": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
   "chart-line-multiple": [
     {
       "name": "data",
@@ -1241,6 +1640,76 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "chart-line-step": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-pie-donut": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-pie-donut-active": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-pie-donut-text": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-pie-interactive": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-pie-label": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-pie-label-custom": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-pie-label-list": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-pie-legend": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-pie-separator-none": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
   "chart-pie-simple": [
     {
       "name": "data",
@@ -1265,6 +1734,216 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "ariaLabel",
       "type": "string",
+      "required": false
+    }
+  ],
+  "chart-pie-stacked": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radar-default": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radar-dots": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radar-grid-circle": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radar-grid-circle-fill": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radar-grid-circle-no-lines": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radar-grid-custom": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radar-grid-fill": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radar-grid-none": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radar-icons": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radar-label-custom": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radar-legend": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radar-lines-only": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radar-multiple": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radar-radius": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radial-grid": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radial-label": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radial-shape": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radial-simple": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radial-stacked": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-radial-text": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-tooltip-advanced": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-tooltip-default": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-tooltip-formatter": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-tooltip-icons": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-tooltip-indicator-line": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-tooltip-indicator-none": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-tooltip-label-custom": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-tooltip-label-formatter": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "chart-tooltip-label-none": [
+    {
+      "name": "loading",
+      "type": "boolean",
       "required": false
     }
   ],
@@ -1310,6 +1989,18 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "name": "showAttachment",
       "type": "boolean",
       "required": false
+    }
+  ],
+  "chat-layout": [
+    {
+      "name": "sidebar",
+      "type": "React.ReactNode",
+      "required": true
+    },
+    {
+      "name": "content",
+      "type": "React.ReactNode",
+      "required": true
     }
   ],
   "chat-list": [
@@ -1368,6 +2059,23 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "loading",
       "type": "boolean",
+      "required": false
+    }
+  ],
+  "checklist": [
+    {
+      "name": "items",
+      "type": "ChecklistItem[]",
+      "required": true
+    },
+    {
+      "name": "onChange",
+      "type": "(items: ChecklistItem[]) => void",
+      "required": true
+    },
+    {
+      "name": "onAdd",
+      "type": "(text: string) => void",
       "required": false
     }
   ],
@@ -1439,6 +2147,13 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "code-tabs": [
+    {
+      "name": "tabs",
+      "type": "CodeTab[]",
+      "required": true
+    }
+  ],
   "color-picker": [
     {
       "name": "value",
@@ -1448,6 +2163,35 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "onChange",
       "type": "(value: string) => void",
+      "required": false
+    }
+  ],
+  "combobox": [
+    {
+      "name": "showTrigger",
+      "type": "boolean",
+      "required": false
+    },
+    {
+      "name": "showClear",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "command": [
+    {
+      "name": "title",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "description",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "showCloseButton",
+      "type": "boolean",
       "required": false
     }
   ],
@@ -1475,6 +2219,28 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "onOpenChange",
       "type": "(open: boolean) => void",
+      "required": false
+    }
+  ],
+  "comment-thread": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    },
+    {
+      "name": "comment",
+      "type": "Comment",
+      "required": true
+    },
+    {
+      "name": "depth",
+      "type": "number",
+      "required": false
+    },
+    {
+      "name": "onReply",
+      "type": "(parentId: string) => void",
       "required": false
     }
   ],
@@ -1561,6 +2327,13 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "onDateClick",
       "type": "(date: string) => void",
+      "required": false
+    }
+  ],
+  "context-menu": [
+    {
+      "name": "side",
+      "type": "\"top\" | \"right\" | \"bottom\" | \"left\"",
       "required": false
     }
   ],
@@ -1837,6 +2610,28 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "date-range-picker": [
+    {
+      "name": "dateRange",
+      "type": "DateRange",
+      "required": false
+    },
+    {
+      "name": "onDateRangeChange",
+      "type": "(range: DateRange | undefined) => void",
+      "required": false
+    },
+    {
+      "name": "presets",
+      "type": "DateRangePreset[]",
+      "required": false
+    },
+    {
+      "name": "placeholder",
+      "type": "string",
+      "required": false
+    }
+  ],
   "dependency-graph": [
     {
       "name": "nodes",
@@ -1901,6 +2696,27 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "description-list": [
+    {
+      "name": "detail",
+      "type": "React.ReactNode",
+      "required": true
+    }
+  ],
+  "dialog": [
+    {
+      "name": "showCloseButton",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "direction": [
+    {
+      "name": "direction",
+      "type": "React.ComponentProps<typeof Direction.DirectionProvider>[\"dir\"]",
+      "required": false
+    }
+  ],
   "driver-profile-card": [
     {
       "name": "name",
@@ -1940,6 +2756,18 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "memberSince",
       "type": "string",
+      "required": false
+    }
+  ],
+  "dropdown-menu": [
+    {
+      "name": "inset",
+      "type": "boolean",
+      "required": false
+    },
+    {
+      "name": "variant",
+      "type": "\"default\" | \"destructive\"",
       "required": false
     }
   ],
@@ -1990,6 +2818,18 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "name": "deprecated",
       "type": "boolean",
       "required": false
+    }
+  ],
+  "env-editor": [
+    {
+      "name": "variables",
+      "type": "EnvVariable[]",
+      "required": true
+    },
+    {
+      "name": "onChange",
+      "type": "(variables: EnvVariable[]) => void",
+      "required": true
     }
   ],
   "error-boundary": [
@@ -2205,6 +3045,35 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "onRolloutChange",
       "type": "(pct: number) => void",
+      "required": false
+    }
+  ],
+  "field": [
+    {
+      "name": "variant",
+      "type": "\"legend\" | \"label\"",
+      "required": false
+    }
+  ],
+  "file-preview": [
+    {
+      "name": "name",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "size",
+      "type": "number",
+      "required": true
+    },
+    {
+      "name": "type",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "thumbnail",
+      "type": "string",
       "required": false
     }
   ],
@@ -2634,6 +3503,13 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "input-otp": [
+    {
+      "name": "containerClassName",
+      "type": "string",
+      "required": false
+    }
+  ],
   "invite-link": [
     {
       "name": "url",
@@ -2662,6 +3538,43 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     },
     {
       "name": "onRegenerate",
+      "type": "() => void",
+      "required": false
+    }
+  ],
+  "invoice-row": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    },
+    {
+      "name": "id",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "date",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "amount",
+      "type": "number",
+      "required": true
+    },
+    {
+      "name": "currency",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "status",
+      "type": "\"paid\" | \"pending\" | \"overdue\"",
+      "required": true
+    },
+    {
+      "name": "onDownload",
       "type": "() => void",
       "required": false
     }
@@ -2832,6 +3745,28 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "lightbox": [
+    {
+      "name": "images",
+      "type": "LightboxImage[]",
+      "required": true
+    },
+    {
+      "name": "initialIndex",
+      "type": "number",
+      "required": false
+    },
+    {
+      "name": "open",
+      "type": "boolean",
+      "required": true
+    },
+    {
+      "name": "onClose",
+      "type": "() => void",
+      "required": true
+    }
+  ],
   "location-picker": [
     {
       "name": "value",
@@ -2903,6 +3838,34 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "login-01": [
+    {
+      "name": "animation",
+      "type": "`nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`",
+      "required": true
+    }
+  ],
+  "login-02": [
+    {
+      "name": "animation",
+      "type": "`nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`",
+      "required": true
+    }
+  ],
+  "login-04": [
+    {
+      "name": "animation",
+      "type": "`nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`",
+      "required": true
+    }
+  ],
+  "login-05": [
+    {
+      "name": "animation",
+      "type": "`nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`",
+      "required": true
+    }
+  ],
   "logs-page": [
     {
       "name": "title",
@@ -2947,6 +3910,23 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "loading",
       "type": "boolean",
+      "required": false
+    }
+  ],
+  "maintenance-page": [
+    {
+      "name": "title",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "description",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "estimatedReturn",
+      "type": "string",
       "required": false
     }
   ],
@@ -3171,6 +4151,18 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "masonry-grid": [
+    {
+      "name": "columns",
+      "type": "number",
+      "required": false
+    },
+    {
+      "name": "gap",
+      "type": "string",
+      "required": false
+    }
+  ],
   "media-filter-strip": [
     {
       "name": "filters",
@@ -3338,6 +4330,74 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "mention-input": [
+    {
+      "name": "value",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "onChange",
+      "type": "(value: string) => void",
+      "required": true
+    },
+    {
+      "name": "users",
+      "type": "MentionUser[]",
+      "required": true
+    },
+    {
+      "name": "placeholder",
+      "type": "string",
+      "required": false
+    }
+  ],
+  "menubar": [
+    {
+      "name": "inset",
+      "type": "boolean",
+      "required": false
+    },
+    {
+      "name": "variant",
+      "type": "\"default\" | \"destructive\"",
+      "required": false
+    }
+  ],
+  "message-thread": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    },
+    {
+      "name": "messages",
+      "type": "ThreadMessage[]",
+      "required": true
+    },
+    {
+      "name": "onReply",
+      "type": "(parentId: string) => void",
+      "required": false
+    }
+  ],
+  "mfa-setup": [
+    {
+      "name": "qrCodeUrl",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "secret",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "onVerify",
+      "type": "(code: string) => void",
+      "required": true
+    }
+  ],
   "mobile-money-selector": [
     {
       "name": "providers",
@@ -3439,6 +4499,13 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "mzizi-abr-content": [
+    {
+      "name": "override",
+      "type": "ContentQuality",
+      "required": false
+    }
+  ],
   "mzizi-chain-gate": [
     {
       "name": "currentChain",
@@ -3495,6 +4562,13 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "fallback",
       "type": "React.ReactNode",
+      "required": false
+    }
+  ],
+  "mzizi-chaos": [
+    {
+      "name": "config",
+      "type": "Partial<ChaosConfig>",
       "required": false
     }
   ],
@@ -3883,6 +4957,13 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "mzizi-skeleton-set": [
+    {
+      "name": "variant",
+      "type": "\"row\" | \"compact\" | \"hero\"",
+      "required": false
+    }
+  ],
   "mzizi-sync-status": [
     {
       "name": "sync",
@@ -3970,6 +5051,13 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     },
     {
       "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
+  "navigation-menu": [
+    {
+      "name": "viewport",
       "type": "boolean",
       "required": false
     }
@@ -4065,6 +5153,33 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": true
     }
   ],
+  "note-card": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    },
+    {
+      "name": "title",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "content",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "timestamp",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "color",
+      "type": "\"cobalt\" | \"tanzanite\" | \"malachite\" | \"gold\" | \"terracotta\"",
+      "required": false
+    }
+  ],
   "note-editor": [
     {
       "name": "title",
@@ -4132,6 +5247,13 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "name": "onViewAll",
       "type": "() => void",
       "required": false
+    }
+  ],
+  "notification-center": [
+    {
+      "name": "items",
+      "type": "Notification[]",
+      "required": true
     }
   ],
   "notification-center-full": [
@@ -5451,6 +6573,33 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": true
     }
   ],
+  "nyuchi-event-card": [
+    {
+      "name": "title",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "time",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "location",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "category",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "mineral",
+      "type": "\"cobalt\" | \"tanzanite\" | \"malachite\" | \"gold\" | \"terracotta\"",
+      "required": false
+    }
+  ],
   "nyuchi-featured-card": [
     {
       "name": "title",
@@ -5564,6 +6713,28 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "onClick",
       "type": "() => void",
+      "required": false
+    }
+  ],
+  "nyuchi-fundi": [
+    {
+      "name": "executors",
+      "type": "RemediationExecutors",
+      "required": true
+    },
+    {
+      "name": "autoHeal",
+      "type": "boolean",
+      "required": false
+    },
+    {
+      "name": "onPlanCreated",
+      "type": "(plan: HealingPlan) => void",
+      "required": false
+    },
+    {
+      "name": "onHealComplete",
+      "type": "(result: HealingResult) => void",
       "required": false
     }
   ],
@@ -6899,6 +8070,38 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "nyuchi-product-card": [
+    {
+      "name": "title",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "image",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "price",
+      "type": "number",
+      "required": true
+    },
+    {
+      "name": "currency",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "originalPrice",
+      "type": "number",
+      "required": false
+    },
+    {
+      "name": "badge",
+      "type": "string",
+      "required": false
+    }
+  ],
   "nyuchi-product-results": [
     {
       "name": "heading",
@@ -7020,6 +8223,13 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "nyuchi-profile-page": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
   "nyuchi-profile-page-layout": [
     {
       "name": "coverUrl",
@@ -7084,6 +8294,13 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "onBack",
       "type": "() => void",
+      "required": false
+    }
+  ],
+  "nyuchi-profile-settings": [
+    {
+      "name": "loading",
+      "type": "boolean",
       "required": false
     }
   ],
@@ -8187,6 +9404,52 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "onboarding-flow": [
+    {
+      "name": "animation",
+      "type": "`nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`",
+      "required": true
+    }
+  ],
+  "onboarding-tour": [
+    {
+      "name": "steps",
+      "type": "TourStep[]",
+      "required": true
+    },
+    {
+      "name": "active",
+      "type": "number",
+      "required": true
+    },
+    {
+      "name": "onNext",
+      "type": "() => void",
+      "required": true
+    },
+    {
+      "name": "onSkip",
+      "type": "() => void",
+      "required": true
+    }
+  ],
+  "order-summary": [
+    {
+      "name": "items",
+      "type": "OrderSummaryItem[]",
+      "required": true
+    },
+    {
+      "name": "total",
+      "type": "number",
+      "required": true
+    },
+    {
+      "name": "currency",
+      "type": "string",
+      "required": false
+    }
+  ],
   "org-profile-page": [
     {
       "name": "org",
@@ -8224,6 +9487,33 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "page-header": [
+    {
+      "name": "title",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "description",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "breadcrumbs",
+      "type": "BreadcrumbItem[]",
+      "required": false
+    },
+    {
+      "name": "actions",
+      "type": "React.ReactNode",
+      "required": false
+    },
+    {
+      "name": "backHref",
+      "type": "string",
+      "required": false
+    }
+  ],
   "pagination": [
     {
       "name": "isActive",
@@ -8236,6 +9526,38 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "name": "password",
       "type": "string",
       "required": true
+    }
+  ],
+  "payment-method-card": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    },
+    {
+      "name": "brand",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "lastFour",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "expiry",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "isDefault",
+      "type": "boolean",
+      "required": false
+    },
+    {
+      "name": "onSetDefault",
+      "type": "() => void",
+      "required": false
     }
   ],
   "payment-page": [
@@ -8298,6 +9620,30 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     },
     {
       "name": "title",
+      "type": "string",
+      "required": false
+    }
+  ],
+  "permission-badge": [
+    {
+      "name": "role",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "phone-input": [
+    {
+      "name": "value",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "onChange",
+      "type": "(value: string) => void",
+      "required": false
+    },
+    {
+      "name": "defaultCountry",
       "type": "string",
       "required": false
     }
@@ -8389,6 +9735,28 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     },
     {
       "name": "creatorName",
+      "type": "string",
+      "required": false
+    }
+  ],
+  "price-display": [
+    {
+      "name": "amount",
+      "type": "number",
+      "required": true
+    },
+    {
+      "name": "currency",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "originalAmount",
+      "type": "number",
+      "required": false
+    },
+    {
+      "name": "discount",
       "type": "string",
       "required": false
     }
@@ -8501,6 +9869,18 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": true
     }
   ],
+  "pull-to-refresh": [
+    {
+      "name": "onRefresh",
+      "type": "() => void",
+      "required": true
+    },
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    }
+  ],
   "quick-action-grid": [
     {
       "name": "actions",
@@ -8537,6 +9917,23 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "showValue",
       "type": "boolean",
+      "required": false
+    }
+  ],
+  "reaction-picker": [
+    {
+      "name": "reactions",
+      "type": "Reaction[]",
+      "required": true
+    },
+    {
+      "name": "onReact",
+      "type": "(emoji: string) => void",
+      "required": false
+    },
+    {
+      "name": "emojis",
+      "type": "string[]",
       "required": false
     }
   ],
@@ -8772,6 +10169,13 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "resizable": [
+    {
+      "name": "withHandle",
+      "type": "boolean",
+      "required": false
+    }
+  ],
   "revenue-dashboard-widget": [
     {
       "name": "totalEarnings",
@@ -8863,6 +10267,23 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "role-selector": [
+    {
+      "name": "roles",
+      "type": "Role[]",
+      "required": true
+    },
+    {
+      "name": "value",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "onChange",
+      "type": "(roleId: string) => void",
+      "required": true
+    }
+  ],
   "route-card": [
     {
       "name": "routeName",
@@ -8908,6 +10329,13 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "name": "frequency",
       "type": "string",
       "required": false
+    }
+  ],
+  "schema-viewer": [
+    {
+      "name": "type",
+      "type": "string",
+      "required": true
     }
   ],
   "search-bar": [
@@ -9013,6 +10441,13 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": true
     }
   ],
+  "select": [
+    {
+      "name": "size",
+      "type": "\"sm\" | \"default\"",
+      "required": false
+    }
+  ],
   "send-money-flow": [
     {
       "name": "step",
@@ -9107,6 +10542,25 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "session-list": [
+    {
+      "name": "sessions",
+      "type": "Session[]",
+      "required": true
+    },
+    {
+      "name": "onRevoke",
+      "type": "(sessionId: string) => void",
+      "required": true
+    }
+  ],
+  "settings-layout": [
+    {
+      "name": "sidebar",
+      "type": "React.ReactNode",
+      "required": true
+    }
+  ],
   "severity-badge": [
     {
       "name": "severity",
@@ -9143,6 +10597,18 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "description",
       "type": "string",
+      "required": false
+    }
+  ],
+  "sheet": [
+    {
+      "name": "side",
+      "type": "\"top\" | \"right\" | \"bottom\" | \"left\"",
+      "required": false
+    },
+    {
+      "name": "showCloseButton",
+      "type": "boolean",
       "required": false
     }
   ],
@@ -9183,6 +10649,34 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": true
     }
   ],
+  "signup-01": [
+    {
+      "name": "animation",
+      "type": "`nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`",
+      "required": true
+    }
+  ],
+  "signup-02": [
+    {
+      "name": "animation",
+      "type": "`nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`",
+      "required": true
+    }
+  ],
+  "signup-03": [
+    {
+      "name": "animation",
+      "type": "`nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`",
+      "required": true
+    }
+  ],
+  "signup-04": [
+    {
+      "name": "animation",
+      "type": "`nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`",
+      "required": true
+    }
+  ],
   "social-feed-page": [
     {
       "name": "stories",
@@ -9202,6 +10696,28 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "loading",
       "type": "boolean",
+      "required": false
+    }
+  ],
+  "source-citation": [
+    {
+      "name": "title",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "url",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "snippet",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "relevance",
+      "type": "number",
       "required": false
     }
   ],
@@ -9367,6 +10883,30 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": true
     }
   ],
+  "stepper": [
+    {
+      "name": "steps",
+      "type": "StepItem[]",
+      "required": true
+    },
+    {
+      "name": "activeStep",
+      "type": "number",
+      "required": true
+    },
+    {
+      "name": "onStepClick",
+      "type": "(step: number) => void",
+      "required": false
+    }
+  ],
+  "sticky-bar": [
+    {
+      "name": "position",
+      "type": "\"top\" | \"bottom\"",
+      "required": false
+    }
+  ],
   "stop-card": [
     {
       "name": "name",
@@ -9421,6 +10961,60 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "streaming-text": [
+    {
+      "name": "text",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "speed",
+      "type": "number",
+      "required": false
+    },
+    {
+      "name": "onComplete",
+      "type": "() => void",
+      "required": false
+    }
+  ],
+  "subscription-card": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "price",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "period",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "features",
+      "type": "string[]",
+      "required": true
+    },
+    {
+      "name": "highlighted",
+      "type": "boolean",
+      "required": false
+    },
+    {
+      "name": "onSelect",
+      "type": "() => void",
+      "required": false
+    }
+  ],
   "subscription-gate": [
     {
       "name": "title",
@@ -9468,6 +11062,25 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "suggested-prompts": [
+    {
+      "name": "prompts",
+      "type": "string[]",
+      "required": true
+    },
+    {
+      "name": "onSelect",
+      "type": "(prompt: string) => void",
+      "required": false
+    }
+  ],
+  "switch": [
+    {
+      "name": "size",
+      "type": "\"sm\" | \"default\"",
+      "required": false
+    }
+  ],
   "symptom-checker": [
     {
       "name": "symptoms",
@@ -9482,6 +11095,28 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "onSubmit",
       "type": "(symptoms: SymptomEntry[]) => void",
+      "required": false
+    }
+  ],
+  "tag-input": [
+    {
+      "name": "tags",
+      "type": "string[]",
+      "required": true
+    },
+    {
+      "name": "onTagsChange",
+      "type": "(tags: string[]) => void",
+      "required": true
+    },
+    {
+      "name": "placeholder",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "maxTags",
+      "type": "number",
       "required": false
     }
   ],
@@ -9707,6 +11342,23 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "required": false
     }
   ],
+  "time-slot-picker": [
+    {
+      "name": "slots",
+      "type": "TimeSlot[]",
+      "required": true
+    },
+    {
+      "name": "selected",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "onSelect",
+      "type": "(time: string) => void",
+      "required": true
+    }
+  ],
   "time-tracker": [
     {
       "name": "initialSeconds",
@@ -9726,6 +11378,50 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "compact",
       "type": "boolean",
+      "required": false
+    }
+  ],
+  "todo-item": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    },
+    {
+      "name": "title",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "completed",
+      "type": "boolean",
+      "required": false
+    },
+    {
+      "name": "priority",
+      "type": "\"low\" | \"medium\" | \"high\"",
+      "required": false
+    },
+    {
+      "name": "dueDate",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "onToggle",
+      "type": "() => void",
+      "required": false
+    }
+  ],
+  "toggle-group": [
+    {
+      "name": "spacing",
+      "type": "number",
+      "required": false
+    },
+    {
+      "name": "orientation",
+      "type": "\"horizontal\" | \"vertical\"",
       "required": false
     }
   ],
@@ -9786,6 +11482,13 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
       "name": "onClick",
       "type": "() => void",
       "required": false
+    }
+  ],
+  "toolbar": [
+    {
+      "name": "ariaLabel",
+      "type": "string",
+      "required": true
     }
   ],
   "transaction-history-page": [
@@ -9905,6 +11608,13 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "defaultExpandedIds",
       "type": "Set<string>",
+      "required": false
+    }
+  ],
+  "typing-indicator": [
+    {
+      "name": "name",
+      "type": "string",
       "required": false
     }
   ],
@@ -10088,6 +11798,23 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "onRequestMore",
       "type": "() => void",
+      "required": false
+    }
+  ],
+  "video-player": [
+    {
+      "name": "src",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "poster",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "title",
+      "type": "string",
       "required": false
     }
   ],
@@ -10282,6 +12009,33 @@ export const COMPONENT_PROPS: Record<string, PropInfo[]> = {
     {
       "name": "loading",
       "type": "boolean",
+      "required": false
+    }
+  ],
+  "webhook-card": [
+    {
+      "name": "loading",
+      "type": "boolean",
+      "required": false
+    },
+    {
+      "name": "url",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "events",
+      "type": "string[]",
+      "required": true
+    },
+    {
+      "name": "status",
+      "type": "\"active\" | \"inactive\"",
+      "required": true
+    },
+    {
+      "name": "lastTriggered",
+      "type": "string",
       "required": false
     }
   ]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -741,7 +741,13 @@ paths:
   /changelog:
     get:
       summary: List releases
-      description: Returns all rows from `changelog`, newest first.
+      description: >-
+        Every release, newest first, classified. Reads the `releases` view rather
+        than the `changelog` table: ordering that table by `released_at` put ten
+        undated 4.1.x rows above the current 1.0.0, because Postgres sorts NULLS
+        FIRST on DESC. Ordering by semver instead would put 4.2.0 above 1.0.0,
+        which is equally wrong — the version line was deliberately reset. `line`
+        carries the era and the response is pre-sorted by it.
       operationId: listChangelog
       tags: [Content]
       responses:
@@ -752,30 +758,54 @@ paths:
               schema:
                 type: object
                 properties:
-                  releases:
+                  data:
                     type: array
                     items:
                       $ref: "#/components/schemas/ChangelogEntry"
+                  meta:
+                    type: object
+                    properties:
+                      total: { type: integer }
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
 
   /changelog/{version}:
     get:
-      summary: Get a release by version
+      summary: Get every entry published under a version
+      description: >-
+        `data` is an ARRAY: a version number is not unique. Eight of them carry
+        two or three entries with different titles and content (4.0.31 has
+        three). This route used a single-row query, and PostgREST answers the
+        same error code for "more than one row" as for "no rows", so those
+        eight versions answered 404 for a release that exists. The first entry
+        is also spread at the top level so consumers written against the older
+        single-object shape keep working.
       operationId: getRelease
       tags: [Content]
       parameters:
         - name: version
           in: path
           required: true
-          schema: { type: string, example: "4.0.40" }
+          schema: { type: string, example: "4.0.31" }
       responses:
         "200":
-          description: Release
+          description: Every entry published under this version
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ChangelogEntry"
+                allOf:
+                  - $ref: "#/components/schemas/ChangelogEntry"
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/ChangelogEntry"
+                      meta:
+                        type: object
+                        properties:
+                          version: { type: string }
+                          entries: { type: integer }
         "404":
           $ref: "#/components/responses/NotFound"
         "503":
@@ -1997,6 +2027,30 @@ components:
         version: { type: string, example: "4.0.40" }
         title: { type: string }
         description: { type: string }
+        line:
+          type: string
+          enum: [public, "pre-1.0"]
+          description: >-
+            Which version era this release belongs to. `public` is the 1.x line;
+            `pre-1.0` is the internal 4.x iteration that 1.0.0 superseded. Both
+            live in one table, which is why no single sort key orders the
+            changelog correctly.
+        line_rank:
+          type: integer
+          description: "Sort weight for `line` — public outranks pre-1.0."
+        major: { type: integer, nullable: true }
+        minor: { type: integer, nullable: true }
+        patch: { type: integer, nullable: true }
+        release_kind:
+          type: string
+          enum: [initial, major, minor, patch]
+          description: >-
+            Compared to the predecessor within the SAME line — a patch bump in
+            4.1.x is not a major bump merely because 1.0.0 exists.
+        breaking: { type: boolean, nullable: true }
+        components_touched:
+          type: integer
+          description: "components_added + modified + deprecated + removed."
         nodes_affected:
           type: array
           description: >-

--- a/package.json
+++ b/package.json
@@ -139,7 +139,8 @@
     "typescript": "6.0.3",
     "typescript-eslint": "^8.65.0",
     "vite": "^7.3.6",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.10",
+    "yaml": "^2.9.0"
   },
   "lint-staged": {
     "*.{ts,tsx,js,mjs}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,7 +338,7 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@26.1.2)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.1)(yaml@2.9.0))
       yaml:
-        specifier: ^2.9.0
+        specifier: ^2.8.3
         version: 2.9.0
 
 packages:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,6 +337,9 @@ importers:
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@26.1.2)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.13.4(@types/node@26.1.2)(typescript@6.0.3))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.1)(yaml@2.9.0))
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
 packages:
 
@@ -11102,8 +11105,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@2.9.0:
-    optional: true
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1:
     optional: true

--- a/scripts/extract-props.ts
+++ b/scripts/extract-props.ts
@@ -64,22 +64,65 @@ function stripComments(src: string): string {
  * nested closing brace, so `{ a: { b: string }, c: number }` loses `c`. Counting braces is
  * the only way to read a nested type correctly.
  */
+/** Read the balanced `{ … }` starting at (or just before) `openBraceAt`. */
+function balancedBody(src: string, openBraceAt: number): string | null {
+  let depth = 0
+  for (let i = openBraceAt; i < src.length; i++) {
+    if (src[i] === "{") depth++
+    else if (src[i] === "}") {
+      depth--
+      if (depth === 0) return src.slice(openBraceAt + 1, i)
+    }
+  }
+  return null
+}
+
 function propsBody(src: string): string | null {
+  // FORM 1 — a named declaration: `interface FooProps extends X { … }`.
+  //
   // `extends VariantProps<typeof listingCardVariants>` sits between the name and the brace,
   // and a pattern that does not allow for it silently matches nothing — `nyuchi-listing-card`
   // and every other CVA-composed brand component extracted zero props, which reads
   // identically to "this component takes no props".
   const decl = /(?:type|interface)\s+\w*Props\w*\s*(?:extends\s+[^{]+?)?(?:=\s*)?\{/.exec(src)
-  if (!decl) return null
-  let depth = 0
-  const start = decl.index + decl[0].length
-  for (let i = start - 1; i < src.length; i++) {
-    if (src[i] === "{") depth++
-    else if (src[i] === "}") {
-      depth--
-      if (depth === 0) return src.slice(start, i)
-    }
-  }
+  if (decl) return balancedBody(src, decl.index + decl[0].length - 1)
+
+  // FORM 2 — declared INLINE on the component's own parameter, which is what most of this
+  // registry actually does:
+  //
+  //   function AudioPlayer({ src, title, … }: React.ComponentProps<"div"> & {
+  //     src: string
+  //     title?: string
+  //   }) {
+  //
+  // Only form 1 was handled, so 256 of 572 components extracted zero props — and a component
+  // with no props resolves to no sample data, which is a preview rendering its "needs props"
+  // fallback rather than the component doing its job. `alert`, `audio-player` and
+  // `ai-response-card` all look propless from the outside for this reason alone.
+  //
+  // The search is for a destructured parameter annotated with an intersection that ENDS in an
+  // object literal. `React.ComponentProps<"div">` on its own contributes nothing this can
+  // resolve (it is every DOM attribute), so a signature with no literal half is correctly
+  // skipped rather than guessed at.
+  const inline = /\)?\s*}\s*:\s*[^{}()]*?&\s*\{/.exec(src)
+  if (inline) return balancedBody(src, inline.index + inline[0].length - 1)
+
+  // FORM 3 — a bare inline object literal with no intersection at all:
+  //
+  //   function CartItem({ name, price, … }: {
+  //     name: string
+  //     price: number
+  //   }) {
+  //
+  // This is the most common shape in the registry after form 2, and it is the one a
+  // pattern written for `X & { … }` cannot see, because there is no `&`. `cart-item`,
+  // `agenda-view` and `changelog-entry` all declare every prop they have this way.
+  //
+  // Anchored on `}` + `:` + `{` so it matches a destructured PARAMETER annotation and not,
+  // say, an object literal inside a function body.
+  const bare = /}\s*:\s*\{/.exec(src)
+  if (bare) return balancedBody(src, bare.index + bare[0].length - 1)
+
   return null
 }
 


### PR DESCRIPTION
Four things, each of which was invisible because it failed by returning *less* rather than by erroring.

## 1. The last component source in Supabase — five shapes, not three

The previous pass closed the two reachable copies. A **text sweep** of the whole table, rather than a structural check of the keys someone expected, found three more. That difference is the lesson: `"does this entry have a sourceCode key"` answered **no** while `document::text LIKE '%sourceCode%'` answered **yes** on 556 rows.

| Shape | Entries |
| --- | ---: |
| `versions[].sourceCode` | 2,728 |
| `versions[].snapshot.source_code` | 576 |
| `versions[].snapshot.versions[].sourceCode` | 556 |

The third sat one level below where anyone was looking: the archive snapshotted whole documents, and those documents already carried their own versions array with source inside it.

Version **history** is untouched — all 4,889 entries keep `changeType`, `comment`, `changedBy`, `versionNumber`, `createdAt`, `version`, `description`, `status`, `category`, `tags`, `ecosystemNode` and every snapshot field except the blob. `component_documents` went **28 MB → 14 MB**, and a text sweep across all 3,195 documents at any depth now returns zero.

Also dropped: the two orphaned snapshot tables (`components_store` 571 rows, `component_versions_store` 2,099 — every row stamped `2026-07-24 13:06:20`, one shot, referenced by nothing in either repo), and the `source_code` column on the `components` view.

**Two consumers surfaced when that column went**, which is the useful part:

- `getDesignTokens()` parsed `components.source_code` into a token object. **Deleted, not repointed** — no callers, and `pnpm tokens:sync` already generates the palette artifacts, so a second reader would be a third copy nothing keeps in step.
- `/api/v1/stats` built its `layers` breakdown from `select("name, layer, source_code")` and returned `{}` on any error. So the query broke and **the response did not change**. `"layers": {}` read as an empty registry rather than a failed query. It now reads the registry on disk: `N1=17 N2=371 N3=67 N4=14 N5=14 N6=52 N7=16 N8=13 N9=3 N10=4 N11=1`.

## 2. The changelog had release information and no way to group by it

**Classification.** `component_versions` gains `entity_kind`, `change_kind`, `release`:

- `component_name` was **null on 1,034 of 4,889 rows** — the view read `document->>'componentName'` and 1,472 archived entities have no such key, while the row's own `name` column held the identity all along. Now zero.
- The view is called `component_versions` and archives far more than components: 60 MCP tools, 11 architecture nodes, documentation pages, changelog entries, design tokens (`Body Large`, `raised`, `duration-quick`) and framework descriptors (`react:badge`).
- The largest `change_type` value — **`4.1.1-alignment`, 2,132 rows** — is a release marker wearing a change type's clothes. The release existed; it was just encoded where nothing could group by it.

**Ordering.** `/api/v1/changelog` opened with 4.1.8, 4.1.1, 4.1.2, 4.1.0 in arbitrary order, with the current release **1.0.0 at position eleven**, because ten of 64 rows have no `released_at` and Postgres sorts NULLS FIRST on DESC. `getLatestVersion()` returned **4.1.8**.

Sorting by semver fixes neither — it puts 4.2.0 above 1.0.0, and the version line was deliberately reset (§14). One key cannot express two eras, so the new `releases` view carries `line` (`public` vs `pre-1.0`) and sorts on it.

**Eight releases answered 404 while existing.** `getChangelogByVersion` used `.single()`, and PostgREST returns PGRST116 for *"more than one row"* as well as *"no rows"*. Eight versions carry two or three entries with genuinely different titles — 4.0.31 has three. They are separate changesets that shared a version number, so all of them are returned now.

## 3. 256 components rendered an empty preview

`scripts/extract-props.ts` only understood `interface FooProps { … }`. Most of this registry declares props **inline on the parameter**, in two shapes the pattern could not see:

```ts
}: React.ComponentProps<"div"> & { src: string }   // audio-player, ai-response-card
}: { name: string; price: number }                 // cart-item, agenda-view, changelog-entry
```

Coverage **316 → 468** components; resolution went from nothing to 118 fully and 309 partially resolved. Components with genuinely nothing resolvable (`alert`, `accordion`, `aspect-ratio` — pure `React.ComponentProps<typeof X>` passthroughs) are still skipped rather than guessed at.

## 4. Docs and the primitives plan

- `docs/pulling-in-primitives.md` — where the primitives are and how to install them per target. The load-bearing part is `readiness` (does source exist) vs `tier` (is this the direction), which point opposite ways today: svelte is production+optional, dioxus is metadata_only+primary.
- `docs/sample-data-to-live-data.md` — the swap is three lines because the sample types already mirror the production validators. What needed writing down is what *changes*: `places.places` holds 15,359 documents of which **38** have a description and **zero** have media.
- Issues #222 / #223 / #224 / #225 / #226 — the Rust primitives build-out, ordered by dependency weight rather than alphabetically. Six primitives carry 212 of the registry's incoming edges; 284 have none at all.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm test` (162 passing, 19 files), `pnpm audit`, `pnpm registry:verify`, `pnpm registry:validate`, `pnpm props:verify`. Every `/api/v1` route probed locally: all 200, all populated. `/changelog/button` renders 7 version entries with dates where production served page chrome and no body.

New guards: `__tests__/db/no-source-in-database.test.ts` (both mechanisms that produced every leak — a select naming a source column, and `select("*")` on a component-bearing relation), `__tests__/api/v1/changelog-classification.test.ts`, and three preview-coverage floors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_