### PR TITLE
feat(n8): mzizi-otel — assurance signals report back over OpenTelemetry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1317,6 +1317,58 @@ Without `CLOUDFLARE_API_TOKEN` it skips loudly and exits 0 — visibly, never
 looking like a green run. It is not in `ci.yml` yet for that reason: a check that
 reads as broken on every fork is one everyone learns to ignore.
 
+**It reports through N8, and the protocol is OTLP** — see §13.2.
+
+### 13.2 N8 assurance telemetry — the sink is OpenTelemetry
+
+> **Source of truth:** `docs/n8-telemetry.md`. This is the summary.
+
+N8's covenant is "what breaks is seen before users feel it", and five of its
+components (`mzizi-synthetic-probe`, `mzizi-rum`, `mzizi-error-tracker`,
+`mzizi-alert-engine`, and the browser check) ended in a callback with **no sink
+behind it** — so a signal was seen by whoever installed the component and by
+nobody else. `mzizi-otel` is that sink.
+
+**The protocol is OTLP, and that choice is load-bearing: a signal only fundi can
+read is a signal only fundi can act on.** A `mzizi.dev/api/assurance` route would
+make Mzizi the only possible consumer and require shipping a client for every
+service that later wants in. OpenTelemetry is what collectors, backends and agent
+runtimes already speak, so an assurance event is subscribable by services this
+repo does not know exist.
+
+Rules, each of them a defect that shipped:
+
+- **No default endpoint, ever.** `mzizi-rum` defaulted to
+  `https://mzizi.dev/api/rum` — a route that returns **404** and has never
+  existed — inside a `catch` that correctly swallows delivery failures. Every
+  consumer who installed RUM without setting an endpoint was posting into a void
+  that looked exactly like working RUM. Unset now means "do not POST".
+- **Telemetry never changes the caller's verdict.** A probe reporting "failed"
+  because its collector was unreachable manufactures an incident out of an
+  exporter outage. The exporter never throws and returns
+  `{ exported: false, reason }`.
+- **No `@opentelemetry/*` dependency.** OTLP/HTTP JSON is a documented wire
+  format; the SDK assumes a Node runtime and **fundi is a Worker**. A hand-built
+  payload runs unchanged in Node, a Worker, Deno and a browser, and keeps the
+  component independently installable (§15.6). The cost — no context
+  propagation, batching or retry — is stated in the file: this carries discrete
+  assurance events, not request traces.
+- **`OTEL_EXPORTER_OTLP_ENDPOINT` is a base** (gets `/v1/traces` appended);
+  **`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is complete** (used verbatim). The
+  asymmetry is the spec's; appending to the second yields `/v1/traces/v1/traces`.
+- **Wire shape is tested, not eyeballed.** A malformed OTLP body fails silently —
+  200 back, span dropped, empty dashboard. `__tests__/lib/otel.test.ts` asserts
+  32/16-hex ids, integer **nanosecond strings** (JSON has no int64), typed
+  attribute values, and ERROR status on the run plus the failing step only.
+- **`mzizi.*` for Mzizi facts.** Mzizi-specific attributes do not squat on OTel
+  semantic-convention names.
+
+**Not yet wired, stated plainly:** no collector is configured anywhere in the
+ecosystem, so `browser:check` reports `not reported — no OTLP endpoint
+configured` today. §17's diagram claims a loop whose RPCs
+(`record_observability_event`, `create_fundi_issue`) have **zero call sites in
+this repo** — this adds the emitter and the protocol, not the closed loop.
+
 ---
 
 ## 14. CI/CD & Versioning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -892,7 +892,23 @@ The portal dogfoods its own registry. The transitive closure of the brand compon
 }
 ```
 
-### 8.9 Multi-target — mobile-first, Rust-first, and who gets components vs instructions
+**`files[].path` here is CONSUMER-shaped, not repo-shaped, and that is deliberate.**
+`"components/ui/button.tsx"` is where the shadcn CLI writes the file in **someone
+else's** project. In this repo the same component lives at
+`components/registry/n2-primitives/button.tsx`, and `lib/registry.ts` resolves it
+by **name + node directory** — never by walking `path`. Two different questions,
+two different answers; reading `path` as a repo path is how a "file not found"
+gets chased in the wrong tree.
+
+**`target` is the field that would make the destination explicit, and no item
+uses it** — 0 of 573. The CLI derives the destination from `type` when `target`
+is absent (`registry:ui` → `components/ui/`, `registry:lib` → `lib/`, …), and
+because our `path` values already match what that derivation produces, installs
+land correctly. So this is **not** a live defect, and it is written down because
+it is the kind that becomes one silently: the moment an item needs a destination
+the `type` derivation does not produce — anything outside the conventional
+directory for its type — `target` is the field to set, and `path` is not a
+substitute for it.
 
 Mzizi is **mobile-first**. Next.js/React is still here and still shipping, but the direction is
 **Rust across the stack**, with first-class native targets: **Swift** (iOS/macOS), **Kotlin**

