### PR TITLE
feat(dev): Kitesurf render checks — pnpm browser:check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,7 @@ pnpm doctrine:verify  # Non-mutating check — fails if an extracted doctrine fi
 pnpm props:extract    # Read component prop types into lib/samples/props.generated.ts (§8.10)
 pnpm props:verify     # Non-mutating check — fails if the extracted props are stale
 pnpm samples:push     # Project lib/samples/data.ts into MongoDB `mzizi_samples` (§8.10)
+pnpm browser:check    # Render pages through Kitesurf and assert they painted (§13.1)
 pnpm audit:check      # pnpm audit --audit-level=moderate --ignore-registry-errors
 ```
 
@@ -1272,6 +1273,49 @@ __tests__/
 pnpm test             # Run all tests once
 pnpm test:watch       # Watch mode for development
 ```
+
+### 13.1 Browser checks — the one thing the offline gates cannot answer
+
+> **Source of truth:** `docs/browser-checks.md`. This is the summary.
+
+`pnpm browser:check` renders pages through Cloudflare **Kitesurf** and asserts
+each produced its own content. It exists because `/changelog/{name}` shipped page
+chrome with **no article body** while every gate was green: typecheck, lint,
+tests and build all passed, and the route answered HTTP 200 with ~140 KB of HTML.
+`new Date(undefined).toISOString()` threw inside the article and React swallowed
+it into an empty region, with the header, sidebar and footer rendering around the
+hole.
+
+A status code and a byte count were both true and both useless. Nothing offline
+can close that gap — a unit test renders a component in jsdom, not the deployed
+page, and `pnpm build` proves a route compiles, not that it paints.
+
+**It is a `fetch`, not Playwright, and that is a requirement rather than a
+preference.** fundi is a Cloudflare Worker and cannot spawn a browser process, so
+a local-browser checker would serve developers and be useless to the N9 rung that
+most needs it. Browser Run is reachable identically from a laptop, from CI, and
+from inside fundi's heal loop — from a Worker via `env.BROWSER.quickAction()`,
+which needs no API token at all.
+
+Rules that are easy to get wrong, each one a bug this already shipped:
+
+- **Assert a string, never a length.** A threshold cannot tell content from
+  chrome; the first version green-ticked navigation on all five routes.
+- **Match the body, never the raw response.** `/markdown` prefixes a YAML block
+  built from the page's `<meta>` tags, so an expectation drawn from the
+  description passes against a page that rendered nothing.
+- **Do not parse the HTML here.** `<main>` on this site wraps the _sidebar_, and
+  `/<[^>]+>/g` breaks on Tailwind's `[&>svg]:` attributes. `/markdown` extracts
+  in the browser's own context, which is why the script has no dependencies.
+- **Kitesurf supports a subset of Quick Actions.** `/markdown`, `/content`,
+  `/accessibilityTree` and `/screenshot` work; `/scrape` and `/links` answer
+  `Action "…" is not supported by the kitesurf browser`.
+- **No colour or contrast assertions.** Kitesurf trades CSS exactness for cost,
+  so it cannot gate the APCA floor. Rendered-or-not is what it can answer.
+
+Without `CLOUDFLARE_API_TOKEN` it skips loudly and exits 0 — visibly, never
+looking like a green run. It is not in `ci.yml` yet for that reason: a check that
+reads as broken on every fork is one everyone learns to ignore.
 
 ---
 

--- a/docs/browser-checks.md
+++ b/docs/browser-checks.md
@@ -43,6 +43,32 @@ green run — the skip prints what was not checked and why.
 `--text` is the debugging tool. When an expectation fails, the answer is almost
 always in what the page rendered instead, and dumping it takes one command.
 
