### PR TITLE
fix(tokens): implement the --status-* names N1 declares, and convert 36 bare hexes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -146,6 +146,15 @@
   --color-neutral: var(--neutral);
   --color-offline: var(--offline);
   --color-syncing: var(--syncing);
+  /* §7.4 rule 2: a new colour token is registered in @theme as well as declared
+   * in both blocks, or no utility class generates for it. The `--status-*` set
+   * skipped all three steps for long enough that 243 components referenced a
+   * property nothing defined. */
+  --color-status-success: var(--status-success);
+  --color-status-warning: var(--status-warning);
+  --color-status-error: var(--status-error);
+  --color-status-info: var(--status-info);
+  --color-status-neutral: var(--status-neutral);
   /* Experimental Seven — computed palette (bundu newsroom, 2026-07-05):
      heptagon hues offset 17°, prime saturations, foregrounds solved to P7. */
   --color-ember: var(--exp-ember);
@@ -253,6 +262,32 @@
   --neutral: #55514b;
   --offline: #674c32;
   --syncing: #1c5962;
+
+  /*
+   * The `--status-*` aliases. These are NOT a second palette — they are the
+   * names N1 declares.
+   *
+   * `nyuchi-tokens.ts`'s `statusTokens` gives each status a `css` field naming
+   * `--status-success` / `--status-warning` / `--status-error` / `--status-info`
+   * / `--status-neutral`, and 243 registry components reference those names.
+   * This file implemented `--success` / `--warning` / `--destructive` instead
+   * and never defined the `--status-*` set, so every one of those 243
+   * references fell through to the hex fallback baked into the component. They
+   * read as tokenised and rendered as hardcoded — the worst of both, because
+   * nothing looked broken and the theme did nothing.
+   *
+   * Aliased rather than given their own values so there is still ONE decision
+   * per status. N1's own hexes (#22C55E etc.) stay where they are: they are the
+   * per-component `var(--token, #hex)` fallback for a consumer app that has not
+   * defined the properties (§7.6), not a value this file should restate.
+   *
+   * `error` maps to `--destructive`, which is the existing name for that role.
+   */
+  --status-success: var(--success);
+  --status-warning: var(--warning);
+  --status-error: var(--destructive);
+  --status-info: var(--info);
+  --status-neutral: var(--neutral);
   /* Experimental Seven — computed, light-base values (≥7:1) */
   --exp-ember: #843d20;
   --exp-acacia: #4d5615;
@@ -380,6 +415,15 @@
   --neutral: #a09c93;
   --offline: #ba9570;
   --syncing: #36abba;
+
+  /* The `--status-*` aliases — see the note in `:root`. Redeclared here so the
+   * alias resolves against the DARK values; a `var()` alias declared only in
+   * `:root` would keep resolving to the light value inside `.dark`. */
+  --status-success: var(--success);
+  --status-warning: var(--warning);
+  --status-error: var(--destructive);
+  --status-info: var(--info);
+  --status-neutral: var(--neutral);
   /* Experimental Seven — computed, dark-base values (≥7:1) */
   --exp-ember: #da8766;
   --exp-acacia: #93a528;