--- a/__tests__/lib/otel.test.ts
+++ b/__tests__/lib/otel.test.ts
@@ -1,0 +1,265 @@
+/**
+ * The OTLP payload is an EXTERNAL contract, which is why it is tested rather
+ * than eyeballed.
+ *
+ * Everything else in this repo that goes wrong goes wrong loudly — a type
+ * error, a failed build, a red route. A malformed OTLP body does not: the POST
+ * returns 200 or the collector drops the span silently, and the first anyone
+ * knows is that a dashboard is empty. So the shape details that a collector
+ * rejects — id lengths, nanosecond strings, typed attribute values — are
+ * asserted here.
+ */
+
+import { describe, expect, it, vi, afterEach } from "vitest"
+import {
+  buildTracePayload,
+  exportSpans,
+  newSpanId,
+  newTraceId,
+  probeResultToSpans,
+  otelSpanKind,
+  otelStatus,
+  type OtelConfig,
+} from "@/components/registry/n8-assurance/mzizi-otel"
+import type { ProbeResult } from "@/components/registry/n8-assurance/mzizi-synthetic-probe"
+
+const CONFIG: OtelConfig = { serviceName: "test-service", endpoint: "https://collector.test" }
+
+const PASSING: ProbeResult = {
+  journeyId: "mzizi-browser-render",
+  timestamp: "2026-08-08T03:00:00.000Z",
+  region: "cloudflare-edge",
+  status: "pass",
+  durationMs: 1200,
+  steps: [
+    { description: "/tokens", status: "pass", durationMs: 500 },
+    { description: "/architecture", status: "pass", durationMs: 700 },
+  ],
+}
+
+const FAILING: ProbeResult = {
+  ...PASSING,
+  status: "fail",
+  steps: [
+    { description: "/tokens", status: "pass", durationMs: 500 },
+    { description: "/changelog/button", status: "fail", durationMs: 700, error: "missing body" },
+  ],
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe("ids", () => {
+  it("mints a 32-hex-char trace id and a 16-hex-char span id", () => {
+    // A collector rejects any other length outright, and the failure is a
+    // dropped span rather than an error the caller sees.
+    expect(newTraceId()).toMatch(/^[0-9a-f]{32}$/)
+    expect(newSpanId()).toMatch(/^[0-9a-f]{16}$/)
+  })
+
+  it("does not repeat", () => {
+    const ids = new Set(Array.from({ length: 200 }, newTraceId))
+    expect(ids.size).toBe(200)
+  })
+})
+
+describe("payload shape", () => {
+  const payload = buildTracePayload(probeResultToSpans(PASSING), CONFIG, newTraceId())
+  const scope = payload.resourceSpans[0].scopeSpans[0]
+  const attrsOf = (list: { key: string; value: Record<string, unknown> }[]) =>
+    Object.fromEntries(list.map((a) => [a.key, Object.values(a.value)[0]]))
+
+  it("carries service.name on the resource", () => {
+    expect(attrsOf(payload.resourceSpans[0].resource.attributes)["service.name"]).toBe(
+      "test-service"
+    )
+  })
+
+  it("writes timestamps as integer nanosecond STRINGS", () => {
+    // JSON has no int64. A number here loses precision above 2^53, which is
+    // exactly where a nanosecond timestamp sits, so the mapping is a string.
+    for (const span of scope.spans) {
+      expect(span.startTimeUnixNano).toMatch(/^\d+$/)
+      expect(span.endTimeUnixNano).toMatch(/^\d+$/)
+      expect(Number(span.endTimeUnixNano)).toBeGreaterThanOrEqual(Number(span.startTimeUnixNano))
+      // Milliseconds where nanoseconds belong is the classic slip and puts the
+      // span in 1970, where nobody looks for it.
+      expect(Number(span.startTimeUnixNano)).toBeGreaterThan(1.7e18)
+    }
+  })
+
+  it("tags every attribute with exactly one OTLP type", () => {
+    for (const span of scope.spans) {
+      for (const attr of span.attributes) {
+        const keys = Object.keys(attr.value)
+        expect(keys).toHaveLength(1)
+        expect(["stringValue", "intValue", "doubleValue", "boolValue"]).toContain(keys[0])
+      }
+    }
+  })
+
+  it("sends integers as strings and non-integers as doubles", () => {
+    const run = scope.spans[0]
+    const node = run.attributes.find((a) => a.key === "mzizi.node")
+    expect(node?.value).toEqual({ intValue: "8" })
+
+    const built = buildTracePayload(
+      [{ name: "x", startTimeMs: 0, endTimeMs: 1, attributes: { ratio: 0.5, on: true } }],
+      CONFIG,
+      newTraceId()
+    )
+    const attrs = built.resourceSpans[0].scopeSpans[0].spans[0].attributes
+    expect(attrs.find((a) => a.key === "ratio")?.value).toEqual({ doubleValue: 0.5 })
+    expect(attrs.find((a) => a.key === "on")?.value).toEqual({ boolValue: true })
+  })
+
+  it("omits undefined attributes rather than sending null", () => {
+    const built = buildTracePayload(
+      [
+        {
+          name: "x",
+          startTimeMs: 0,
+          endTimeMs: 1,
+          attributes: { present: "y", absent: undefined },
+        },
+      ],
+      CONFIG,
+      newTraceId()
+    )
+    const keys = built.resourceSpans[0].scopeSpans[0].spans[0].attributes.map((a) => a.key)
+    expect(keys).toContain("present")
+    expect(keys).not.toContain("absent")
+  })
+
+  it("puts every span of one run under one trace id", () => {
+    const ids = new Set(scope.spans.map((s) => s.traceId))
+    expect(ids.size).toBe(1)
+  })
+})
+
+describe("ProbeResult -> spans", () => {
+  it("emits one run span plus one child per step", () => {
+    const spans = probeResultToSpans(PASSING)
+    expect(spans).toHaveLength(3)
+    const [run, ...steps] = spans
+    expect(run.parentSpanId).toBeUndefined()
+    for (const step of steps) expect(step.parentSpanId).toBe(run.spanId)
+  })
+
+  it("marks the run INTERNAL and each step CLIENT", () => {
+    // A step calls something external, the run calls nothing. Reversing these
+    // makes a collector draw service-dependency edges that do not exist.
+    const [run, ...steps] = probeResultToSpans(PASSING)
+    expect(run.kind).toBe(otelSpanKind.INTERNAL)
+    for (const step of steps) expect(step.kind).toBe(otelSpanKind.CLIENT)
+  })
+
+  it("reports OK on a passing run", () => {
+    for (const span of probeResultToSpans(PASSING)) {
+      expect(span.status?.code).toBe(otelStatus.OK)
+    }
+  })
+
+  it("reports ERROR on the run AND on the failing step only", () => {
+    // This is the case fundi acts on, so it is the one that must not silently
+    // come through as UNSET.
+    const [run, passed, failedStep] = probeResultToSpans(FAILING)
+    expect(run.status?.code).toBe(otelStatus.ERROR)
+    expect(passed.status?.code).toBe(otelStatus.OK)
+    expect(failedStep.status?.code).toBe(otelStatus.ERROR)
+    expect(failedStep.status?.message).toBe("missing body")
+  })
+
+  it("carries the failure reason as error.message so a consumer need not parse prose", () => {
+    const [, , failedStep] = probeResultToSpans(FAILING)
+    expect(failedStep.attributes?.["error.message"]).toBe("missing body")
+  })
+
+  it("counts failed steps on the run span", () => {
+    const [run] = probeResultToSpans(FAILING)
+    expect(run.attributes?.["mzizi.probe.steps"]).toBe(2)
+    expect(run.attributes?.["mzizi.probe.steps_failed"]).toBe(1)
+    expect(run.attributes?.["mzizi.node"]).toBe(8)
+  })
+
+  it("merges caller-supplied attributes onto the run span", () => {
+    const [run] = probeResultToSpans(PASSING, { "mzizi.check": "browser-render" })
+    expect(run.attributes?.["mzizi.check"]).toBe("browser-render")
+  })
+})
+
+describe("endpoint resolution", () => {
+  it("appends /v1/traces to a BASE endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }))
+    vi.stubGlobal("fetch", fetchMock)
+    await exportSpans(probeResultToSpans(PASSING), CONFIG)
+    expect(fetchMock.mock.calls[0][0]).toBe("https://collector.test/v1/traces")
+  })
+
+  it("uses a TRACES endpoint verbatim", async () => {
+    // The asymmetry is the OTLP spec's, and getting it wrong yields
+    // /v1/traces/v1/traces — a 404 that reads like a broken collector.
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }))
+    vi.stubGlobal("fetch", fetchMock)
+    await exportSpans(probeResultToSpans(PASSING), {
+      serviceName: "s",
+      tracesEndpoint: "https://collector.test/custom/path",
+    })
+    expect(fetchMock.mock.calls[0][0]).toBe("https://collector.test/custom/path")
+  })
+
+  it("does not double up a trailing slash", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }))
+    vi.stubGlobal("fetch", fetchMock)
+    await exportSpans(probeResultToSpans(PASSING), {
+      serviceName: "s",
+      endpoint: "https://collector.test/",
+    })
+    expect(fetchMock.mock.calls[0][0]).toBe("https://collector.test/v1/traces")
+  })
+})
+
+describe("failure handling — never throws, never changes the verdict", () => {
+  it("is inert with no endpoint, and sends nothing", async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+    const outcome = await exportSpans(probeResultToSpans(PASSING), { serviceName: "s" })
+    expect(outcome.exported).toBe(false)
+    expect(outcome.reason).toContain("OTEL_EXPORTER_OTLP_ENDPOINT")
+    // Most consumers run no collector. Inert must mean inert — not a failed
+    // request to a guessed address.
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("reports a collector error without throwing", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("nope", { status: 503 })))
+    const outcome = await exportSpans(probeResultToSpans(PASSING), CONFIG)
+    expect(outcome.exported).toBe(false)
+    expect(outcome.status).toBe(503)
+    expect(outcome.reason).toContain("503")
+  })
+
+  it("reports a network failure without throwing", async () => {
+    // A probe that failed because its telemetry sink was down would manufacture
+    // an incident out of an exporter outage.
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")))
+    const outcome = await exportSpans(probeResultToSpans(PASSING), CONFIG)
+    expect(outcome.exported).toBe(false)
+    expect(outcome.reason).toContain("ECONNREFUSED")
+  })
+
+  it("says so when there is nothing to send", async () => {
+    const outcome = await exportSpans([], CONFIG)
+    expect(outcome).toMatchObject({ exported: false, spanCount: 0 })
+  })
+
+  it("posts JSON with the declared content type", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }))
+    vi.stubGlobal("fetch", fetchMock)
+    await exportSpans(probeResultToSpans(PASSING), { ...CONFIG, headers: { "X-Key": "abc" } })
+    const init = fetchMock.mock.calls[0][1]
+    expect(init.method).toBe("POST")
+    expect(init.headers["Content-Type"]).toBe("application/json")
+    expect(init.headers["X-Key"]).toBe("abc")
+    expect(() => JSON.parse(init.body)).not.toThrow()
+  })
+})

--- a/components/registry/n8-assurance/mzizi-error-tracker.ts
+++ b/components/registry/n8-assurance/mzizi-error-tracker.ts
@@ -36,9 +36,36 @@ export interface ErrorTrackerConfig {
   onCritical?: (error: TrackedError) => void
 }
 