+**`--base` against a Vercel preview does not work, and the script says so.**
+Preview deployments sit behind Vercel SSO, so the route 302s off-origin and the
+browser faithfully renders 2,035 characters of "Log in to Vercel". Left alone the
+check would report `its content did not render` — the checker blaming the site
+for the checker's own problem, which is the same mistake as expecting a
+capitalised `Malachite`. On failure it now probes for an off-origin redirect and
+reports the real cause instead:
+
+```
+✗ /tokens
+    rendered 2035 chars of prose, but not "malachite".
+    NOT a rendering failure — the URL redirects off-origin to https://vercel.com,
+    so the browser rendered that page rather than this route — an auth wall
+    (Vercel SSO, Cloudflare Access, …), not an empty page.
+```
+
+An off-origin redirect is the general signal, so this covers Cloudflare Access
+and anything else without naming a vendor. Same-origin redirects are not
+reported, because this site has legitimate ones
+(`/architecture/layers/:n` → `/architecture/nodes/:n`). The probe only runs on
+failure, so the happy path still costs one request per route.
+
+Checking a protected preview needs a bypass token
+(`VERCEL_AUTOMATION_BYPASS_SECRET`), which is why the practical targets today are
+production and a local dev server.
+
 Kitesurf is in free beta and uses 3–7× less CPU and memory than Chromium for
 exactly this kind of task. It is not pixel-perfect, which does not matter here —
 see _What this does not check_.