--- a/components/registry/n2-primitives/severity-badge.tsx
+++ b/components/registry/n2-primitives/severity-badge.tsx
@@ -13,14 +13,14 @@ type Severity = "low" | "moderate" | "high" | "severe" | "extreme" | "cold"
 
 const severityColors: Record<Severity, { bg: string; text: string; dot: string }> = {
   low: {
-    bg: "bg-[var(--severity-low, #22C55E)]/10",
-    text: "text-[var(--severity-low, #22C55E)]",
-    dot: "bg-[var(--severity-low, #22C55E)]",
+    bg: "bg-[var(--severity-low,#22C55E)]/10",
+    text: "text-[var(--severity-low,#22C55E)]",
+    dot: "bg-[var(--severity-low,#22C55E)]",
   },
   moderate: {
-    bg: "bg-[var(--severity-moderate, #F59E0B)]/10",
-    text: "text-[var(--severity-moderate, #F59E0B)]",
-    dot: "bg-[var(--severity-moderate, #F59E0B)]",
+    bg: "bg-[var(--severity-moderate,#F59E0B)]/10",
+    text: "text-[var(--severity-moderate,#F59E0B)]",
+    dot: "bg-[var(--severity-moderate,#F59E0B)]",
   },
   high: {
     bg: "bg-[var(--severity-high,#FF7043)]/10",

--- a/components/registry/n3-brand/nyuchi-badge-display.tsx
+++ b/components/registry/n3-brand/nyuchi-badge-display.tsx
@@ -21,7 +21,7 @@ interface BadgeItem {
 }
 
 const rarityColors = {
-  common: "#6B6B66",
+  common: "var(--status-neutral, #6B6B66)",
   uncommon: "var(--color-cobalt,#00B0FF)",
   rare: "var(--color-tanzanite,#B388FF)",
   legendary: "var(--color-gold,#FFD740)",

--- a/components/registry/n3-brand/nyuchi-commute-card.tsx
+++ b/components/registry/n3-brand/nyuchi-commute-card.tsx
@@ -118,7 +118,7 @@ export function NyuchiCommuteCard({
               e.stopPropagation()
               onStart()
             }}
-            className="h-10 rounded-full bg-[var(--color-gold,#FFD740)] px-4 text-[12px] font-medium text-[#0A0A0A] transition-opacity hover:opacity-80"
+            className="h-10 rounded-full bg-[var(--color-gold,#FFD740)] px-4 text-[12px] font-medium text-[var(--brand-accent-foreground,#0A0A0A)] transition-opacity hover:opacity-80"
           >
             Go →
           </button>

--- a/components/registry/n3-brand/nyuchi-conversation-row.tsx
+++ b/components/registry/n3-brand/nyuchi-conversation-row.tsx
@@ -90,7 +90,7 @@ function NyuchiConversationRow({
           )}
         </div>
         {isOnline && (
-          <div className="absolute right-0 bottom-0 size-3 rounded-full bg-[#4ADE80] ring-2 ring-card" />
+          <div className="absolute right-0 bottom-0 size-3 rounded-full bg-[var(--status-success,#4ADE80)] ring-2 ring-card" />
         )}
       </div>
       {/* Content */}

--- a/components/registry/n3-brand/nyuchi-health-dashboard.tsx
+++ b/components/registry/n3-brand/nyuchi-health-dashboard.tsx
@@ -118,7 +118,7 @@ export function NyuchiHealthDashboard({
                   className={cn(
                     "text-[10px] font-medium",
                     v.trend === "up"
-                      ? "text-[var(--status-success, #22C55E)]"
+                      ? "text-[var(--status-success,#22C55E)]"
                       : v.trend === "down"
                         ? "text-red-400"
                         : "text-muted-foreground"
@@ -136,7 +136,7 @@ export function NyuchiHealthDashboard({
           <p className="text-[11px] font-semibold text-muted-foreground">Upcoming</p>
           {appointments.slice(0, 2).map((a, i) => (
             <div key={i} className="flex items-center gap-3">
-              <div className="bg-[var(--status-success, #22C55E)]/10 flex size-8 items-center justify-center rounded-full text-sm">
+              <div className="flex size-8 items-center justify-center rounded-full bg-[var(--status-success,#22C55E)]/10 text-sm">
                 🏥
               </div>
               <div className="min-w-0 flex-1">
@@ -158,7 +158,7 @@ export function NyuchiHealthDashboard({
                 className={cn(
                   "flex size-5 items-center justify-center rounded-full border-2 text-[10px]",
                   m.taken
-                    ? "border-[var(--status-success, #22C55E)] bg-[var(--status-success, #22C55E)]/20 text-[var(--status-success, #22C55E)]"
+                    ? "border-[var(--status-success,#22C55E)] bg-[var(--status-success,#22C55E)]/20 text-[var(--status-success,#22C55E)]"
                     : "border-border text-transparent"
                 )}
               >
@@ -180,7 +180,7 @@ export function NyuchiHealthDashboard({
         <div className="border-t border-border p-3">
           <button
             onClick={onViewAll}
-            className="bg-[var(--status-success, #22C55E)] flex h-12 w-full items-center justify-center rounded-full text-[13px] font-medium text-[#0A0A0A] transition-opacity hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+            className="flex h-12 w-full items-center justify-center rounded-full bg-[var(--status-success,#22C55E)] text-[13px] font-medium text-[var(--brand-accent-foreground,#0A0A0A)] transition-opacity hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
           >
             View All Health Data
           </button>

--- a/components/registry/n3-brand/nyuchi-job-card.tsx
+++ b/components/registry/n3-brand/nyuchi-job-card.tsx
@@ -170,7 +170,7 @@ export function NyuchiJobCard({
                 e.stopPropagation()
                 onApply()
               }}
-              className="h-10 rounded-full bg-[var(--color-gold,#FFD740)] px-4 text-[12px] font-medium text-[#0A0A0A] hover:opacity-80"
+              className="h-10 rounded-full bg-[var(--color-gold,#FFD740)] px-4 text-[12px] font-medium text-[var(--brand-accent-foreground,#0A0A0A)] hover:opacity-80"
             >
               Apply
             </button>

--- a/components/registry/n3-brand/nyuchi-leaderboard-row.tsx
+++ b/components/registry/n3-brand/nyuchi-leaderboard-row.tsx
@@ -129,9 +129,9 @@ function NyuchiLeaderboardRow({
             className={cn(
               "flex items-center gap-0.5 text-[10px]",
               trend === "up"
-                ? "text-[#4ADE80]"
+                ? "text-[var(--status-success,#4ADE80)]"
                 : trend === "down"
-                  ? "text-[#F87171]"
+                  ? "text-[var(--status-error,#F87171)]"
                   : "text-muted-foreground"
             )}
           >

--- a/components/registry/n3-brand/nyuchi-lesson-card.tsx
+++ b/components/registry/n3-brand/nyuchi-lesson-card.tsx
@@ -153,7 +153,7 @@ export function NyuchiLessonCard({
               e.stopPropagation()
               onStart()
             }}
-            className="h-10 rounded-full bg-[var(--color-cobalt,#00B0FF)] px-4 text-[12px] font-medium text-[#0A0A0A] hover:opacity-80"
+            className="h-10 rounded-full bg-[var(--color-cobalt,#00B0FF)] px-4 text-[12px] font-medium text-[var(--brand-accent-foreground,#0A0A0A)] hover:opacity-80"
           >
             {progress > 0 ? "Continue" : "Start"}
           </button>

--- a/components/registry/n3-brand/nyuchi-phrase-card.tsx
+++ b/components/registry/n3-brand/nyuchi-phrase-card.tsx
@@ -140,7 +140,7 @@ export function NyuchiPhraseCard({
                 e.stopPropagation()
                 onPractice()
               }}
-              className="h-10 rounded-full bg-[var(--color-cobalt,#00B0FF)] px-4 text-[12px] font-medium text-[#0A0A0A] hover:opacity-80"
+              className="h-10 rounded-full bg-[var(--color-cobalt,#00B0FF)] px-4 text-[12px] font-medium text-[var(--brand-accent-foreground,#0A0A0A)] hover:opacity-80"
             >
               Practice
             </button>

--- a/components/registry/n3-brand/nyuchi-place-card.tsx
+++ b/components/registry/n3-brand/nyuchi-place-card.tsx
@@ -141,7 +141,13 @@ function NyuchiPlaceCard({
               </span>
             )}
             {openNow != null && (
-              <span style={{ color: openNow ? "#4ADE80" : "#F87171" }}>
+              <span
+                style={{
+                  color: openNow
+                    ? "var(--status-success, #4ADE80)"
+                    : "var(--status-error, #F87171)",
+                }}
+              >
                 {openNow ? "Open" : "Closed"}
               </span>
             )}
@@ -210,7 +216,9 @@ function NyuchiPlaceCard({
         {openNow != null && (
           <span
             className="text-[10px] font-medium"
-            style={{ color: openNow ? "#4ADE80" : "#F87171" }}
+            style={{
+              color: openNow ? "var(--status-success, #4ADE80)" : "var(--status-error, #F87171)",
+            }}
           >
             {openNow ? "Open" : "Closed"}
           </span>

--- a/components/registry/n3-brand/nyuchi-profile-block.tsx
+++ b/components/registry/n3-brand/nyuchi-profile-block.tsx
@@ -50,7 +50,7 @@ const TIER_DISPLAY: Record<
   unverified: {
     label: "Unverified",
     mineral: null,
-    fg: "#6B6B66",
+    fg: "var(--status-neutral, #6B6B66)",
     bg: "rgba(107,107,102,0.15)",
     icon: "circle",
   },
@@ -208,11 +208,11 @@ export function NyuchiProfileBlock({
   const trustColor =
     trustScore != null
       ? trustScore >= 0.4
-        ? "#4ADE80" /* Green — strong trust */
+        ? "var(--status-success, #4ADE80)" /* Green — strong trust */
         : trustScore >= 0.2
-          ? "#FBBF24" /* Amber — growing trust */
-          : "#F87171" /* Red — low trust */
-      : "#6B6B66"
+          ? "var(--status-warning, #FBBF24)" /* Amber — growing trust */
+          : "var(--status-error, #F87171)" /* Red — low trust */
+      : "var(--status-neutral, #6B6B66)"
 
   return (
     <div

--- a/components/registry/n3-brand/nyuchi-route-planner.tsx
+++ b/components/registry/n3-brand/nyuchi-route-planner.tsx
@@ -206,7 +206,7 @@ export function NyuchiRoutePlanner({
                 e.stopPropagation()
                 onBook()
               }}
-              className="h-12 flex-1 rounded-full bg-[var(--color-gold,#FFD740)] text-[13px] font-medium text-[#0A0A0A] transition-opacity hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
+              className="h-12 flex-1 rounded-full bg-[var(--color-gold,#FFD740)] text-[13px] font-medium text-[var(--brand-accent-foreground,#0A0A0A)] transition-opacity hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary,#00B0FF)]"
             >
               Book Ride
             </button>

--- a/components/registry/n3-brand/nyuchi-rsvp-button.tsx
+++ b/components/registry/n3-brand/nyuchi-rsvp-button.tsx
@@ -26,15 +26,30 @@ const statusDisplay: Record<
     bg: "var(--brand-accent, var(--color-malachite))",
     fg: "var(--brand-accent-foreground, var(--color-background, var(--muted,#050504)))",
   },
-  pending: { label: "Pending", icon: Clock, bg: "rgba(251,191,36,0.15)", fg: "#FBBF24" },
-  confirmed: { label: "Confirmed", icon: Check, bg: "rgba(74,222,128,0.15)", fg: "#4ADE80" },
+  pending: {
+    label: "Pending",
+    icon: Clock,
+    bg: "rgba(251,191,36,0.15)",
+    fg: "var(--status-warning, #FBBF24)",
+  },
+  confirmed: {
+    label: "Confirmed",
+    icon: Check,
+    bg: "rgba(74,222,128,0.15)",
+    fg: "var(--status-success, #4ADE80)",
+  },
   waitlisted: {
     label: "Waitlisted",
     icon: Users,
     bg: "rgba(179,136,255,0.15)",
     fg: "var(--color-tanzanite,#B388FF)",
   },
-  declined: { label: "Declined", icon: X, bg: "rgba(248,113,113,0.15)", fg: "#F87171" },
+  declined: {
+    label: "Declined",
+    icon: X,
+    bg: "rgba(248,113,113,0.15)",
+    fg: "var(--status-error, #F87171)",
+  },
 }
 
 interface NyuchiRSVPButtonProps {

--- a/components/registry/n3-brand/nyuchi-search-view.tsx
+++ b/components/registry/n3-brand/nyuchi-search-view.tsx
@@ -128,7 +128,7 @@ export function NyuchiSearchView({
             className={cn(
               "shrink-0 rounded-full px-3.5 py-1.5 text-xs font-medium transition-colors",
               activeCategory === cat.key
-                ? "text-[#0A0A0A]"
+                ? "text-[var(--brand-accent-foreground,#0A0A0A)]"
                 : "bg-muted text-muted-foreground hover:text-foreground"
             )}
             style={

--- a/components/registry/n3-brand/nyuchi-trust-meter.tsx
+++ b/components/registry/n3-brand/nyuchi-trust-meter.tsx
@@ -107,12 +107,12 @@ function NyuchiTrustMeter({
   /* Score color thresholds */
   const scoreColor =
     trustScore >= 0.4
-      ? "#4ADE80" /* Green — strong */
+      ? "var(--status-success, #4ADE80)" /* Green — strong */
       : trustScore >= 0.2
-        ? "#FBBF24" /* Amber — growing */
+        ? "var(--status-warning, #FBBF24)" /* Amber — growing */
         : trustScore >= 0.05
-          ? "#FB923C" /* Orange — low */
-          : "#6B6B66" /* Grey — none */
+          ? "var(--status-warning, #FB923C)" /* Orange — low */
+          : "var(--status-neutral, #6B6B66)" /* Grey — none */
 
   const signals: TrustSignal[] = [
     {
@@ -129,7 +129,7 @@ function NyuchiTrustMeter({
         statusScore + 0.5,
         0
       ) /* Normalize: -0.05–0.0 → 0.45–0.50 range for display */,
-      color: statusScore >= 0 ? "#4ADE80" : "#F87171",
+      color: statusScore >= 0 ? "var(--status-success, #4ADE80)" : "var(--status-error, #F87171)",
       detail: statusLabel,
     },
     {

--- a/components/registry/n3-brand/nyuchi-verified-badge.tsx
+++ b/components/registry/n3-brand/nyuchi-verified-badge.tsx
@@ -187,7 +187,12 @@ function NyuchiVerifiedBadge({
         className={cn(badgeSizeVariants({ size }), "opacity-40", className)}
         style={{ backgroundColor: "rgba(107,107,102,0.15)" }}
       >
-        <Ban width={iconSize} height={iconSize} strokeWidth={2.5} color="#6B6B66" />
+        <Ban
+          width={iconSize}
+          height={iconSize}
+          strokeWidth={2.5}
+          color="var(--status-neutral, #6B6B66)"
+        />
       </span>
     )
   }

--- a/components/registry/n4-safety/mzizi-feature-gate.tsx
+++ b/components/registry/n4-safety/mzizi-feature-gate.tsx
@@ -72,7 +72,7 @@ export function NyuchiFeatureGate({
         className
       )}
     >
-      <div className="bg-[var(--status-info, #3B82F6)]/15 flex size-10 shrink-0 items-center justify-center rounded-full">
+      <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-[var(--status-info,#3B82F6)]/15">
         <svg
           width="20"
           height="20"

--- a/components/registry/n4-safety/mzizi-rate-gate.tsx
+++ b/components/registry/n4-safety/mzizi-rate-gate.tsx
@@ -82,7 +82,7 @@ export function NyuchiRateGate({
         className
       )}
     >
-      <div className="bg-[var(--status-warning, #F59E0B)]/15 flex size-12 shrink-0 items-center justify-center rounded-full">
+      <div className="flex size-12 shrink-0 items-center justify-center rounded-full bg-[var(--status-warning,#F59E0B)]/15">
         <svg
           width="24"
           height="24"
@@ -110,7 +110,7 @@ export function NyuchiRateGate({
         {remainingAttempts != null && maxAttempts != null && (
           <div className="mt-1.5 h-1 overflow-hidden rounded-full bg-muted">
             <div
-              className="bg-[var(--status-warning, #F59E0B)] h-full rounded-full transition-all"
+              className="h-full rounded-full bg-[var(--status-warning,#F59E0B)] transition-all"
               style={{ width: `${(remainingAttempts / maxAttempts) * 100}%` }}
             />
           </div>

--- a/components/registry/n4-safety/subscription-gate.tsx
+++ b/components/registry/n4-safety/subscription-gate.tsx
@@ -79,7 +79,7 @@ function SubscriptionGate({
           <ul className="mt-3 space-y-1 text-xs text-muted-foreground">
             {features.map((f, i) => (
               <li key={i} className="flex items-center gap-1.5">
-                <span className="text-[var(--status-success, #22C55E)]">✓</span>
+                <span className="text-[var(--status-success,#22C55E)]">✓</span>
                 {f}
               </li>
             ))}

--- a/components/registry/n5-resilience/mzizi-degradation-chain.tsx
+++ b/components/registry/n5-resilience/mzizi-degradation-chain.tsx
@@ -74,7 +74,7 @@ export function NyuchiDegradationChain<T>({
       className={className}
     >
       {state.degraded && state.level < levels.length && (
-        <p className="text-[var(--status-warning, #F59E0B)] mb-2 text-xs" role="status">
+        <p className="mb-2 text-xs text-[var(--status-warning,#F59E0B)]" role="status">
           Showing {levels[state.level].label} (personalized content unavailable)
         </p>
       )}

--- a/components/registry/n5-resilience/mzizi-error-set.tsx
+++ b/components/registry/n5-resilience/mzizi-error-set.tsx
@@ -150,7 +150,7 @@ function NotFound({
         {onHome && (
           <button
             onClick={onHome}
-            className="bg-[var(--status-success, #22C55E)] flex h-11 items-center gap-2 rounded-full px-5 text-sm font-semibold text-background"
+            className="flex h-11 items-center gap-2 rounded-full bg-[var(--status-success,#22C55E)] px-5 text-sm font-semibold text-background"
           >
             <Home className="size-4" />
             Home
@@ -192,7 +192,7 @@ function OfflineBanner({
       className={cn(
         "flex items-center justify-center gap-2 px-4 py-2 text-xs font-medium",
         isOnline
-          ? "bg-[var(--status-warning, #F59E0B)]/10 text-[var(--status-warning, #F59E0B)]"
+          ? "bg-[var(--status-warning,#F59E0B)]/10 text-[var(--status-warning,#F59E0B)]"
           : "bg-foreground/5 text-muted-foreground",
         className
       )}
@@ -319,7 +319,7 @@ function SectionFallback({
         className
       )}
     >
-      <AlertTriangle className="text-[var(--status-error, #EF4444)] size-8" />
+      <AlertTriangle className="size-8 text-[var(--status-error,#EF4444)]" />
       <p className="mt-3 text-sm font-medium text-foreground">{sectionName} could not load</p>
       {error && (
         <p className="mt-1 text-xs text-muted-foreground">

--- a/components/registry/n6-pages/nyuchi-create-page.tsx
+++ b/components/registry/n6-pages/nyuchi-create-page.tsx
@@ -109,7 +109,7 @@ export function NyuchiCreatePage({
               "flex h-14 w-full items-center justify-center rounded-full text-[15px] font-semibold transition-opacity",
               submitting
                 ? "bg-muted text-muted-foreground"
-                : "bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] text-[#0A0A0A] hover:opacity-80"
+                : "bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] text-[var(--brand-accent-foreground,#0A0A0A)] hover:opacity-80"
             )}
           >
             {submitting ? "Saving..." : submitLabel}

--- a/components/registry/n6-pages/nyuchi-detail-page.tsx
+++ b/components/registry/n6-pages/nyuchi-detail-page.tsx
@@ -92,7 +92,7 @@ export function NyuchiDetailPage({
                 className={cn(
                   "flex size-10 items-center justify-center rounded-full backdrop-blur-sm",
                   saved
-                    ? "bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] text-[#0A0A0A]"
+                    ? "bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] text-[var(--brand-accent-foreground,#0A0A0A)]"
                     : "bg-background/80 text-foreground"
                 )}
                 aria-label={saved ? "Unsave" : "Save"}
@@ -136,7 +136,7 @@ export function NyuchiDetailPage({
           <div className="mx-auto flex max-w-2xl gap-2">
             <button
               onClick={ctaAction}
-              className="bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] h-14 flex-1 rounded-full text-[15px] font-semibold text-[#0A0A0A] transition-opacity hover:opacity-80"
+              className="bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] h-14 flex-1 rounded-full text-[15px] font-semibold text-[var(--brand-accent-foreground,#0A0A0A)] transition-opacity hover:opacity-80"
             >
               {ctaLabel}
             </button>

--- a/components/registry/n6-pages/nyuchi-feed-page.tsx
+++ b/components/registry/n6-pages/nyuchi-feed-page.tsx
@@ -174,7 +174,7 @@ export function NyuchiFeedPage<T>({
             {onCreateAction && (
               <button
                 onClick={onCreateAction}
-                className="bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] mt-6 h-12 rounded-full px-6 text-[13px] font-medium text-[#0A0A0A] transition-opacity hover:opacity-80"
+                className="bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] mt-6 h-12 rounded-full px-6 text-[13px] font-medium text-[var(--brand-accent-foreground,#0A0A0A)] transition-opacity hover:opacity-80"
               >
                 {createLabel}
               </button>
@@ -188,7 +188,7 @@ export function NyuchiFeedPage<T>({
         <button
           onClick={onCreateAction}
           aria-label={createLabel}
-          className="bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] fixed right-5 bottom-24 z-40 flex size-14 items-center justify-center rounded-full text-[#0A0A0A] shadow-lg transition-opacity hover:opacity-80 md:hidden"
+          className="bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] fixed right-5 bottom-24 z-40 flex size-14 items-center justify-center rounded-full text-[var(--brand-accent-foreground,#0A0A0A)] shadow-lg transition-opacity hover:opacity-80 md:hidden"
         >
           <span className="text-xl font-bold">+</span>
         </button>

--- a/components/registry/n6-pages/nyuchi-profile-page-layout.tsx
+++ b/components/registry/n6-pages/nyuchi-profile-page-layout.tsx
@@ -134,7 +134,7 @@ export function NyuchiProfilePageLayout({
               {primaryAction && (
                 <button
                   onClick={primaryAction.onClick}
-                  className="bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] h-12 flex-1 rounded-full text-[13px] font-medium text-[#0A0A0A] transition-opacity hover:opacity-80"
+                  className="bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))] h-12 flex-1 rounded-full text-[13px] font-medium text-[var(--brand-accent-foreground,#0A0A0A)] transition-opacity hover:opacity-80"
                 >
                   {primaryAction.label}
                 </button>

--- a/scripts/validate-registry.mjs
+++ b/scripts/validate-registry.mjs
@@ -46,6 +46,23 @@ const NOT_SOURCE = new Set([".ds_store", ".map", ".snap", ".log"])
 /** Only N1 may define raw colour values (CLAUDE.md §7.4). */
 const TOKENS_NODE_DIR = "n1-tokens"
 
+/**
+ * Components whose hexes are DATA, not styling.
+ *
+ * A named list of two rather than a pattern, because a pattern that exempts
+ * "anything that looks like a palette" would silently swallow the next real
+ * violation — and the §8.2 touch-target check already taught this repo what an
+ * unactionable gate costs.
+ *
+ * `color-picker` and `caption-editor` present colours for a user to CHOOSE. The
+ * hex is the value the component returns, so it has to be a literal: a swatch
+ * rendered as `var(--color-cobalt)` cannot report which colour was picked. They
+ * do duplicate N1's palette, which is a real (smaller) problem — the fix is to
+ * source the swatch list from N1 rather than retype it, and that needs an
+ * import a self-contained registry component (§15.6) cannot currently make.
+ */
+const LITERAL_COLOUR_DATA = new Set(["color-picker", "caption-editor"])
+
 /*
  * There is deliberately NO touch-target check here any more.
  *
@@ -310,11 +327,15 @@ function main() {
       const src = readFileSync(join(REGISTRY_DIR, onDisk.rel), "utf8")
 
       // §7.4 — only N1 defines raw colour values.
-      if (onDisk.dir !== TOKENS_NODE_DIR) {
-        const hexes = src.match(/#[0-9a-fA-F]{6}\b/g) ?? []
+      if (onDisk.dir !== TOKENS_NODE_DIR && !LITERAL_COLOUR_DATA.has(n)) {
+        // Third-party brand marks are stripped before the scan: a `fill="#4285F4"`
+        // in Google's "G" is that company's identity, not a Mzizi design
+        // decision, and §7.4 already exempts SVG where Tailwind cannot reach.
+        const scannable = src.replace(/\b(?:fill|stroke|stop-color)=["']#[0-9a-fA-F]{6}["']/g, "")
+        const hexes = scannable.match(/#[0-9a-fA-F]{6}\b/g) ?? []
         // A hex inside a `var(--token, #fallback)` is the documented fallback
         // form, so only flag hexes that are NOT preceded by a comma in a var().
-        const bare = hexes.filter((h) => !new RegExp(`var\\([^)]*,\\s*${h}`).test(src))
+        const bare = hexes.filter((h) => !new RegExp(`var\\([^)]*,\\s*${h}`).test(scannable))
         if (bare.length > 0) {
           warn(
             n,


### PR DESCRIPTION
Started from "components use tokens, not hex" and followed it to where the tokens are defined. The 32 flagged components were the visible tip.

## The `--status-*` set was declared and never defined

`nyuchi-tokens.ts`'s `statusTokens` gives each status a `css` field naming `--status-success` / `--status-warning` / `--status-error` / `--status-info` / `--status-neutral`. That is **N1 declaring the contract**, and **243 registry components reference those names**.

`globals.css` implemented a *different* set — `--success` / `--warning` / `--destructive` / `--info` / `--neutral` — and never defined the `--status-*` names at all.

So all 243 references fell through to the hex fallback baked into each component. **They read as tokenised and rendered as hardcoded** — nothing looked broken, and the theme did nothing. §7.4 rule 2 says a new colour token is declared in both blocks *and* registered in `@theme`; this set skipped all three.

Fixed by **aliasing rather than adding values**, so there is still one decision per status:

```css
--status-success: var(--success);
--status-error:   var(--destructive);   /* existing name for that role */
```

Declared in `:root`, in `.dark` (a `var()` alias declared only in `:root` keeps resolving to the *light* value inside `.dark`), and registered in `@theme`. Verified in the built CSS: `--status-success:var(--success)` is emitted.

N1's own hexes (`#22C55E` etc.) stay put — they are the per-component `var(--token, #hex)` fallback for a consumer that hasn't defined the properties (§7.6), not a value this file should restate.

## The 32 flagged components are three different things

**Converted** — 36 substitutions across 25 files, Mzizi design decisions written as hex:

| Hex | × | → |
| --- | --: | --- |
| `#0A0A0A` | 13 | `--brand-accent-foreground` |
| `#4ADE80` | 8 | `--status-success` |
| `#F87171` | 7 | `--status-error` |
| `#FBBF24` | 3 | `--status-warning` |
| `#6B6B66` | 5 | `--status-neutral` |
| `#FB923C` | 1 | `--status-warning` |

`--brand-accent-foreground` rather than `--foreground` for the first group: its polarity flips correctly (`#ffffff` light / `#3e2723` dark), where plain `--foreground` would put near-white text on bright malachite in dark mode.

`nyuchi-trust-meter` is the shape of the whole problem — lines 122 and 139 already used `var(--status-warning, …)` while 109–114 sat on bare hex. A conversion that was started and stopped.

**Not converted, deliberately:**

- **Third-party brand marks.** `#4285F4/#34A853/#FBBC05/#EA4335` is Google's logo in an SVG `fill`; `#00A651` is EcoCash; `#627EEA` is Ethereum. Other companies' identities, not design decisions — rendering them in malachite would be wrong. The validator now strips `fill`/`stroke`/`stop-color` before scanning, which §7.4 already exempts.
- **Literal colour *data*.** `color-picker` and `caption-editor` present colours for a user to **choose** — the hex is the value returned, so a swatch rendered as `var(--color-cobalt)` could not report what was picked. Named allow-list of two rather than a pattern, because a pattern for "looks like a palette" would swallow the next real violation.
- **`wallet-card`'s gradients.** These *are* minerals (`#4B0082/#B388FF` tanzanite, `#004D40/#64FFDA` malachite…). I started converting them to `--mineral-*-light` / `--mineral-*-dark` **before checking, and those names do not exist** — N1 emits one theme-resolved `--mineral-*` per mineral, not per end, and a light→dark gradient needs both at once. Inventing them would have recreated the exact `--status-*` bug above. Exposing per-end mineral values is an N1 / `tokens:sync` change, not a component fix.

Validator flags drop **32 → 9**, and the 9 that remain are those three groups, each with its reason.

## One thing I could not establish

Many registry components use a **spaced** arbitrary value, e.g. `bg-[var(--brand-accent,var(--status-success, var(--color-malachite, #64FFDA)))]`. Tailwind splits candidates on whitespace, so these may not generate — which would mean no background at all in a consumer's app. This is **pre-existing** and my conversions are space-free.

I could not settle it: registry components are payload served over HTTP, not compiled into the portal, so this build never scans them, and two attempts at a standalone extractor probe returned 0 rules **even for a plainly-valid space-free class** — the harness was faulty, not the classes. Worth its own investigation against a real consumer build rather than a guess here.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm test` (162 passing), `pnpm build` (exit 0), `pnpm audit`, `pnpm registry:validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_