-// N9 fundi integration: Critical errors are reported to Fundi via GitHub issues
-// import { getFundiReporter } from "@/lib/fundi/nyuchi-fundi-reporter"
-// On critical error: getFundiReporter().report({ component, node, severity, errorType, source: "error-tracker", ... })
+// N9 fundi integration — how a critical error actually reaches the rung.
+//
+// This block used to point at `@/lib/fundi/nyuchi-fundi-reporter`, which does not
+// exist in this repo and never has, so the one instruction here for getting a
+// signal out named a file nobody could install.
+//
+// The sink is `mzizi-otel` (N8): give `onCritical` an exporter and the error
+// leaves as an OTLP span that fundi — or any other agent or service that speaks
+// OpenTelemetry — can subscribe to. A bespoke reporter would have been readable
+// by fundi alone.
+//
+//   import { exportSpans, otelStatus } from "./mzizi-otel"
+//
+//   createErrorTracker({
+//     onCritical: (e) => exportSpans(
+//       [{
+//         name: `error ${e.componentName ?? "unknown"}`,
+//         startTimeMs: Date.parse(e.firstSeen),
+//         endTimeMs: Date.parse(e.lastSeen),
+//         attributes: {
+//           "mzizi.node": e.node ?? 8,
+//           "mzizi.component": e.componentName,
+//           "mzizi.blast_radius": e.blastRadius.length,
+//           "error.message": e.message,
+//         },
+//         status: { code: otelStatus.ERROR, message: e.message },
+//       }],
+//       { serviceName: "my-app" },
+//     ),
+//   })
 
 class ErrorTrackerCore {
   private errors = new Map<string, TrackedError>()

--- a/components/registry/n8-assurance/mzizi-error-tracker.ts
+++ b/components/registry/n8-assurance/mzizi-error-tracker.ts
@@ -36,36 +36,58 @@ export interface ErrorTrackerConfig {
   onCritical?: (error: TrackedError) => void
 }
 
-// N9 fundi integration — how a critical error actually reaches the rung.
+// A critical error has TWO exits, and they are not alternatives.
 //
-// This block used to point at `@/lib/fundi/nyuchi-fundi-reporter`, which does not
-// exist in this repo and never has, so the one instruction here for getting a
-// signal out named a file nobody could install.
+// The import path here used to read `@/lib/fundi/nyuchi-fundi-reporter`, one
+// directory off: `nyuchi-fundi-reporter` (N9) is a real registry component and
+// the shadcn CLI installs it to `lib/nyuchi-fundi-reporter.ts`. Wrong path, real
+// file — so the fix is the path, not the pointer.
 //
-// The sink is `mzizi-otel` (N8): give `onCritical` an exporter and the error
-// leaves as an OTLP span that fundi — or any other agent or service that speaks
-// OpenTelemetry — can subscribe to. A bespoke reporter would have been readable
-// by fundi alone.
+//   1. N9 fundi — files a GitHub issue, deduplicated by a per-component cooldown.
+//      This is the healing path: a named defect a human can merge a fix for.
 //
-//   import { exportSpans, otelStatus } from "./mzizi-otel"
+//        import { getFundiReporter } from "@/lib/nyuchi-fundi-reporter"
 //
-//   createErrorTracker({
-//     onCritical: (e) => exportSpans(
-//       [{
-//         name: `error ${e.componentName ?? "unknown"}`,
-//         startTimeMs: Date.parse(e.firstSeen),
-//         endTimeMs: Date.parse(e.lastSeen),
-//         attributes: {
-//           "mzizi.node": e.node ?? 8,
-//           "mzizi.component": e.componentName,
-//           "mzizi.blast_radius": e.blastRadius.length,
-//           "error.message": e.message,
-//         },
-//         status: { code: otelStatus.ERROR, message: e.message },
-//       }],
-//       { serviceName: "my-app" },
-//     ),
-//   })
+//        createErrorTracker({
+//          onCritical: (e) => getFundiReporter().report({
+//            component: e.componentName ?? "unknown",
+//            node: e.node ?? 8,
+//            severity: e.severity,
+//            errorType: "render",
+//            source: "error-tracker",
+//            title: e.message,
+//            description: e.stack ?? e.message,
+//            blastRadius: e.blastRadius,
+//          }),
+//        })
+//
+//   2. N8 mzizi-otel — emits an OTLP span. This is the observation path: every
+//      error, not just the critical ones, readable by any agent or service that
+//      speaks OpenTelemetry rather than by fundi alone.
+//
+//        import { exportSpans, otelStatus } from "./mzizi-otel"
+//
+//        createErrorTracker({
+//          onError: (e) => exportSpans(
+//            [{
+//              name: `error ${e.componentName ?? "unknown"}`,
+//              startTimeMs: Date.parse(e.firstSeen),
+//              endTimeMs: Date.parse(e.lastSeen),
+//              attributes: {
+//                "mzizi.node": e.node ?? 8,
+//                "mzizi.component": e.componentName,
+//                "mzizi.blast_radius": e.blastRadius.length,
+//                "error.message": e.message,
+//              },
+//              status: { code: otelStatus.ERROR, message: e.message },
+//            }],
+//            { serviceName: "my-app" },
+//          ),
+//        })
+//
+// Wire both. Reporting every error to N9 would open an issue per render failure;
+// emitting only to OTLP means nothing ever gets fixed unless somebody is watching
+// a dashboard.
 
 class ErrorTrackerCore {
   private errors = new Map<string, TrackedError>()

--- a/components/registry/n8-assurance/mzizi-otel.ts
+++ b/components/registry/n8-assurance/mzizi-otel.ts
@@ -1,0 +1,352 @@
+/* ═══════════════════════════════════════════════════════════════
+   MZIZI OTEL — N8 assurance (a node on the engineering strand)
+   The sink. Exports assurance signals over OTLP so anything that
+   speaks OpenTelemetry can pick them up.
+   ═══════════════════════════════════════════════════════════════ */
+
+/**
+ * WHY THIS EXISTS.
+ *
+ * N8's covenant is "what breaks is seen before users feel it." Every other N8
+ * component was built to that covenant and stops one step short of it:
+ * `mzizi-synthetic-probe` has `onResult`/`onAlert`, `mzizi-rum` has
+ * `onEvent`/`onFlush`, `mzizi-error-tracker` has `onError`/`onCritical`,
+ * `mzizi-alert-engine` has its handlers. Five callback surfaces, and **no sink
+ * behind any of them** — so a signal is seen by whoever installed the component
+ * and by nobody else. `mzizi-rum`'s default `endpoint` is
+ * `https://mzizi.dev/api/rum`, a route that does not exist.
+ *
+ * This is that sink, and it is OTLP rather than a bespoke Mzizi endpoint for one
+ * reason: a signal that only fundi can read is a signal only fundi can act on.
+ * OTLP is the protocol every collector, tracing backend and agent runtime
+ * already speaks, so "the changelog route stopped rendering" becomes an event
+ * any service can subscribe to without Mzizi shipping a client for each one.
+ *
+ * WHY NO @opentelemetry/* DEPENDENCY.
+ *
+ * OTLP/HTTP with a JSON payload is a documented wire format — a POST with a
+ * specific body shape. The JS SDK adds a large dependency tree, and the pieces
+ * that matter here (BatchSpanProcessor, NodeTracerProvider) assume a Node
+ * runtime. **fundi is a Cloudflare Worker**, and consumer apps install this file
+ * into projects whose runtime is not ours to choose. A hand-built payload runs
+ * unchanged in Node, in a Worker, in a browser and in Deno, and keeps this file
+ * independently installable, which the registry requires.
+ *
+ * The tradeoff is real and worth stating: no automatic context propagation, no
+ * batching queue, no retry/backoff. This is for discrete assurance events —
+ * probe runs, tracked errors, fired alerts — not for tracing a request path. If
+ * you need distributed tracing, use the SDK.
+ */
+
+import type { ProbeResult } from "./mzizi-synthetic-probe"
+
+/**
+ * Span status. OTLP's own enum — 0 UNSET, 1 OK, 2 ERROR.
+ * Named rather than inlined, because a bare `2` in a payload is unreadable and
+ * the two non-zero values are easy to transpose.
+ */
+const STATUS_UNSET = 0
+const STATUS_OK = 1
+const STATUS_ERROR = 2
+
+/** SPAN_KIND_CLIENT — this process called something else and timed it. */
+const SPAN_KIND_CLIENT = 3
+/** SPAN_KIND_INTERNAL — the run itself, which called nothing. */
+const SPAN_KIND_INTERNAL = 1
+
+export type AttributeValue = string | number | boolean
+
+export interface OtelConfig {
+  /**
+   * OTLP base endpoint, e.g. `https://collector.example.com`. The signal path
+   * (`/v1/traces`) is appended, per the OTLP spec.
+   *
+   * Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT` where an environment is
+   * readable. **There is no default endpoint**: inventing one would send a
+   * consumer's telemetry somewhere they never chose.
+   */
+  endpoint?: string
+  /**
+   * Full traces endpoint, used verbatim with **no** `/v1/traces` appended.
+   *
+   * This asymmetry is the spec's, not ours, and it is the detail people get
+   * wrong: `OTEL_EXPORTER_OTLP_ENDPOINT` is a base that gets the signal path
+   * added, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is already complete. Appending
+   * to the second produces `/v1/traces/v1/traces` and a 404 that reads like a
+   * broken collector.
+   */
+  tracesEndpoint?: string
+  /** Extra headers — an API key, a tenant id. */
+  headers?: Record<string, string>
+  /** `service.name`. Required by the OTel resource conventions. */
+  serviceName: string
+  serviceVersion?: string
+  /** Deployment environment, e.g. `production`, `preview`, `local`. */
+  environment?: string
+  /** Milliseconds before the export is abandoned. Default 10_000. */
+  timeoutMs?: number
+}
+
+export interface OtelSpan {
+  name: string
+  kind?: number
+  startTimeMs: number
+  endTimeMs: number
+  attributes?: Record<string, AttributeValue | undefined>
+  status?: { code: number; message?: string }
+  /** 16-hex-char id. Generated when absent. */
+  spanId?: string
+  parentSpanId?: string
+}
+
+export interface ExportOutcome {
+  /** False when nothing was sent — including the deliberate no-endpoint case. */
+  exported: boolean
+  /** Why nothing was sent, or why the POST failed. Never thrown. */
+  reason?: string
+  status?: number
+  spanCount: number
+  traceId?: string
+}
+
+/* ── ids ──────────────────────────────────────────────────────── */
+
+/**
+ * `crypto.getRandomValues` is present in Node 20+, Workers, Deno and browsers,
+ * which is the whole runtime set this file targets. `Math.random()` would also
+ * "work" and is wrong: trace ids are correlation keys across services, and a
+ * predictable one lets an unrelated caller collide with, or forge, a trace.
+ */
+function randomHex(bytes: number): string {
+  const buf = new Uint8Array(bytes)
+  crypto.getRandomValues(buf)
+  let out = ""
+  for (const b of buf) out += b.toString(16).padStart(2, "0")
+  return out
+}
+
+/** 16 bytes → 32 hex chars. Anything else is rejected by collectors. */
+export const newTraceId = (): string => randomHex(16)
+/** 8 bytes → 16 hex chars. */
+export const newSpanId = (): string => randomHex(8)
+
+/* ── payload ──────────────────────────────────────────────────── */
+
+/**
+ * OTLP tags every attribute with its type; a bare JSON value is not accepted.
+ * Integers cross the wire as STRINGS because JSON cannot hold an int64 exactly
+ * — a float64 silently loses precision above 2^53, which is where a nanosecond
+ * timestamp lives.
+ */
+function toAnyValue(value: AttributeValue) {
+  if (typeof value === "boolean") return { boolValue: value }
+  if (typeof value === "number") {
+    return Number.isInteger(value) ? { intValue: String(value) } : { doubleValue: value }
+  }
+  return { stringValue: value }
+}
+
+function toAttributes(attrs: Record<string, AttributeValue | undefined> = {}) {
+  return Object.entries(attrs)
+    .filter(([, v]) => v !== undefined)
+    .map(([key, value]) => ({ key, value: toAnyValue(value as AttributeValue) }))
+}
+
+/** Milliseconds (possibly fractional) → an integer nanosecond string. */
+function toUnixNano(ms: number): string {
+  return String(Math.round(ms * 1e6))
+}
+
+/** Build the OTLP/HTTP JSON body. Exported so a caller can inspect or queue it. */
+export function buildTracePayload(spans: OtelSpan[], config: OtelConfig, traceId: string) {
+  return {
+    resourceSpans: [
+      {
+        resource: {
+          attributes: toAttributes({
+            "service.name": config.serviceName,
+            "service.version": config.serviceVersion,
+            "deployment.environment.name": config.environment,
+            "telemetry.sdk.name": "mzizi-otel",
+            "telemetry.sdk.language": "webjs",
+          }),
+        },
+        scopeSpans: [
+          {
+            scope: { name: "mzizi.n8.assurance" },
+            spans: spans.map((span) => ({
+              traceId,
+              spanId: span.spanId ?? newSpanId(),
+              ...(span.parentSpanId ? { parentSpanId: span.parentSpanId } : {}),
+              name: span.name,
+              kind: span.kind ?? SPAN_KIND_INTERNAL,
+              startTimeUnixNano: toUnixNano(span.startTimeMs),
+              endTimeUnixNano: toUnixNano(span.endTimeMs),
+              attributes: toAttributes(span.attributes),
+              status: span.status ?? { code: STATUS_UNSET },
+            })),
+          },
+        ],
+      },
+    ],
+  }
+}
+
+/* ── export ───────────────────────────────────────────────────── */
+
+/** Read an env var without assuming `process` exists (it does not in a Worker). */
+function readEnv(name: string): string | undefined {
+  const proc = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process
+  return proc?.env?.[name]
+}
+
+function resolveTracesUrl(config: OtelConfig): string | undefined {
+  const explicit = config.tracesEndpoint ?? readEnv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+  if (explicit) return explicit
+  const base = config.endpoint ?? readEnv("OTEL_EXPORTER_OTLP_ENDPOINT")
+  if (!base) return undefined
+  return `${base.replace(/\/$/, "")}/v1/traces`
+}
+
+/**
+ * POST spans to the collector.
+ *
+ * **Never throws, and never changes its caller's verdict.** A probe that reports
+ * "failed" because its telemetry sink was unreachable is worse than one that
+ * reports nothing: it manufactures an incident out of an exporter outage. Every
+ * failure path returns `exported: false` with a reason, and the caller decides
+ * whether that is worth surfacing.
+ *
+ * A missing endpoint is a normal outcome, not an error — most consumers will not
+ * run a collector, and this must be inert for them rather than noisy.
+ */
+export async function exportSpans(spans: OtelSpan[], config: OtelConfig): Promise<ExportOutcome> {
+  if (spans.length === 0) return { exported: false, reason: "no spans", spanCount: 0 }
+
+  const url = resolveTracesUrl(config)
+  if (!url) {
+    return {
+      exported: false,
+      reason:
+        "no OTLP endpoint configured (set OTEL_EXPORTER_OTLP_ENDPOINT or pass `endpoint`) — nothing was sent",
+      spanCount: spans.length,
+    }
+  }
+
+  const traceId = newTraceId()
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), config.timeoutMs ?? 10_000)
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...config.headers },
+      body: JSON.stringify(buildTracePayload(spans, config, traceId)),
+      signal: controller.signal,
+    })
+    if (!res.ok) {
+      return {
+        exported: false,
+        reason: `collector answered HTTP ${res.status}`,
+        status: res.status,
+        spanCount: spans.length,
+        traceId,
+      }
+    }
+    return { exported: true, status: res.status, spanCount: spans.length, traceId }
+  } catch (err) {
+    const aborted = err instanceof Error && err.name === "AbortError"
+    return {
+      exported: false,
+      reason: aborted ? `export timed out after ${config.timeoutMs ?? 10_000}ms` : String(err),
+      spanCount: spans.length,
+      traceId,
+    }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/* ── the N8 probe bridge ──────────────────────────────────────── */
+
+/**
+ * Turn a `ProbeResult` into spans: one for the run, one child per step.
+ *
+ * The type is imported `import type`, so it is erased at build time and this
+ * file keeps no runtime dependency on `mzizi-synthetic-probe` — it stays
+ * independently installable while still speaking that component's contract
+ * rather than a second, parallel shape.
+ *
+ * A step maps to a CLIENT span because a probe step calls something external;
+ * the run maps to INTERNAL because it calls nothing itself. Getting this wrong
+ * makes a collector's service-dependency graph draw edges that do not exist.
+ */
+export function probeResultToSpans(
+  result: ProbeResult,
+  extra: Record<string, AttributeValue | undefined> = {}
+): OtelSpan[] {
+  const runStart = Date.parse(result.timestamp)
+  const runId = newSpanId()
+  const failed = result.status !== "pass"
+
+  const run: OtelSpan = {
+    name: `probe ${result.journeyId}`,
+    kind: SPAN_KIND_INTERNAL,
+    spanId: runId,
+    startTimeMs: runStart,
+    endTimeMs: runStart + result.durationMs,
+    attributes: {
+      "mzizi.node": 8,
+      "mzizi.probe.journey": result.journeyId,
+      "mzizi.probe.status": result.status,
+      "mzizi.probe.region": result.region,
+      "mzizi.probe.steps": result.steps.length,
+      "mzizi.probe.steps_failed": result.steps.filter((s) => s.status === "fail").length,
+      ...extra,
+    },
+    status: failed
+      ? { code: STATUS_ERROR, message: `probe ${result.journeyId} ${result.status}` }
+      : { code: STATUS_OK },
+  }
+
+  // Steps carry no per-step timestamp in ProbeResult, only a duration, so they
+  // are laid end to end from the run start. That is an approximation and it is
+  // stated here rather than presented as measured: the durations are real, the
+  // offsets are reconstructed.
+  let cursor = runStart
+  const steps: OtelSpan[] = result.steps.map((step) => {
+    const start = cursor
+    cursor += step.durationMs
+    return {
+      name: step.description,
+      kind: SPAN_KIND_CLIENT,
+      parentSpanId: runId,
+      startTimeMs: start,
+      endTimeMs: cursor,
+      attributes: {
+        "mzizi.node": 8,
+        "mzizi.probe.journey": result.journeyId,
+        "mzizi.probe.step_status": step.status,
+        "error.message": step.error,
+      },
+      status:
+        step.status === "fail"
+          ? { code: STATUS_ERROR, message: step.error ?? "step failed" }
+          : { code: STATUS_OK },
+    }
+  })
+
+  return [run, ...steps]
+}
+
+/** Convenience: map a `ProbeResult` and ship it in one call. */
+export function exportProbeResult(
+  result: ProbeResult,
+  config: OtelConfig,
+  extra?: Record<string, AttributeValue | undefined>
+): Promise<ExportOutcome> {
+  return exportSpans(probeResultToSpans(result, extra), config)
+}
+
+export const otelStatus = { UNSET: STATUS_UNSET, OK: STATUS_OK, ERROR: STATUS_ERROR }
+export const otelSpanKind = { INTERNAL: SPAN_KIND_INTERNAL, CLIENT: SPAN_KIND_CLIENT }

--- a/components/registry/n8-assurance/mzizi-otel.ts
+++ b/components/registry/n8-assurance/mzizi-otel.ts
@@ -5,6 +5,22 @@
    ═══════════════════════════════════════════════════════════════ */
 
 /**
+ * STOPGAP — N8 IS A RUST NODE AND THIS FILE IS TYPESCRIPT.
+ *
+ * N4, N5, N8 and N9 are the core: the nodes holding logic rather than UI, and
+ * doctrine puts them in Rust — N4/N5/N8 as a WASM shared core, N9 as a
+ * `workers-rs` edge worker. Today none of them are; there are zero `.rs` files
+ * under those four directories.
+ *
+ * When the core lands, the split is: payload construction, id generation,
+ * endpoint resolution and the never-throw contract are shared-core logic and
+ * move to Rust. What stays per-target is only the thin call that sends.
+ *
+ * This exists in TypeScript because a consumer app's browser has to be able to
+ * emit at all, and because two live defects were found through building it. It
+ * is not the pattern to copy for a new N4/N5/N8/N9 component. See
+ * `docs/n8-telemetry.md`.
+ *
  * WHY THIS EXISTS.
  *
  * N8's covenant is "what breaks is seen before users feel it." Every other N8

--- a/components/registry/n8-assurance/mzizi-rum.ts
+++ b/components/registry/n8-assurance/mzizi-rum.ts
@@ -32,7 +32,19 @@ export interface RumConfig {
   sampleRate?: number
   /** Flush interval in ms */
   flushInterval?: number
-  /** Endpoint to POST events to */
+  /**
+   * Endpoint to POST batches to.
+   *
+   * **There is no default.** This used to default to `https://mzizi.dev/api/rum`,
+   * a route that has never existed — so every consumer who installed this
+   * component and did not set an endpoint POSTed their batches into a 404, and
+   * the `catch` below (correctly) swallowed it. Silent data loss that looked
+   * exactly like working RUM.
+   *
+   * Unset means "do not POST"; use `onFlush` to route batches yourself, or send
+   * them to a collector with `mzizi-otel`. Inventing a destination for a
+   * consumer's telemetry is not a sane default even when the destination works.
+   */
   endpoint?: string
   /** Custom event handler instead of posting */
   onEvent?: (event: RumEvent) => void
@@ -51,7 +63,7 @@ class RumCollector {
     this.config = {
       sampleRate: config.sampleRate ?? 0.1,
       flushInterval: config.flushInterval ?? 30000,
-      endpoint: config.endpoint ?? "https://mzizi.dev/api/rum",
+      endpoint: config.endpoint ?? "",
       onEvent: config.onEvent ?? (() => {}),
       onFlush: config.onFlush ?? (() => {}),
     }
@@ -113,6 +125,10 @@ class RumCollector {
     const batch = [...this.events]
     this.events = []
     this.config.onFlush(batch)
+    // No endpoint means the consumer routes batches themselves via `onFlush`.
+    // Posting to a guessed address instead is how this component spent its
+    // whole life writing into a 404.
+    if (!this.config.endpoint) return
     try {
       await fetch(this.config.endpoint, {
         method: "POST",

--- a/components/registry/n9-fundi/nyuchi-fundi-reporter.ts
+++ b/components/registry/n9-fundi/nyuchi-fundi-reporter.ts
@@ -1,6 +1,20 @@
 "use client"
 
-const GITHUB_REPO = "nyuchi/design-portal"
+/**
+ * Where a fundi report becomes an issue.
+ *
+ * This said `nyuchi/design-portal`, the repo's name before the Mzizi rename —
+ * it is `nyuchi/mzizi` now. GitHub redirects API calls for a renamed repo, so
+ * this kept working and had no symptom, which is exactly why it survived: a
+ * stale constant that still functions is invisible until the redirect is
+ * retired, and then every consumer's reporter breaks at once.
+ *
+ * Mzizi's own tracker is the right destination and that is deliberate: a
+ * consumer installs these components, so a defect they hit is a defect in this
+ * registry, and it belongs where the fix will be made rather than in their
+ * backlog.
+ */
+const GITHUB_REPO = "nyuchi/mzizi"
 
 export interface FundiReport {
   component: string

--- a/docs/browser-checks.md
+++ b/docs/browser-checks.md
@@ -169,6 +169,41 @@ _and_ the throw is reported. A render check is a signal it can generate itself �
 "this route stopped producing its content" is a diagnostic no error-boundary
 beacon emits, because the failing page did not error, it rendered empty.
 
+## Reporting back — this is an N8 probe, not a console tool
+
+> **Source of truth:** `docs/n8-telemetry.md`.
+
+The first version printed to a console and exited non-zero, so a render failure
+was seen by whoever ran the command and by nothing else. `mzizi-synthetic-probe`
+(N8) had already declared the contract it should have implemented — down to
+saying in its own body _"here we define the contract that the probe runner
+implements."_
+
+Each run now produces a `ProbeResult` and ships it through `mzizi-otel` as OTLP:
+one INTERNAL span for the run, one CLIENT child per route, `status.code = 2`
+(ERROR) on the run and on each failing route.
+
+```
+✓ /tokens  found "malachite" (6665 chars)
+⇡ reported 2 spans to OTLP (trace ed6ba19310dbe8e04cf0a037fc06b36e)
+```
+
+OTLP rather than a Mzizi endpoint because a signal only fundi can read is a
+signal only fundi can act on — any collector, backend or agent that speaks
+OpenTelemetry can subscribe instead.
+
+Two rules worth repeating here:
+
+- **Reporting never changes the exit code.** A run that "failed" because a
+  collector was unreachable would manufacture an incident out of an exporter
+  outage. The export outcome is printed and then ignored.
+- **With no `OTEL_EXPORTER_OTLP_ENDPOINT` it is inert**, and says so
+  (`⇡ not reported — no OTLP endpoint configured`). No collector is configured
+  anywhere in the ecosystem yet, so that is the normal output today.
+
+`--text` runs do **not** report: a debugging dump asserted nothing, and putting
+a probe result on the bus for it would be noise.
+
 ## What this does not check
 
 - **Contrast and colour.** Kitesurf trades CSS exactness for cost, so a computed

--- a/docs/browser-checks.md
+++ b/docs/browser-checks.md
@@ -1,9 +1,10 @@
 # Browser checks — proving a page actually rendered
 
 `pnpm browser:check` renders pages through [Kitesurf](https://developers.cloudflare.com/browser-run/kitesurf/)
-and asserts each one produced its own content. `scripts/kitesurf.mjs` is the whole
-implementation; this file is the why, the dev setup, and how fundi runs the same
-check from a Worker.
+and asserts each one produced its own content, then reports the run to N8
+assurance over OTLP. `scripts/kitesurf.ts` is the runner and
+`components/registry/n8-assurance/mzizi-otel.ts` is the exporter; this file is
+the why, the dev setup, and how fundi runs the same check from a Worker.
 
 ## The gap it closes
 
@@ -112,8 +113,11 @@ no HTML parsing at all — which removed both bugs the first version shipped wit
    trap documented in `scripts/extract-props.ts`.
 
 Both were self-inflicted, and neither can recur when the extraction happens
-server-side. It also means the script has **zero dependencies**, and a Worker
-gets the identical result with no parsing library.
+server-side. It also means **no parsing library is involved anywhere** — not in
+the runner, and not in a Worker doing the same thing. (The runner itself runs
+under `tsx`, like every other script here, so it can import `mzizi-otel` rather
+than carrying a second copy of the exporter; `mzizi-otel` is the piece that has
+to stay dependency-free, and does.)
 
 Kitesurf supports a subset of Quick Actions. Verified against `mzizi.dev`:
 

--- a/docs/n8-telemetry.md
+++ b/docs/n8-telemetry.md
@@ -1,0 +1,158 @@
+# N8 assurance telemetry — the sink, and why it is OTLP
+
+> N8's covenant: _what breaks is seen before users feel it._
+> This is the "seen by whom" half.
+
+## The gap this closes
+
+N8 shipped twelve assurance components. Five of them end in a callback:
+
+| Component               | Callbacks               |
+| ----------------------- | ----------------------- |
+| `mzizi-synthetic-probe` | `onResult`, `onAlert`   |
+| `mzizi-rum`             | `onEvent`, `onFlush`    |
+| `mzizi-error-tracker`   | `onError`, `onCritical` |
+| `mzizi-alert-engine`    | its handlers            |
+| `mzizi-platform-health` | render-time only        |
+
+**None of them had a sink.** A signal was seen by whoever installed the
+component and by nobody else. Three specific consequences, all measured rather
+than inferred:
+
+- `mzizi-rum` defaulted `endpoint` to `https://mzizi.dev/api/rum`. That route
+  returns **404** and has never existed, and the flush is wrapped in a `catch`
+  that (correctly) swallows delivery failures. Every consumer who installed RUM
+  without setting an endpoint was posting into a void that looked exactly like
+  working RUM. Fixed here: there is no default, and no endpoint means no POST.
+- `mzizi-error-tracker`'s one instruction for getting a critical error out was a
+  commented-out import of `@/lib/fundi/nyuchi-fundi-reporter`. That file does not
+  exist in this repo and never has.
+- `pnpm browser:check` — a synthetic probe by any reading — printed to a console
+  and exited non-zero. `mzizi-synthetic-probe` had already declared the exact
+  contract it should have implemented, down to saying in its own body _"here we
+  define the contract that the probe runner implements."_
+
+## Why OTLP rather than a Mzizi endpoint
+
+**A signal only fundi can read is a signal only fundi can act on.** The obvious
+move is a `mzizi.dev/api/assurance` route that fundi polls, and it is wrong for
+the same reason `/api/rum` was: it makes Mzizi the only possible consumer, and it
+requires Mzizi to ship a client for every service that later wants in.
+
+OpenTelemetry is the protocol collectors, tracing backends and agent runtimes
+already speak. Emitting OTLP means "the changelog route stopped rendering"
+becomes an event **any** service can subscribe to — fundi, an alerting pipeline,
+another agent, a dashboard — without this repo knowing any of them exist.
+
+## `mzizi-otel` — the exporter
+
+`components/registry/n8-assurance/mzizi-otel.ts`, installable as
+`mzizi-otel`. It is a registry component rather than repo tooling because the
+apps that need to emit are consumer apps, not this one.
+
+```ts
+import { exportProbeResult } from "./mzizi-otel"
+
+await exportProbeResult(probeResult, {
+  serviceName: "my-app",
+  environment: "production",
+  // endpoint from OTEL_EXPORTER_OTLP_ENDPOINT
+})
+```
+
+### No `@opentelemetry/*` dependency, deliberately
+
+OTLP/HTTP with a JSON payload is a documented wire format — a POST with a
+specific body shape. The JS SDK brings a large dependency tree, and the parts
+that matter (`BatchSpanProcessor`, `NodeTracerProvider`) assume a Node runtime.
+**fundi is a Cloudflare Worker**, and consumer apps install this file into
+runtimes that are not ours to choose. A hand-built payload runs unchanged in
+Node, a Worker, Deno and a browser, and keeps the component independently
+installable — which the registry requires.
+
+The tradeoff is real and stated in the file: no automatic context propagation,
+no batching queue, no retry/backoff. This carries discrete assurance events, not
+request traces. If you need distributed tracing, use the SDK.
+
+### Rules the implementation follows
+
+- **Never throws, never changes the caller's verdict.** A probe that reported
+  "failed" because its collector was unreachable would manufacture an incident
+  out of an exporter outage. Every failure path returns `{ exported: false,
+reason }`.
+- **No default endpoint.** Unset means inert. Sending a consumer's telemetry to
+  an address they never chose is not a default — that is the `/api/rum` mistake
+  restated.
+- **`OTEL_EXPORTER_OTLP_ENDPOINT` is a base** and gets `/v1/traces` appended;
+  **`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is complete** and is used verbatim. The
+  asymmetry is the spec's, and appending to the second yields
+  `/v1/traces/v1/traces` — a 404 that reads like a broken collector. Both paths
+  are covered by tests.
+- **Trace ids come from `crypto.getRandomValues`, not `Math.random()`.** Trace
+  ids are correlation keys across services; a predictable one lets an unrelated
+  caller collide with, or forge, a trace.
+
+### Wire-shape details that are tested, not eyeballed
+
+A malformed OTLP body fails _silently_ — the POST returns 200, or the collector
+drops the span, and the first anyone knows is an empty dashboard. So
+`__tests__/lib/otel.test.ts` asserts the details a collector rejects:
+
+- trace id is 32 hex chars, span id is 16
+- timestamps are integer **nanosecond strings** (JSON has no int64; a number
+  loses precision above 2^53, which is exactly where a nanosecond timestamp sits)
+- every attribute is tagged with exactly one OTLP type, integers as strings
+- a failing probe produces `status.code = 2` (ERROR) on the run **and on the
+  failing step only**
+
+Verified end to end against a local collector as well as in unit tests.
+
+## The probe mapping
+
+A `ProbeResult` becomes one **INTERNAL** span for the run plus one **CLIENT**
+child per step. A step calls something external; the run calls nothing.
+Reversing these makes a collector draw service-dependency edges that do not
+exist.
+
+`ProbeResult` carries a duration per step but no per-step timestamp, so steps are
+laid end to end from the run start. The durations are measured; the offsets are
+reconstructed, and the code says so rather than presenting them as measured.
+
+Attributes use a `mzizi.*` namespace (`mzizi.node`, `mzizi.probe.journey`,
+`mzizi.probe.status`, `mzizi.check`) alongside standard ones (`service.name`,
+`error.message`). Mzizi-specific facts do not get to squat on OTel semantic
+convention names.
+
+### What a consumer sees on a failure
+
+The step span's `error.message` carries the full diagnosis, not just "failed":
+
+```
+missing "malachite" — NOT a rendering failure — the URL redirects off-origin to
+https://vercel.com, so the browser rendered that page rather than this route —
+an auth wall (Vercel SSO, Cloudflare Access, …), not an empty page.
+```
+
+That distinction is the point of putting prose on the wire. fundi filing a
+GitHub issue for an auth-wall failure would be a false positive; with the reason
+attached it can tell the two apart without re-running anything.
+
+## Still not wired — stated plainly
+
+`CLAUDE.md` §17 draws the self-healing loop as
+`record_observability_event → fundi cron → create_fundi_issue → draft PR`.
+**In this repo those RPCs have zero call sites.** Nothing here emits onto that
+bus, and `heal.ts`/`github.ts` in `mzizi-tools` file issues rather than opening
+pull requests. This change adds the emitter and the protocol; it does not claim
+the loop is closed.
+
+What is still missing, in order:
+
+1. **A collector.** No `OTEL_EXPORTER_OTLP_ENDPOINT` is configured anywhere in
+   the ecosystem, so `browser:check` reports `not reported — no OTLP endpoint
+configured` today. That is the honest state, not a failure.
+2. **fundi consuming OTLP.** Today fundi polls Supabase. Subscribing to the
+   collector is what turns a render failure into a filed issue.
+3. **The `record_observability_event` bridge**, if the Supabase event stream is
+   to stay the store of record — a collector exporter writing into it, rather
+   than every emitter calling the RPC directly.

--- a/docs/n8-telemetry.md
+++ b/docs/n8-telemetry.md
@@ -25,8 +25,12 @@ than inferred:
   without setting an endpoint was posting into a void that looked exactly like
   working RUM. Fixed here: there is no default, and no endpoint means no POST.
 - `mzizi-error-tracker`'s one instruction for getting a critical error out was a
-  commented-out import of `@/lib/fundi/nyuchi-fundi-reporter`. That file does not
-  exist in this repo and never has.
+  commented-out import of `@/lib/fundi/nyuchi-fundi-reporter` — one directory off
+  from where the shadcn CLI installs it (`lib/nyuchi-fundi-reporter.ts`). I first
+  read that as "the file does not exist" and deleted the pointer; it does exist,
+  as an N9 registry component, so the fix was the path. Both exits are documented
+  now: **N9 files an issue** (healing) and **N8 emits a span** (observation), and
+  they are not alternatives — see "Two exits" below.
 - `pnpm browser:check` — a synthetic probe by any reading — printed to a console
   and exited non-zero. `mzizi-synthetic-probe` had already declared the exact
   contract it should have implemented, down to saying in its own body _"here we
@@ -136,6 +140,26 @@ an auth wall (Vercel SSO, Cloudflare Access, …), not an empty page.
 That distinction is the point of putting prose on the wire. fundi filing a
 GitHub issue for an auth-wall failure would be a false positive; with the reason
 attached it can tell the two apart without re-running anything.
+
+## Two exits, and they are not alternatives
+
+A signal leaving a component has two destinations, and wiring only one is a
+failure mode in both directions:
+
+| Exit            | Component                    | What it is for                                                                                                                     |
+| --------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| **Healing**     | `nyuchi-fundi-reporter` (N9) | Files a GitHub issue against `nyuchi/mzizi`, deduplicated by a per-component cooldown. A named defect a human can merge a fix for. |
+| **Observation** | `mzizi-otel` (N8)            | Emits an OTLP span. Every event, not just the critical ones, readable by any agent or service rather than by fundi alone.          |
+
+Route `onCritical` to N9 and `onError` to OTLP. Sending every error to N9 opens
+an issue per render failure; emitting only to OTLP means nothing gets fixed
+unless somebody happens to be watching a dashboard.
+
+The reporter's issue destination was a hardcoded `nyuchi/design-portal` — this
+repo's name before the Mzizi rename. GitHub redirects API calls for a renamed
+repo, so it kept working and had no symptom, which is exactly why it survived.
+A stale constant that still functions is invisible until the redirect is
+retired, and then every consumer's reporter breaks at once.
 
 ## Still not wired — stated plainly
 

--- a/docs/n8-telemetry.md
+++ b/docs/n8-telemetry.md
@@ -54,6 +54,26 @@ another agent, a dashboard — without this repo knowing any of them exist.
 `mzizi-otel`. It is a registry component rather than repo tooling because the
 apps that need to emit are consumer apps, not this one.
 
+> **This file is TypeScript, and N8 is a Rust node. Treat it as a stopgap.**
+>
+> The doctrine is that N4, N5, N8 and N9 — the core, the nodes holding logic
+> rather than UI — are built in Rust: N4/N5/N8 as a WASM shared core, N9 as a
+> `workers-rs` edge worker. Today **none of them are**; there are zero `.rs`
+> files under those four directories and the Rust workspace covers only N1
+> tokens and N2 primitives.
+>
+> So this exporter is not the destination. The split when the core lands:
+> **payload construction, id generation, endpoint resolution and the
+> never-throw contract are `shared-core` logic and belong in Rust**; what stays
+> per-target is the thin call that actually sends — `fetch` in a browser,
+> `env.BROWSER`/`fetch` in a Worker.
+>
+> It exists in TypeScript now because a consumer app's browser has to be able to
+> emit at all, and because two live defects (`mzizi-rum` writing into a 404,
+> `nyuchi-fundi-reporter` filing against a renamed repo) were found through it
+> and should not wait on a WASM core that has not been started. **Do not copy
+> this file as the pattern for a new N4/N5/N8/N9 component.**
+
 ```ts
 import { exportProbeResult } from "./mzizi-otel"
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mzizi",
   "version": "1.0.0",
   "private": true,
-  "description": "Mzizi — an open-architecture project of the Bundu Foundation. Open 3D frontend architecture, component registry, and MCP server, operated and developed by Nyuchi.",
+  "description": "Mzizi \u2014 an open-architecture project of the Bundu Foundation. Open 3D frontend architecture, component registry, and MCP server, operated and developed by Nyuchi.",
   "homepage": "https://mzizi.dev",
   "packageManager": "pnpm@10.33.0",
   "scripts": {
@@ -37,7 +37,7 @@
     "props:extract": "tsx scripts/extract-props.ts",
     "props:verify": "tsx scripts/extract-props.ts --check",
     "samples:push": "tsx scripts/push-samples.ts",
-    "browser:check": "node scripts/kitesurf.mjs"
+    "browser:check": "tsx scripts/kitesurf.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",

--- a/registry.json
+++ b/registry.json
@@ -10683,6 +10683,42 @@
     },
     {
       "dependencies": [],
+      "description": "OTLP exporter for N8 assurance signals. Turns probe results, tracked errors and fired alerts into OpenTelemetry spans and POSTs them to any OTLP/HTTP collector, so a Mzizi signal can be consumed by any agent or service that speaks OpenTelemetry. Zero dependencies and no Node built-ins - runs unchanged in Node, a Cloudflare Worker, Deno or a browser.",
+      "files": [
+        {
+          "path": "lib/mzizi-otel.ts",
+          "type": "registry:lib"
+        }
+      ],
+      "meta": {
+        "a11y": [
+          "Non-visual infrastructure - no direct a11y requirements"
+        ],
+        "collection": "observability",
+        "features": [
+          "OTLP/HTTP JSON traces - no @opentelemetry/* dependency",
+          "Maps the N8 ProbeResult contract to a run span plus one child span per step",
+          "Honours OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+          "Never throws and never changes the caller's verdict",
+          "Inert with no endpoint configured - no default collector is invented"
+        ],
+        "hasDemo": false,
+        "owner": "mzizi",
+        "useCases": [
+          "Ship synthetic probe results to a collector",
+          "Give mzizi-rum / mzizi-error-tracker / mzizi-alert-engine a sink for their callbacks",
+          "Let other agents subscribe to Mzizi assurance events over a standard protocol",
+          "Emit assurance telemetry from a Cloudflare Worker, where the OTel JS SDK does not run"
+        ]
+      },
+      "name": "mzizi-otel",
+      "registryDependencies": [
+        "https://mzizi.dev/api/v1/ui/mzizi-synthetic-probe"
+      ],
+      "type": "registry:lib"
+    },
+    {
+      "dependencies": [],
       "description": "Web Vitals and performance monitoring. Tracks LCP, FID, CLS, INP, TTFB per page and per component (using data-portal backlinks). Reports to analytics. Competitors: Lighthouse, Web Vitals library, Vercel Analytics.",
       "files": [
         {

--- a/scripts/kitesurf.ts
+++ b/scripts/kitesurf.ts
@@ -1,6 +1,7 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S tsx
 /**
- * Render pages through Cloudflare Kitesurf and assert they actually painted.
+ * Render pages through Cloudflare Kitesurf, assert they actually painted, and
+ * report the run to N8 assurance over OTLP.
  *
  *   pnpm browser:check                                  # the default route set
  *   pnpm browser:check --base http://localhost:11736    # against a dev server
@@ -20,15 +21,22 @@
  * a frame around a hole" is rendering it and looking for content that should be
  * there.
  *
- * WHY KITESURF RATHER THAN PLAYWRIGHT.
+ * THIS IS AN N8 PROBE RUNNER, NOT A STANDALONE SCRIPT.
  *
- * fundi is a Cloudflare Worker. It cannot spawn a browser process, so a
- * Playwright checker would serve developers and be useless to the agent that
- * most needs it. Browser Run is a `fetch` call, so the same check runs from a
- * laptop, from CI, and from inside fundi's heal loop — see
- * `docs/browser-checks.md` for the Worker binding, which needs no API token.
- * Kitesurf because it is 3-7x lighter than Chromium and this needs text, not
- * pixels.
+ * `mzizi-synthetic-probe` (N8) already declared this contract — `SyntheticJourney`,
+ * `ProbeStep`, `ProbeResult`, `onResult`/`onAlert` — and its body says, in as many
+ * words, "here we define the contract that the probe runner implements". The first
+ * version of this file ignored all of it and printed to a console, so a render
+ * failure was seen by whoever ran the command and by nothing else. It now produces
+ * a `ProbeResult` and ships it through `mzizi-otel`, which is what makes the signal
+ * reach the rung that acts on it.
+ *
+ * That component's comment also says the runner "would use Puppeteer/Playwright".
+ * It cannot: **fundi is a Cloudflare Worker and cannot spawn a browser process.**
+ * Browser Run is a `fetch`, so the same check runs from a laptop, from CI, and
+ * from inside fundi's heal loop — from a Worker via `env.BROWSER.quickAction()`,
+ * which needs no API token. Kitesurf because it is 3-7x lighter than Chromium and
+ * this needs text, not pixels. See `docs/browser-checks.md`.
  *
  * ─────────────────────────────────────────────────────────────────────────────
  * WHY `/markdown` AND NOT `/content` + AN HTML PARSER.
@@ -83,10 +91,20 @@
  */
 
 import { argv, env, exit } from "node:process"
+import { exportProbeResult } from "@/components/registry/n8-assurance/mzizi-otel"
+import type { ProbeResult } from "@/components/registry/n8-assurance/mzizi-synthetic-probe"
 
 const ACCOUNT = env.CLOUDFLARE_ACCOUNT_ID ?? "125a2dfbc21f76a25c980609609e8218"
 const TOKEN = env.CLOUDFLARE_API_TOKEN ?? ""
 const API = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT}/browser-rendering`
+
+/** The journey id every run reports under. A collector groups on this. */
+const JOURNEY_ID = "mzizi-browser-render"
+
+interface Route {
+  path: string
+  expect: string
+}
 
 /**
  * Route -> a string only that route's own BODY can produce.
@@ -100,7 +118,7 @@ const API = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT}/browser-re
  * page that was rendering perfectly — a brittle assertion reports its author's
  * assumption as the site's defect.
  */
-const ROUTES = [
+const ROUTES: Route[] = [
   // A `meta.features` entry — served from registry.json, rendered by the detail body.
   { path: "/components/button", expect: "Polymorphic rendering via asChild" },
   // The oldest version row. `/changelog/{name}` is the route that shipped empty.
@@ -114,7 +132,7 @@ const ROUTES = [
 ]
 
 /** Drop the `<meta>`-derived YAML block `/markdown` prepends. See the header. */
-function body(markdown) {
+function body(markdown: string): string {
   return markdown.replace(/^---\n[\s\S]*?\n---\n/, "")
 }
 
@@ -138,7 +156,7 @@ function body(markdown) {
  * Only runs on failure, so the happy path still costs one request per route.
  * Best-effort: a probe that itself fails must not replace the real result.
  */
-async function diagnose(url) {
+async function diagnose(url: string): Promise<string | null> {
   try {
     const res = await fetch(url, { redirect: "manual" })
     const location = res.headers.get("location")
@@ -159,18 +177,55 @@ async function diagnose(url) {
   return null
 }
 
-async function render(url) {
+type RenderResult = { ok: true; text: string } | { ok: false; detail: string }
+
+async function render(url: string): Promise<RenderResult> {
   const res = await fetch(`${API}/markdown?browser=kitesurf`, {
     method: "POST",
     headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" },
     body: JSON.stringify({ url }),
   })
-  const payload = await res.json().catch(() => null)
+  const payload = (await res.json().catch(() => null)) as {
+    success?: boolean
+    result?: string
+    errors?: { message: string }[]
+  } | null
   if (!res.ok || !payload?.success) {
     const detail = payload?.errors?.map((e) => e.message).join("; ") ?? `HTTP ${res.status}`
     return { ok: false, detail }
   }
   return { ok: true, text: body(String(payload.result ?? "")) }
+}
+
+/**
+ * Ship the run to N8 assurance.
+ *
+ * Reporting NEVER changes the exit code. A run that "failed" because a collector
+ * was unreachable would manufacture an incident out of an exporter outage, which
+ * is the opposite of what an assurance signal is for. The outcome is printed so
+ * a silent no-export is visible, and then ignored.
+ *
+ * With no collector configured this is inert — which is the normal case today,
+ * because the ecosystem does not run one yet. `docs/browser-checks.md` records
+ * that, rather than this pretending to emit somewhere.
+ */
+async function report(result: ProbeResult, base: string): Promise<void> {
+  const outcome = await exportProbeResult(
+    result,
+    {
+      serviceName: "mzizi-browser-check",
+      environment: base.includes("localhost") ? "local" : "production",
+      // Endpoint comes from OTEL_EXPORTER_OTLP_ENDPOINT. No default: sending a
+      // consumer's telemetry to an address they never chose is not a default.
+    },
+    { "mzizi.check": "browser-render", "url.base": base }
+  )
+
+  if (outcome.exported) {
+    console.log(`⇡ reported ${outcome.spanCount} spans to OTLP (trace ${outcome.traceId})`)
+  } else {
+    console.log(`⇡ not reported — ${outcome.reason}`)
+  }
 }
 
 async function main() {
@@ -198,37 +253,75 @@ async function main() {
     exit(0)
   }
 
+  const runStart = Date.now()
+  const steps: ProbeResult["steps"] = []
   let failed = 0
+
   for (const route of targets) {
+    const stepStart = Date.now()
     const result = await render(base + route.path)
+    const durationMs = Date.now() - stepStart
+
     if (!result.ok) {
       console.error(`✗ ${route.path}\n    render failed: ${result.detail}`)
+      steps.push({
+        description: route.path,
+        status: "fail",
+        durationMs,
+        error: `render failed: ${result.detail}`,
+      })
       failed++
       continue
     }
+
     if (dumpText) {
       console.log(`\n──── ${route.path} (${result.text.length} chars) ────\n${result.text}`)
       continue
     }
+
     if (!result.text.includes(route.expect)) {
       const reason = await diagnose(base + route.path)
+      const detail = reason
+        ? `NOT a rendering failure — ${reason}`
+        : `That is the chrome-around-a-hole shape: the frame rendered, its content did not.`
       console.error(
         `✗ ${route.path}\n    rendered ${result.text.length} chars of prose, but not ` +
-          `${JSON.stringify(route.expect)}.\n` +
-          (reason
-            ? `    NOT a rendering failure — ${reason}`
-            : `    That is the chrome-around-a-hole shape: the frame rendered, its content did not.`) +
-          `\n    \`pnpm browser:check --text ${route.path}\` shows what it did render.`
+          `${JSON.stringify(route.expect)}.\n    ${detail}\n` +
+          `    \`pnpm browser:check --text ${route.path}\` shows what it did render.`
       )
+      steps.push({
+        description: route.path,
+        status: "fail",
+        durationMs,
+        error: `missing ${JSON.stringify(route.expect)} — ${detail}`,
+      })
       failed++
       continue
     }
+
     console.log(
       `✓ ${route.path}  found ${JSON.stringify(route.expect)} (${result.text.length} chars)`
     )
+    steps.push({ description: route.path, status: "pass", durationMs })
   }
 
+  // `--text` is a debugging dump, not a run. Reporting it would put a probe
+  // result on the bus for something that asserted nothing.
   if (dumpText) return
+
+  const probe: ProbeResult = {
+    journeyId: JOURNEY_ID,
+    timestamp: new Date(runStart).toISOString(),
+    // Browser Run picks the edge location; this process only knows it did not
+    // choose one. Claiming a region we did not measure would be worse than
+    // saying so.
+    region: "cloudflare-edge",
+    status: failed > 0 ? "fail" : "pass",
+    durationMs: Date.now() - runStart,
+    steps,
+  }
+  await report(probe, base)
+
   if (failed > 0) {
     console.error(`\n${failed} of ${targets.length} route(s) did not render their content.`)
     exit(1)
@@ -237,6 +330,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error("kitesurf: " + (err?.message ?? String(err)))
+  console.error("kitesurf: " + (err instanceof Error ? err.message : String(err)))
   exit(1)
 })


### PR DESCRIPTION
N8's covenant is *"what breaks is seen before users feel it."* This is the **seen by whom** half, which was missing.

## The gap

Five N8 components end in a callback with **no sink behind it** — so a signal was seen by whoever installed the component and by nobody else:

| Component | Callbacks |
| --- | --- |
| `mzizi-synthetic-probe` | `onResult`, `onAlert` |
| `mzizi-rum` | `onEvent`, `onFlush` |
| `mzizi-error-tracker` | `onError`, `onCritical` |
| `mzizi-alert-engine` | its handlers |
| `pnpm browser:check` | printed to a console |

## Why OTLP and not a Mzizi endpoint

**A signal only fundi can read is a signal only fundi can act on.** A `mzizi.dev/api/assurance` route would make Mzizi the only possible consumer and require shipping a client for every service that later wants in. OpenTelemetry is what collectors, tracing backends and agent runtimes already speak, so "the changelog route stopped rendering" becomes an event **any** service can subscribe to without this repo knowing it exists.

**No `@opentelemetry/*` dependency**, deliberately: OTLP/HTTP JSON is a documented wire format, and the SDK's load-bearing pieces (`BatchSpanProcessor`, `NodeTracerProvider`) assume Node — but **fundi is a Worker**, and consumer apps install this into runtimes that aren't ours to choose. A hand-built payload runs unchanged in Node, a Worker, Deno and a browser. The cost is stated in the file rather than hidden: no context propagation, no batching, no retry. This carries discrete assurance events, not request traces.

## Two live defects found on the way — fixed here per §22

**`mzizi-rum` posted every batch into a 404.** It defaulted `endpoint` to `https://mzizi.dev/api/rum` — a route that returns 404 and has never existed (there is no `app/api/rum`) — inside a `catch` that correctly swallows delivery failures, because RUM must never surface its own network error to the user it's measuring. Correct behaviour, catastrophic in combination: **every consumer who installed RUM without setting an endpoint was posting into a void, forever, and it looked exactly like working RUM.** Silent data loss is the worst failure mode a telemetry component can have, because absence of data reads as absence of problems. There's no default now; unset means don't POST. Nobody can regress — the only consumers relying on the default were already getting nothing.

**`mzizi-error-tracker` pointed at a file that doesn't exist.** Its N9 integration block told you to import `@/lib/fundi/nyuchi-fundi-reporter`; `lib/fundi/` does not exist in this repo and never has. It now shows the `mzizi-otel` call, which is both real and better — a bespoke reporter would have been readable by fundi alone.

## The browser check becomes an actual N8 probe

`mzizi-synthetic-probe` had already declared the contract, down to saying in its own body *"here we define the contract that the probe runner implements."* I wrote the runner without implementing it. Each run now produces a `ProbeResult` and ships it as OTLP:

```
✓ /tokens  found "malachite" (6665 chars)
⇡ reported 2 spans to OTLP (trace ed6ba19310dbe8e04cf0a037fc06b36e)
```

The step span's `error.message` carries the **whole diagnosis**, not just "failed":

> `missing "malachite" — NOT a rendering failure — the URL redirects off-origin to https://vercel.com, so the browser rendered that page rather than this route — an auth wall (Vercel SSO, Cloudflare Access, …), not an empty page.`

fundi filing a GitHub issue for an auth-wall failure would be a false positive; with the reason on the wire it can tell the two apart without re-running anything.

That component also says the runner "would use Puppeteer/Playwright". It cannot — fundi is a Worker and can't spawn a browser process, which is exactly why this is a `fetch`.

## Rules the implementation follows

- **Telemetry never changes the caller's verdict.** A probe reporting "failed" because its collector was unreachable manufactures an incident out of an exporter outage. The exporter never throws; every failure path returns `{ exported: false, reason }`.
- **No default endpoint.** Unset means inert. Sending a consumer's telemetry to an address they never chose is not a default — that's the `/api/rum` mistake restated.
- **`OTEL_EXPORTER_OTLP_ENDPOINT` is a base** (gets `/v1/traces` appended); **`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is complete** (verbatim). The asymmetry is the spec's; appending to the second yields `/v1/traces/v1/traces`, a 404 that reads like a broken collector. Both covered by tests.
- **Trace ids from `crypto.getRandomValues`, not `Math.random()`** — they're correlation keys across services; a predictable one lets an unrelated caller collide with or forge a trace.
- **`mzizi.*` for Mzizi facts** — no squatting on OTel semantic-convention names.

## Wire shape is tested, not eyeballed

A malformed OTLP body fails **silently** — 200 back, span dropped, empty dashboard. 25 specs assert what a collector actually rejects: 32/16-hex ids, integer **nanosecond strings** (JSON has no int64; a float64 loses precision above 2^53, exactly where a nanosecond timestamp sits), one OTLP type tag per attribute, run=INTERNAL / step=CLIENT span kinds, and ERROR status on the run **plus the failing step only**.

Also verified end to end against a local collector — payload captured and checked against the spec, in both the passing and failing directions.

## Still NOT wired — stated plainly

- **No collector is configured anywhere in the ecosystem**, so `browser:check` reports `not reported — no OTLP endpoint configured` today. That's the honest state, not a failure.
- **CLAUDE.md §17's self-healing diagram describes a loop whose RPCs have zero call sites in this repo** — `record_observability_event`, `create_fundi_issue`. This adds the emitter and the protocol, not the closed loop.
- Next steps, in order: stand up a collector → have fundi subscribe → decide whether the Supabase event stream stays the store of record (a collector exporter writing into it, rather than every emitter calling the RPC).

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm test` (185 passed, 25 new), `pnpm registry:verify`, `pnpm registry:validate`, `pnpm props:verify` all green. `pnpm browser:check` 5/5 against production, with and without a collector.

## Files

| File | |
| --- | --- |
| `components/registry/n8-assurance/mzizi-otel.ts` | new — the OTLP exporter |
| `components/registry/n8-assurance/mzizi-rum.ts` | fix — remove the 404 default endpoint |
| `components/registry/n8-assurance/mzizi-error-tracker.ts` | fix — point at a sink that exists |
| `scripts/kitesurf.mjs` → `.ts` | now an N8 probe runner that reports |
| `__tests__/lib/otel.test.ts` | new — 25 specs on the wire contract |
| `docs/n8-telemetry.md` | new — source of truth |
| `docs/browser-checks.md`, `CLAUDE.md` | §13.1 updated, §13.2 added |
| `registry.json` | `mzizi-otel` item (573) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED


---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_