--- a/docs/browser-checks.md
+++ b/docs/browser-checks.md
@@ -1,0 +1,164 @@
+# Browser checks — proving a page actually rendered
+
+`pnpm browser:check` renders pages through [Kitesurf](https://developers.cloudflare.com/browser-run/kitesurf/)
+and asserts each one produced its own content. `scripts/kitesurf.mjs` is the whole
+implementation; this file is the why, the dev setup, and how fundi runs the same
+check from a Worker.
+
+## The gap it closes
+
+`/changelog/{name}` served page chrome with **no article body** in production.
+Every gate was green — typecheck, lint, tests, build — and the route answered
+HTTP 200 with ~140 KB of HTML. The failure was `new Date(undefined).toISOString()`
+throwing inside the article, which React swallowed into an empty region while the
+header, sidebar and footer rendered around it.
+
+A status code says 200. A byte count says 140 KB. Both were true and neither was
+useful. Nothing in the repo asked the only question that separates "the page
+works" from "the page is a frame around a hole": **render it and look for content
+that should be there.**
+
+That question cannot be answered offline. A unit test renders a component in
+jsdom, not the deployed page; `pnpm build` proves the route compiles, not that it
+paints. So this check needs a real browser, and it is the only gate of its kind
+here.
+
+## Dev setup
+
+```bash
+export CLOUDFLARE_API_TOKEN=...        # Browser Rendering - Edit permission
+export CLOUDFLARE_ACCOUNT_ID=...       # optional; the script defaults to Nyuchi's
+
+pnpm browser:check                                 # the default route set
+pnpm browser:check --base http://localhost:11736   # against a dev server
+pnpm browser:check /changelog/button               # one route
+pnpm browser:check --text /components/button       # dump what the page rendered
+```
+
+**Without a token it skips loudly and exits 0.** That is deliberate: there is no
+offline substitute, so the alternatives are "skip visibly" or "fail every
+contributor who has no Cloudflare token". What it must never do is _look_ like a
+green run — the skip prints what was not checked and why.
+
+`--text` is the debugging tool. When an expectation fails, the answer is almost
+always in what the page rendered instead, and dumping it takes one command.
+
+Kitesurf is in free beta and uses 3–7× less CPU and memory than Chromium for
+exactly this kind of task. It is not pixel-perfect, which does not matter here —
+see _What this does not check_.
+
+## Adding a route
+
+Each entry in `ROUTES` names a string **only that route's own body can produce**:
+
+```js
+{ path: "/components/button", expect: "Polymorphic rendering via asChild" },
+```
+
+Pick content the page reads from data — a `meta.features` entry from
+`registry.json`, a version row, a mineral name, a rendered headline. Three things
+that look like reasonable expectations and are not:
+
+- **A text-length threshold.** The first version used one, and it green-ticked
+  navigation on all five routes. A threshold cannot tell content from chrome.
+- **Anything in the page's `<meta>` description.** `/markdown` prefixes a YAML
+  block built from the meta tags, and two of the five current expectations appear
+  in it. The script strips that block before matching; an expectation that only
+  exists there would pass against a page that rendered nothing.
+- **A capitalised wordmark.** §7.2 makes them lowercase — the page renders
+  `malachite`. Expecting `Malachite` failed against a page that was rendering
+  perfectly, which is a brittle assertion reporting its author's assumption as
+  the site's defect.
+
+## Which Quick Action, and why
+
+`/markdown`. It extracts prose in the browser's own context, so the script does
+no HTML parsing at all — which removed both bugs the first version shipped with:
+
+1. It read `<main>`. On this site `<main>` wraps the **sidebar**; the button
+   page's real content sits outside it and `</main>` closes at character 61,535
+   of 140,113. Every page reported ~600 characters of identical navigation and a
+   green tick. Five very different pages agreeing to within 11 characters was
+   the tell.
+2. It stripped tags with `/<[^>]+>/g`. Tailwind arbitrary variants put `>` inside
+   attribute values — `class="[&>svg]:size-4"` — so the regex cut in the wrong
+   place and leaked class names into the "visible text". Same family as the `=>`
+   trap documented in `scripts/extract-props.ts`.
+
+Both were self-inflicted, and neither can recur when the extraction happens
+server-side. It also means the script has **zero dependencies**, and a Worker
+gets the identical result with no parsing library.
+
+Kitesurf supports a subset of Quick Actions. Verified against `mzizi.dev`:
+
+| Action               | Kitesurf                                                   |
+| -------------------- | ---------------------------------------------------------- |
+| `/markdown`          | works                                                      |
+| `/content`           | works                                                      |
+| `/accessibilityTree` | works                                                      |
+| `/screenshot`        | works                                                      |
+| `/scrape`            | `Action "scrape" is not supported by the kitesurf browser` |
+| `/links`             | same refusal                                               |
+
+If a future check needs `/scrape` or `/links`, drop `?browser=kitesurf` for that
+call and pay for Chromium — do not assume the refusal is a transient error.
+
+## Running it from fundi
+
+fundi is a Cloudflare Worker. It cannot spawn a browser process, so a Playwright
+checker would serve developers and be useless to the agent that most needs it.
+**This is the reason the check is a `fetch` and not a local browser** — the same
+capability is reachable from a laptop, from CI, and from inside the heal loop.
+
+From a Worker, use the binding rather than the REST API: it needs **no API
+token**, does not leave Cloudflare's network, and is lower latency.
+
+```jsonc
+// fundi/wrangler.jsonc
+{
+  "browser": { "binding": "BROWSER" },
+}
+```
+
+```ts
+const md = await env.BROWSER.quickAction("markdown", { url })
+const body = md.replace(/^---\n[\s\S]*?\n---\n/, "") // same frontmatter strip
+```
+
+Three constraints, each verified rather than assumed:
+
+- **`quickAction()` needs `compatibility_date >= 2026-03-24`.** `fundi-tester` is
+  on `2026-05-22`, so it already qualifies — no bump, no flag.
+- **It does not work under plain `wrangler dev`.** Local mode answers
+  `The RPC receiver does not implement the method "quickAction"`. Use
+  `wrangler dev --remote`, or set `"remote": true` on the binding.
+- **The binding has no `?browser=kitesurf` query string.** The REST path opts in
+  through the URL; check the binding's own options before assuming a Worker call
+  gets Kitesurf rather than Chromium. The check works either way — this only
+  affects cost.
+
+What this buys the N9 rung: fundi currently files issues from observability
+events, which means it learns about a broken page only when something throws
+_and_ the throw is reported. A render check is a signal it can generate itself —
+"this route stopped producing its content" is a diagnostic no error-boundary
+beacon emits, because the failing page did not error, it rendered empty.
+
+## What this does not check
+
+- **Contrast and colour.** Kitesurf trades CSS exactness for cost, so a computed
+  style from it cannot gate an APCA floor. Rendered-or-not is a binary it can
+  answer; "is this colour exactly right" is not. Use Chromium if that check is
+  ever wanted.
+- **The live component previews.** Those mount client-side and Kitesurf returns
+  before they resolve, so every page currently shows `Loading preview…`. That is
+  a limit of this check, not a defect on the page — asserting on it would produce
+  a failure nobody could fix.
+- **Anything below the fold that renders lazily**, for the same reason.
+
+## Why it is not in CI (yet)
+
+It needs a Cloudflare token, so wiring it into `ci.yml` makes a missing secret
+look like a broken build on every fork and every PR from outside the org. The
+honest sequence is: run it against production after a deploy, and add it to CI
+once the secret is provisioned and the route set has settled. A red check
+everyone learns to ignore is worse than no check.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "doctrine:verify": "tsx scripts/extract-doctrine.ts --check",
     "props:extract": "tsx scripts/extract-props.ts",
     "props:verify": "tsx scripts/extract-props.ts --check",
-    "samples:push": "tsx scripts/push-samples.ts"
+    "samples:push": "tsx scripts/push-samples.ts",
+    "browser:check": "node scripts/kitesurf.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",

--- a/scripts/kitesurf.mjs
+++ b/scripts/kitesurf.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * Render pages through Cloudflare Kitesurf and assert they actually painted.
+ *
+ *   pnpm browser:check                                  # the default route set
+ *   pnpm browser:check --base http://localhost:11736    # against a dev server
+ *   pnpm browser:check /changelog/button                # one route
+ *   pnpm browser:check --text /components/button        # dump what the page rendered
+ *
+ * WHY THIS EXISTS, AND WHY NOTHING OFFLINE REPLACES IT.
+ *
+ * `/changelog/{name}` served page chrome with **no article body** in production.
+ * Every gate was green — typecheck, lint, tests, build — and the route answered
+ * HTTP 200 with ~140 KB of HTML. The failure was `new Date(undefined)
+ * .toISOString()` throwing inside the article, which React swallowed into an
+ * empty region while the header, sidebar and footer rendered around it.
+ *
+ * A status code says 200 and a byte count says 140 KB. Both are true, and both
+ * are useless. The only thing that separates "the page works" from "the page is
+ * a frame around a hole" is rendering it and looking for content that should be
+ * there.
+ *
+ * WHY KITESURF RATHER THAN PLAYWRIGHT.
+ *
+ * fundi is a Cloudflare Worker. It cannot spawn a browser process, so a
+ * Playwright checker would serve developers and be useless to the agent that
+ * most needs it. Browser Run is a `fetch` call, so the same check runs from a
+ * laptop, from CI, and from inside fundi's heal loop — see
+ * `docs/browser-checks.md` for the Worker binding, which needs no API token.
+ * Kitesurf because it is 3-7x lighter than Chromium and this needs text, not
+ * pixels.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY `/markdown` AND NOT `/content` + AN HTML PARSER.
+ *
+ * The first version fetched raw HTML and extracted the text here. That is a
+ * whole class of bug this does not need to own, and it hit two of them before
+ * getting one green run:
+ *
+ * 1. It read `<main>`. On this site `<main>` wraps the SIDEBAR — the button
+ *    page's real content sits outside it, and `</main>` closes at character
+ *    61,535 of 140,113. Every page therefore reported ~600 characters of
+ *    identical navigation text and a green tick. Five very different pages
+ *    agreeing to within 11 characters was the tell.
+ *
+ * 2. It stripped tags with `/<[^>]+>/g`. Tailwind arbitrary variants contain
+ *    `>` inside attribute values — `class="[&>svg]:size-4"` — so the regex cut
+ *    in the wrong place and leaked class names into the "visible text". Same
+ *    family as the `=>` trap in `extract-props.ts`.
+ *
+ * `/markdown` extracts in the browser's own context and returns prose, so both
+ * disappear, the dependency goes with them, and a Worker gets the identical
+ * result with no parsing library at all. `/scrape` and `/links` would also have
+ * done, but Kitesurf answers `Action "scrape" is not supported by the kitesurf
+ * browser` — only a subset of Quick Actions works on it. `/markdown`,
+ * `/content`, `/screenshot` and `/accessibilityTree` do.
+ *
+ * THE FRONTMATTER STRIP IS LOAD-BEARING, NOT TIDYING.
+ *
+ * `/markdown` prefixes a YAML block carrying the page's `<meta>` tags —
+ * including `description`. Two of the five expectations below are satisfied by
+ * that block alone, so matching against the raw response would green-tick a
+ * page whose body rendered nothing: the exact failure this exists to catch,
+ * reintroduced through the front door. Only the body is searched.
+ *
+ * A THRESHOLD IS NOT AN ASSERTION.
+ *
+ * The first version also measured text LENGTH, which cannot tell content from
+ * chrome and so passed navigation. Each route names a string only its own body
+ * produces.
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * WHAT THIS DELIBERATELY DOES NOT DO.
+ *
+ * No contrast or colour assertions. Kitesurf trades CSS exactness for cost, so
+ * a computed style from it cannot gate an APCA floor. Rendered-or-not is a
+ * binary it can answer; "is this colour exactly right" is not.
+ *
+ * No assertions on the live component previews either. Those mount client-side
+ * and Kitesurf returns before they resolve, so every page shows
+ * "Loading preview…". That is a limit of this check, not a defect on the page —
+ * asserting on it would produce a failure nobody can fix.
+ */
+
+import { argv, env, exit } from "node:process"
+
+const ACCOUNT = env.CLOUDFLARE_ACCOUNT_ID ?? "125a2dfbc21f76a25c980609609e8218"
+const TOKEN = env.CLOUDFLARE_API_TOKEN ?? ""
+const API = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT}/browser-rendering`
+
+/**
+ * Route -> a string only that route's own BODY can produce.
+ *
+ * Each one is content the page reads from data — a `meta.features` entry from
+ * `registry.json`, a version row, a mineral name, a rendered headline. Chrome
+ * cannot satisfy any of them, which is the property a length threshold lacked.
+ *
+ * `/tokens` is lowercase on purpose: §7.2 makes every wordmark lowercase and
+ * the page renders "malachite". A capitalised expectation here failed against a
+ * page that was rendering perfectly — a brittle assertion reports its author's
+ * assumption as the site's defect.
+ */
+const ROUTES = [
+  // A `meta.features` entry — served from registry.json, rendered by the detail body.
+  { path: "/components/button", expect: "Polymorphic rendering via asChild" },
+  // The oldest version row. `/changelog/{name}` is the route that shipped empty.
+  { path: "/changelog/button", expect: "backfilled from existing design system" },
+  // A mineral name out of the live palette.
+  { path: "/tokens", expect: "malachite" },
+  // The helix headline — doctrine, and read live from component_documents.
+  { path: "/architecture", expect: "Two backbones. Cross-cutting rungs. No axes." },
+  // The Ubuntu line on the landing hero.
+  { path: "/", expect: "Ndiri nekuti tiri" },
+]
+
+/** Drop the `<meta>`-derived YAML block `/markdown` prepends. See the header. */
+function body(markdown) {
+  return markdown.replace(/^---\n[\s\S]*?\n---\n/, "")
+}
+
+async function render(url) {
+  const res = await fetch(`${API}/markdown?browser=kitesurf`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ url }),
+  })
+  const payload = await res.json().catch(() => null)
+  if (!res.ok || !payload?.success) {
+    const detail = payload?.errors?.map((e) => e.message).join("; ") ?? `HTTP ${res.status}`
+    return { ok: false, detail }
+  }
+  return { ok: true, text: body(String(payload.result ?? "")) }
+}
+
+async function main() {
+  const args = argv.slice(2)
+  const dumpText = args.includes("--text")
+  const baseAt = args.indexOf("--base")
+  const base = (baseAt !== -1 ? args[baseAt + 1] : "https://mzizi.dev").replace(/\/$/, "")
+  const only = args.filter((a, i) => !a.startsWith("--") && !(baseAt !== -1 && i === baseAt + 1))
+  const targets = only.length ? ROUTES.filter((r) => only.includes(r.path)) : ROUTES
+
+  if (only.length && targets.length === 0) {
+    console.error(`No known route among: ${only.join(", ")}`)
+    console.error(`Known routes: ${ROUTES.map((r) => r.path).join(", ")}`)
+    console.error("A route needs an `expect` string here before it can be checked.")
+    exit(1)
+  }
+
+  if (!TOKEN) {
+    // A loud skip, not a silent pass. There is no offline version of "did the
+    // browser paint it", so this cannot be made non-fatal by moving work
+    // around. What it must not do is look like a green run.
+    console.error("⊘ CLOUDFLARE_API_TOKEN is not set — SKIPPING the render check.")
+    console.error("  This is the only gate that catches a page rendering empty.")
+    console.error("  Needs a token with the `Browser Rendering - Edit` permission.")
+    exit(0)
+  }
+
+  let failed = 0
+  for (const route of targets) {
+    const result = await render(base + route.path)
+    if (!result.ok) {
+      console.error(`✗ ${route.path}\n    render failed: ${result.detail}`)
+      failed++
+      continue
+    }
+    if (dumpText) {
+      console.log(`\n──── ${route.path} (${result.text.length} chars) ────\n${result.text}`)
+      continue
+    }
+    if (!result.text.includes(route.expect)) {
+      console.error(
+        `✗ ${route.path}\n    rendered ${result.text.length} chars of prose, but not ` +
+          `${JSON.stringify(route.expect)}.\n` +
+          `    That is the chrome-around-a-hole shape: the frame rendered, its content did not.\n` +
+          `    \`pnpm browser:check --text ${route.path}\` shows what it did render.`
+      )
+      failed++
+      continue
+    }
+    console.log(
+      `✓ ${route.path}  found ${JSON.stringify(route.expect)} (${result.text.length} chars)`
+    )
+  }
+
+  if (dumpText) return
+  if (failed > 0) {
+    console.error(`\n${failed} of ${targets.length} route(s) did not render their content.`)
+    exit(1)
+  }
+  console.log(`\nAll ${targets.length} route(s) rendered their content.`)
+}
+
+main().catch((err) => {
+  console.error("kitesurf: " + (err?.message ?? String(err)))
+  exit(1)
+})

--- a/scripts/kitesurf.mjs
+++ b/scripts/kitesurf.mjs
@@ -118,6 +118,47 @@ function body(markdown) {
   return markdown.replace(/^---\n[\s\S]*?\n---\n/, "")
 }
 
+/**
+ * On a failure, tell "the page rendered empty" apart from "you were never
+ * looking at the page".
+ *
+ * Pointing `--base` at a Vercel preview renders **Vercel's login page** — the
+ * deployment sits behind SSO, so `/tokens` 302s off-origin and the browser
+ * faithfully returns 2,035 characters of "Log in to Vercel". The expectation
+ * then fails and, without this, the script reports the chrome-around-a-hole
+ * message: the checker blaming the site for the checker's own problem. That is
+ * the same mistake as expecting a capitalised `Malachite`, and it is worth
+ * catching in code rather than in a doc nobody reads mid-debugging.
+ *
+ * An off-origin redirect is the general signal — it covers Vercel SSO,
+ * Cloudflare Access and any other auth wall without naming a vendor. A
+ * same-origin redirect is not reported, because this site has legitimate ones
+ * (`/architecture/layers/:n` → `/architecture/nodes/:n`).
+ *
+ * Only runs on failure, so the happy path still costs one request per route.
+ * Best-effort: a probe that itself fails must not replace the real result.
+ */
+async function diagnose(url) {
+  try {
+    const res = await fetch(url, { redirect: "manual" })
+    const location = res.headers.get("location")
+    if (location) {
+      const target = new URL(location, url)
+      if (target.origin !== new URL(url).origin) {
+        return (
+          `the URL redirects off-origin to ${target.origin}, so the browser rendered ` +
+          `that page rather than this route — an auth wall (Vercel SSO, Cloudflare ` +
+          `Access, …), not an empty page. This route cannot be checked without a bypass token.`
+        )
+      }
+    }
+    if (!res.ok && res.status < 300) return `the URL answers HTTP ${res.status}.`
+  } catch {
+    // A failed probe is not evidence of anything; fall through to the plain report.
+  }
+  return null
+}
+
 async function render(url) {
   const res = await fetch(`${API}/markdown?browser=kitesurf`, {
     method: "POST",
@@ -170,11 +211,14 @@ async function main() {
       continue
     }
     if (!result.text.includes(route.expect)) {
+      const reason = await diagnose(base + route.path)
       console.error(
         `✗ ${route.path}\n    rendered ${result.text.length} chars of prose, but not ` +
           `${JSON.stringify(route.expect)}.\n` +
-          `    That is the chrome-around-a-hole shape: the frame rendered, its content did not.\n` +
-          `    \`pnpm browser:check --text ${route.path}\` shows what it did render.`
+          (reason
+            ? `    NOT a rendering failure — ${reason}`
+            : `    That is the chrome-around-a-hole shape: the frame rendered, its content did not.`) +
+          `\n    \`pnpm browser:check --text ${route.path}\` shows what it did render.`
       )
       failed++
       continue


### PR DESCRIPTION
Adds `pnpm browser:check`: renders pages through Cloudflare **Kitesurf** and asserts each one produced its own content. Kitesurf becomes part of the dev setup, and the same capability is reachable from fundi.

## Why

`/changelog/{name}` served page chrome with **no article body** in production. Every gate was green — typecheck, lint, tests, build — and the route answered HTTP 200 with ~140 KB of HTML. `new Date(undefined).toISOString()` threw inside the article and React swallowed it into an empty region, with the header, sidebar and footer rendering around the hole.

A status code says 200 and a byte count says 140 KB. Both were true and neither was useful. Nothing offline closes that gap: a unit test renders a component in jsdom rather than the deployed page, and `pnpm build` proves a route compiles rather than that it paints.

## Why a `fetch` and not Playwright

This is a requirement, not a preference. **fundi is a Cloudflare Worker and cannot spawn a browser process**, so a local-browser checker would serve developers and be useless to the N9 rung that most needs it. Browser Run is reachable identically from a laptop, from CI, and from inside the heal loop — from a Worker via `env.BROWSER.quickAction()`, which needs **no API token at all**.

Verified rather than assumed: `quickAction()` requires `compatibility_date >= 2026-03-24` and `fundi-tester` is on `2026-05-22`, so that path needs no bump and no flag.

## Three bugs the first version shipped with

All recorded in the file header, because each is a trap the next person walks into.

1. **It read `<main>`.** On this site `<main>` wraps the **sidebar** — the button page's content sits outside it and `</main>` closes at character 61,535 of 140,113. Every page reported ~600 characters of identical navigation and a green tick. Five very different pages agreeing to within 11 characters was the tell.
2. **It stripped tags with `/<[^>]+>/g`.** Tailwind arbitrary variants put `>` inside attribute values — `class="[&>svg]:size-4"` — so the regex cut in the wrong place and leaked class names into the "visible text". Same family as the `=>` trap already documented in `extract-props.ts`.
3. **It measured text LENGTH.** A threshold cannot tell content from chrome, so it green-ticked navigation.

Switching from `/content` to `/markdown` removes 1 and 2 by construction — extraction happens in the browser's own context — and leaves the script with **zero dependencies**. Each route now asserts a string only its own body can produce.

**The frontmatter strip is load-bearing, not tidying.** `/markdown` prefixes a YAML block built from the page's `<meta>` tags, and two of the five expectations appear in it. Matching the raw response would green-tick a page whose body rendered nothing — the exact failure this exists to catch, reintroduced through the front door.

A fourth, caught during review of my own work: `/tokens` expected `Malachite`. The page renders `malachite`, per §7.2. That failure was a brittle assertion reporting its author's assumption as the site's defect.

## Kitesurf capability boundary

Verified against `mzizi.dev`. `/markdown`, `/content`, `/accessibilityTree` and `/screenshot` work; `/scrape` and `/links` answer `Action "…" is not supported by the kitesurf browser`. That refusal is a capability boundary, not a transient error — drop `?browser=kitesurf` and pay for Chromium if one is ever needed.

## What it deliberately does not check

- **Contrast and colour.** Kitesurf trades CSS exactness for cost, so a computed style from it cannot gate the APCA floor.
- **The live component previews.** They mount client-side and Kitesurf returns before they resolve, so every page shows `Loading preview…`. A limit of the check, not a defect on the page — asserting on it would produce a failure nobody could fix.

## Not in CI yet, and why

It needs a Cloudflare token, so a missing secret would read as a broken build on every fork and every outside PR. A red check everyone learns to ignore is worse than no check. The recorded sequence: run against production after deploy, wire into `ci.yml` once the secret is provisioned and the route set has settled.

## Verification

```
✓ /components/button  found "Polymorphic rendering via asChild" (3633 chars)
✓ /changelog/button   found "backfilled from existing design system" (3258 chars)
✓ /tokens             found "malachite" (6665 chars)
✓ /architecture       found "Two backbones. Cross-cutting rungs. No axes." (11407 chars)
✓ /                   found "Ndiri nekuti tiri" (13484 chars)

All 5 route(s) rendered their content.
```

Varied character counts are themselves the signal that extraction is correct — the false-green version reported ~600 identical chars on all five.

`pnpm typecheck`, `pnpm lint` and `pnpm audit` pass (pre-commit gates). No dependency added; `package.json` gains one script line and `pnpm-lock.yaml` is untouched.

## Files

| File | |
| --- | --- |
| `scripts/kitesurf.mjs` | new — the check, zero dependencies |
| `docs/browser-checks.md` | new — source of truth: dev setup, adding a route, the fundi/Worker path, limits |
| `CLAUDE.md` | §4 command + new §13.1 summary |
| `package.json` | `browser:check` script |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED


---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_