### PR TITLE
feat(n8,n9): the core nodes move to Rust — every N8 and N9 component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,12 +303,19 @@ design-portal/
 │   ├── icons/                        # Favicon assets
 │   └── llms.txt                      # LLM-readable registry summary
 ├── mzizi-rs/                         # Cargo workspace — the Rust half of the registry (§8.9)
-│   ├── Cargo.toml                    #   workspace: mzizi-tokens (N1), mzizi-ui (N2/Dioxus)
+│   ├── Cargo.toml                    #   workspace: mzizi-tokens (N1), mzizi-ui (N2/Dioxus),
+│   │                                 #              mzizi-assurance (N8), mzizi-fundi (N9)
 │   └── crates/
 │       ├── mzizi-tokens/src/lib.rs   #   #[path]-includes n1-tokens/nyuchi-tokens-rust.rs
-│       └── mzizi-ui/
-│           ├── src/lib.rs            #   #[path]-includes n2-primitives/<name>.rs
-│           └── tests/contract.rs     #   asserts each .rs agrees with its .tsx sibling
+│       ├── mzizi-ui/
+│       │   ├── src/lib.rs            #   #[path]-includes n2-primitives/<name>.rs
+│       │   └── tests/contract.rs     #   asserts each .rs agrees with its .tsx sibling
+│       ├── mzizi-assurance/          #   N8 — every component, zero dependencies
+│       │   ├── src/lib.rs            #   #[path]-includes n8-assurance/<name>.rs
+│       │   └── tests/contract.rs     #   asserts each .rs agrees with its .ts/.tsx sibling
+│       └── mzizi-fundi/              #   N9 — the reporter, the learning log, the engine
+│           ├── src/lib.rs            #   #[path]-includes n9-fundi/<name>.rs
+│           └── tests/contract.rs     #   same, plus the N8-to-N9 vocabulary check
 ├── supabase/
 │   ├── schema.sql                    # Single-file schema snapshot
 │   ├── config.toml
@@ -959,12 +966,27 @@ generated token module) and `mzizi-ui` (N2, Dioxus primitives). The primitives a
 `#[path]`-includes. `cargo fmt --check`, `cargo check`, `clippy -D warnings` and `cargo test`
 run in CI's `Rust` job, and `Build` needs it.
 
-**What does not:** no WASM shared core. The harness is still `lib/harness/index.tsx`, the
-resilience primitives are still `lib/*.ts`, the N4 safety gates are still TypeScript, and the
-fundi worker is still TypeScript. Every Rust statement about N4, N5, N8 and N9 in
-`documentation-architecture-nodes` remains **target state, explicitly labelled** — `rust.state`
-reads `target`, never `shipping`. A node that describes a Rust implementation in the present
-tense reads as shipped to every agent that queries it.
+**N8 and N9 now ship too, and the distinction between what landed and what did not is the
+whole of this paragraph.** `mzizi-assurance` (N8) and `mzizi-fundi` (N9) compile a Rust core
+for **every** component in those two directories — the probes, the error and alert
+aggregation, the a11y and RTL rule engines, the chaos classifier, the incident lifecycle, the
+OTLP payload builder and the healing decision engine. Each `.rs` sits beside its `.ts`/`.tsx`
+sibling and a contract suite reads that sibling on disk, so the two cannot drift apart
+silently.
+
+**What does not ship: a WASM build.** Every core above is pure logic with no I/O, which is what
+makes it portable — and nothing compiles it to WASM, no consumer loads it, and no `.ts` calls
+into it. The two implementations agree **by contract test, not by sharing a binary**. "N8 is a
+Rust node" therefore means its rules have one authoritative home; it does not yet mean one
+binary serves every target, and reading it as the latter is the drift this paragraph exists to
+prevent.
+
+**Still TypeScript, entirely:** the harness (`lib/harness/index.tsx`), the N5 resilience
+primitives (`lib/*.ts`), the N4 safety gates, and the deployed fundi worker in `mzizi-tools`.
+Rust statements about **N4 and N5** in `documentation-architecture-nodes` remain **target
+state, explicitly labelled** — `rust.state` reads `target`, never `shipping`. A node that
+describes a Rust implementation in the present tense reads as shipped to every agent that
+queries it.
 
 **The gate landed with the first component, not after it.** A `.rs` file in the registry with
 no crate compiling it is exactly what a `source_code` database column was: bytes nothing

--- a/components/registry/n8-assurance/mzizi-a11y-audit.rs
+++ b/components/registry/n8-assurance/mzizi-a11y-audit.rs
@@ -1,0 +1,528 @@
+//! Mzizi N8 assurance — runtime accessibility rules.
+//!
+//! The Rust implementation of `mzizi-a11y-audit`. The rules, the levels, the
+//! selector and the score; not the DOM walk. The host observes the page and hands
+//! over a list of [`ObservedNode`] in document order, which is the only step that
+//! needs a browser.
+//!
+//! Document order matters and is part of the contract: [`Rule::HeadingOrder`]
+//! reads it. Hand nodes over in the order `querySelectorAll("*")` yields them, not
+//! sorted or filtered.
+//!
+//! # Four defects in the TypeScript, fixed here
+//!
+//! **1. One element could report at most ONE violation.** The `.ts` chains its
+//! rules with `else if`, so an `<img>` with no alt is never checked for anything
+//! else, and a `<button>` with no accessible name is never checked for touch
+//! target size. The rules are independent facts about an element; chaining them
+//! means the *first* finding hides the rest, and a button with no name is exactly
+//! the button most likely to also be too small. Every rule is evaluated here.
+//!
+//! **2. A conformant button never counted as a pass.** Falling into the
+//! touch-target branch and finding nothing wrong incremented nothing — `passes++`
+//! lived only in the branches an interactive element could not reach. So a page
+//! of correct buttons scored *lower* than a page of `<div>`s, and the one number
+//! anybody looks at moved the wrong way as accessibility improved. An element
+//! passes here when it produced no violations, which is the only definition that
+//! cannot invert.
+//!
+//! **3. The heading-order rule was a comment.** `// Rule: Headings should be in
+//! order` sat above a branch that matched `H1`–`H6` and then did nothing but count
+//! a pass. A stated rule that evaluates nothing reads as coverage on a dashboard
+//! and is worse than an absent one. Implemented — see [`Rule::HeadingOrder`].
+//!
+//! **4. The touch-target rule measured the wrong box.** `getBoundingClientRect()`
+//! is the *visual* box, and Mzizi's control scale is deliberately dense — `h-8` /
+//! `h-9` / `h-10`, so 32-40px (CLAUDE.md §8.2). Measuring the visual box therefore
+//! flagged every correctly-built Mzizi control as a moderate violation: the design
+//! system failed its own audit universally, which is the fastest way to teach
+//! everyone to ignore a rule. §8.2 says a dense control earns its hit area through
+//! surrounding spacing or padding beyond the visual box, so the hit area is what
+//! the rule is about. The host supplies [`ObservedNode::hit_box`] and is expected
+//! to include that padding.
+//!
+//! # Two things recorded rather than changed
+//!
+//! **`<a>` is held to a size but not to a name.** `button-name` covers `<button>`
+//! and `role="button"`; `touch-target` additionally covers `<a>`. So a link with
+//! no accessible name passes. That is a coverage gap in the rule set, not a defect
+//! in this port, and adding a `link-name` rule would silently change what every
+//! existing consumer's score means. Left as it is, said out loud.
+//!
+//! **The node guess can only ever answer 2, 3 or 6.** `guessNodeFromSlot` is a
+//! string heuristic over the slot name, so a violation in an N7 shell component is
+//! labelled N6 and routed to the wrong owner — and N1, N4, N5 and N8-N12 are
+//! unreachable answers. The registry knows the real node, so [`resolve_node`]
+//! prefers a lookup the host supplies and falls back to the heuristic only when
+//! there is no entry. The heuristic is kept because a consumer auditing their own
+//! app has no Mzizi registry to consult.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+/// How much an accessibility violation matters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum A11yLevel {
+    /// Cosmetic or advisory.
+    Minor,
+    /// Degrades the experience for assistive technology.
+    Moderate,
+    /// Blocks a common task.
+    Serious,
+    /// Makes the element unusable.
+    Critical,
+}
+
+impl A11yLevel {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Critical => "critical",
+            Self::Serious => "serious",
+            Self::Moderate => "moderate",
+            Self::Minor => "minor",
+        }
+    }
+}
+
+/// Which rule produced a finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Rule {
+    /// An image with no `alt` attribute at all.
+    ImgAlt,
+    /// A button with no accessible name.
+    ButtonName,
+    /// An interactive control whose hit area is below the floor.
+    TouchTarget,
+    /// A heading that skips a level.
+    HeadingOrder,
+}
+
+impl Rule {
+    /// The wire spelling, matching the `.ts` `rule` strings.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ImgAlt => "img-alt",
+            Self::ButtonName => "button-name",
+            Self::TouchTarget => "touch-target",
+            Self::HeadingOrder => "heading-order",
+        }
+    }
+
+    /// Every rule this core evaluates.
+    #[must_use]
+    pub fn all() -> BTreeSet<Self> {
+        [
+            Self::ImgAlt,
+            Self::ButtonName,
+            Self::TouchTarget,
+            Self::HeadingOrder,
+        ]
+        .into_iter()
+        .collect()
+    }
+}
+
+/// The measured hit area of a control, in CSS pixels.
+///
+/// This is the *interactive* area — the visual box plus any padding that extends
+/// what a finger can land on — not `getBoundingClientRect()` on the painted
+/// element. See the module docs, defect 4.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HitBox {
+    /// Width in CSS pixels.
+    pub width: f64,
+    /// Height in CSS pixels.
+    pub height: f64,
+}
+
+/// One element as the host observed it.
+///
+/// Every field is a plain value rather than a live DOM reference, which is what
+/// lets the rules run in a Worker, in CI against server-rendered HTML, or in a
+/// test. It also sidesteps a real crash in the `.ts`: `el.className` is an
+/// `SVGAnimatedString` on SVG elements, so `.split(" ")` throws on any SVG element
+/// that reaches the selector builder.
+///
+/// `PartialEq` without `Eq`, because [`HitBox`] holds `f64` and floats have no
+/// total equality — the same reason [`f64::NAN`] is not equal to itself.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct ObservedNode {
+    /// Uppercase tag name, e.g. `BUTTON`.
+    pub tag_name: String,
+    /// The `id`, when present.
+    pub id: Option<String>,
+    /// The first class, when present.
+    pub first_class: Option<String>,
+    /// The `data-slot` value.
+    pub data_slot: Option<String>,
+    /// The `data-portal` backlink.
+    pub data_portal: Option<String>,
+    /// The `alt` attribute. `Some("")` is a decorative image and passes; `None`
+    /// means the attribute is absent, which does not.
+    pub alt: Option<String>,
+    /// The `aria-label`.
+    pub aria_label: Option<String>,
+    /// The `aria-labelledby`.
+    pub aria_labelledby: Option<String>,
+    /// The `role`.
+    pub role: Option<String>,
+    /// Rendered text content.
+    pub text: Option<String>,
+    /// Whether the element occupies space. The `.ts` uses `offsetHeight > 0`,
+    /// which reports true for `visibility: hidden` and `opacity: 0` — so a hidden
+    /// control is still audited. Named `visible` because that is what the rule
+    /// wants; supplying the honest answer is the host's job.
+    pub visible: bool,
+    /// The interactive area, when the host could measure it.
+    pub hit_box: Option<HitBox>,
+}
+
+impl ObservedNode {
+    /// Whether this element is a button for the purposes of [`Rule::ButtonName`].
+    #[must_use]
+    pub fn is_button(&self) -> bool {
+        self.tag_name.eq_ignore_ascii_case("button") || self.role.as_deref() == Some("button")
+    }
+
+    /// Whether this element is a touch target for [`Rule::TouchTarget`].
+    #[must_use]
+    pub fn is_touch_target(&self) -> bool {
+        self.is_button() || self.tag_name.eq_ignore_ascii_case("a")
+    }
+
+    /// The name a screen reader would announce, if any.
+    ///
+    /// `role` is NOT a name. `mzizi-conformity-check.ts` treats it as one
+    /// (`aria-label || role`), which makes its own rule unfireable for exactly the
+    /// `role="button"` elements it was widened to cover; this is the correct
+    /// definition and the two now agree.
+    #[must_use]
+    pub fn accessible_name(&self) -> Option<&str> {
+        [
+            self.aria_label.as_deref(),
+            self.aria_labelledby.as_deref(),
+            self.text.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|name| !name.is_empty())
+    }
+
+    /// The heading level, for `H1`-`H6`.
+    #[must_use]
+    pub fn heading_level(&self) -> Option<u8> {
+        let bytes = self.tag_name.as_bytes();
+        match bytes {
+            [h, d] if h.eq_ignore_ascii_case(&b'H') && d.is_ascii_digit() => {
+                let level = d - b'0';
+                (1..=6).contains(&level).then_some(level)
+            }
+            _ => None,
+        }
+    }
+}
+
+/// One finding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct A11yViolation {
+    /// Which rule.
+    pub rule: Rule,
+    /// How much it matters.
+    pub level: A11yLevel,
+    /// What is wrong, in words.
+    pub message: String,
+    /// The element's tag.
+    pub element: String,
+    /// A selector that finds it again.
+    pub selector: String,
+    /// Which helix node owns the component, when known.
+    pub node: Option<u32>,
+    /// The `data-slot` value, when present.
+    pub component_name: Option<String>,
+    /// Where the component's documentation is.
+    pub portal_url: Option<String>,
+    /// How to fix it.
+    pub fix: String,
+}
+
+/// What a whole page scored.
+#[derive(Debug, Clone, PartialEq)]
+pub struct A11yAuditResult {
+    /// The URL audited.
+    pub url: String,
+    /// How many elements were observed.
+    pub total_elements: usize,
+    /// Every finding.
+    pub violations: Vec<A11yViolation>,
+    /// How many elements produced no finding.
+    pub passes: usize,
+    /// Percentage passing, 0-100.
+    pub score: u32,
+}
+
+/// The touch-target floor the `.ts` uses, and the Apple HIG figure.
+///
+/// Material's is 48dp. This is a floor on the HIT AREA, not on the painted
+/// control — see the module docs, defect 4.
+pub const DEFAULT_TOUCH_TARGET_MIN_PX: f64 = 44.0;
+
+/// What to check and how strictly.
+#[derive(Debug, Clone, PartialEq)]
+pub struct A11yConfig {
+    /// Which rules to run. Empty means none, which is not the same as [`None`].
+    pub rules: Option<BTreeSet<Rule>>,
+    /// The hit-area floor in CSS pixels.
+    pub touch_target_min_px: f64,
+}
+
+impl Default for A11yConfig {
+    fn default() -> Self {
+        Self {
+            rules: None,
+            touch_target_min_px: DEFAULT_TOUCH_TARGET_MIN_PX,
+        }
+    }
+}
+
+impl A11yConfig {
+    /// Whether a rule is enabled. Absent configuration means every rule.
+    #[must_use]
+    pub fn runs(&self, rule: Rule) -> bool {
+        self.rules.as_ref().is_none_or(|set| set.contains(&rule))
+    }
+}
+
+/// Whether a string is usable bare after `#` in a selector.
+fn is_plain_ident(value: &str) -> bool {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(first) if first.is_ascii_alphabetic() || first == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+/// Escape a value for a double-quoted attribute selector.
+fn escape_attr(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// A selector that finds this element again.
+///
+/// The `.ts` interpolates the id and the slot raw, so an id containing a quote,
+/// a space or a leading digit produces a selector that does not parse — and the
+/// selector's only job is to let a human or an agent locate the element. Quoted
+/// attribute form is used whenever the bare form would not survive.
+#[must_use]
+pub fn css_selector(node: &ObservedNode) -> String {
+    if let Some(id) = node.id.as_deref().filter(|s| !s.is_empty()) {
+        return if is_plain_ident(id) {
+            format!("#{id}")
+        } else {
+            format!("[id=\"{}\"]", escape_attr(id))
+        };
+    }
+    if let Some(slot) = node.data_slot.as_deref().filter(|s| !s.is_empty()) {
+        return format!("[data-slot=\"{}\"]", escape_attr(slot));
+    }
+    let tag = node.tag_name.to_ascii_lowercase();
+    match node.first_class.as_deref().filter(|s| !s.is_empty()) {
+        Some(class) if is_plain_ident(class) => format!("{tag}.{class}"),
+        Some(class) => format!("{tag}[class~=\"{}\"]", escape_attr(class)),
+        None => tag,
+    }
+}
+
+/// The heuristic the `.ts` uses to guess a node from a slot name.
+///
+/// It can only ever answer 2, 3 or 6, so it is a guess and named like one. Prefer
+/// [`resolve_node`], which asks the registry first.
+#[must_use]
+pub fn guess_node_from_slot(slot: &str) -> Option<u32> {
+    if slot.is_empty() {
+        return None;
+    }
+    if slot.starts_with("nyuchi-") && !slot.contains("page") {
+        return Some(3);
+    }
+    if slot.contains("page") || slot.contains("layout") {
+        return Some(6);
+    }
+    Some(2)
+}
+
+/// Which node owns the component in this slot.
+///
+/// The registry lookup wins; the heuristic is the fallback for a consumer
+/// auditing their own app, who has no Mzizi registry to consult.
+#[must_use]
+pub fn resolve_node(slot: Option<&str>, registry: &BTreeMap<String, u32>) -> Option<u32> {
+    let slot = slot?;
+    registry
+        .get(slot)
+        .copied()
+        .or_else(|| guess_node_from_slot(slot))
+}
+
+/// Build a violation carrying the element's identity.
+fn violation(
+    node: &ObservedNode,
+    helix_node: Option<u32>,
+    rule: Rule,
+    level: A11yLevel,
+    message: String,
+    fix: &str,
+) -> A11yViolation {
+    A11yViolation {
+        rule,
+        level,
+        message,
+        element: node.tag_name.clone(),
+        selector: css_selector(node),
+        node: helix_node,
+        component_name: node.data_slot.clone().filter(|s| !s.is_empty()),
+        portal_url: node.data_portal.clone().filter(|s| !s.is_empty()),
+        fix: fix.to_owned(),
+    }
+}
+
+/// Check one element against every enabled rule.
+///
+/// `previous_heading` is the level of the last heading seen before this element,
+/// which is why the caller iterates in document order. Returns every violation,
+/// never just the first.
+#[must_use]
+pub fn check_node(
+    node: &ObservedNode,
+    previous_heading: Option<u8>,
+    config: &A11yConfig,
+    registry: &BTreeMap<String, u32>,
+) -> Vec<A11yViolation> {
+    let mut found = Vec::new();
+    let helix_node = resolve_node(node.data_slot.as_deref(), registry);
+
+    if config.runs(Rule::ImgAlt) && node.tag_name.eq_ignore_ascii_case("img") && node.alt.is_none()
+    {
+        found.push(violation(
+            node,
+            helix_node,
+            Rule::ImgAlt,
+            A11yLevel::Critical,
+            "Image missing alt text".to_owned(),
+            "Add alt=\"\" for decorative or alt=\"description\" for informative",
+        ));
+    }
+
+    if config.runs(Rule::ButtonName) && node.is_button() && node.accessible_name().is_none() {
+        found.push(violation(
+            node,
+            helix_node,
+            Rule::ButtonName,
+            A11yLevel::Critical,
+            "Button missing accessible name".to_owned(),
+            "Add aria-label, aria-labelledby, or visible text",
+        ));
+    }
+
+    if config.runs(Rule::TouchTarget)
+        && node.is_touch_target()
+        && node.visible
+        && let Some(hit) = node.hit_box
+        && (hit.height < config.touch_target_min_px || hit.width < config.touch_target_min_px)
+    {
+        let min = config.touch_target_min_px.round();
+        found.push(violation(
+            node,
+            helix_node,
+            Rule::TouchTarget,
+            A11yLevel::Moderate,
+            format!(
+                "Touch target too small ({}×{}px, min {min}×{min})",
+                hit.width.round(),
+                hit.height.round()
+            ),
+            "Extend the interactive area with padding or surrounding spacing",
+        ));
+    }
+
+    // A heading may not skip a level going DOWN the document — h2 after h4 is a
+    // section ending, not a gap. The first heading on a page is compared against
+    // level 0, so an h3 with no h1 or h2 above it is a skip.
+    if config.runs(Rule::HeadingOrder)
+        && let Some(level) = node.heading_level()
+    {
+        let previous = previous_heading.unwrap_or(0);
+        if level > previous + 1 {
+            found.push(violation(
+                node,
+                helix_node,
+                Rule::HeadingOrder,
+                A11yLevel::Moderate,
+                format!("Heading level skipped (h{previous} → h{level})"),
+                "Use the next heading level down, or restructure the section",
+            ));
+        }
+    }
+
+    found
+}
+
+/// Audit a page.
+///
+/// `nodes` must be in document order — [`Rule::HeadingOrder`] depends on it.
+///
+/// An element PASSES when it produced no violation. The `.ts` counts passes in
+/// branches an interactive element cannot reach, so a correct button scored as
+/// neither a pass nor a violation and the page score fell as accessibility rose.
+#[must_use]
+pub fn audit(
+    url: impl Into<String>,
+    nodes: &[ObservedNode],
+    config: &A11yConfig,
+    registry: &BTreeMap<String, u32>,
+) -> A11yAuditResult {
+    let mut violations = Vec::new();
+    let mut passes = 0usize;
+    let mut previous_heading: Option<u8> = None;
+
+    for node in nodes {
+        let found = check_node(node, previous_heading, config, registry);
+        if found.is_empty() {
+            passes += 1;
+        }
+        violations.extend(found);
+        if let Some(level) = node.heading_level() {
+            previous_heading = Some(level);
+        }
+    }
+
+    let total = nodes.len();
+    A11yAuditResult {
+        url: url.into(),
+        total_elements: total,
+        violations,
+        passes,
+        // A page with no elements is not failing anything, which is different from
+        // being untested — `total_elements` says which.
+        score: if total == 0 {
+            100
+        } else {
+            ((passes as f64 / total as f64) * 100.0).round() as u32
+        },
+    }
+}
+
+/// The worst level present, for a single go/no-go answer.
+#[must_use]
+pub fn worst_level(violations: &[A11yViolation]) -> Option<A11yLevel> {
+    violations.iter().map(|v| v.level).max()
+}
+
+/// Whether a result clears a score threshold.
+#[must_use]
+pub fn meets_threshold(result: &A11yAuditResult, threshold: u32) -> bool {
+    result.score >= threshold
+}

--- a/components/registry/n8-assurance/mzizi-alert-engine.rs
+++ b/components/registry/n8-assurance/mzizi-alert-engine.rs
@@ -1,0 +1,320 @@
+//! Mzizi N8 assurance — SLO tracking, burn-rate alerting and escalation.
+//!
+//! The Rust implementation of `mzizi-alert-engine`.
+//!
+//! # What this owns
+//!
+//! Burn-rate arithmetic, the escalation decision, and the alert lifecycle. Not
+//! the timer, not the metrics store, not the DOM. The `.ts` sibling's `evaluate`
+//! runs on a `setInterval` and reads `const currentValue = 99.95` — a literal,
+//! under a comment saying *"in production this would query metrics… here we
+//! define the contract."*
+//!
+//! So the measurement is the host's and always was. What belongs here is the part
+//! that must not vary: given an observed value and an SLO, what fires and how
+//! loudly.
+//!
+//! # Two defects in the TypeScript, fixed here rather than ported
+//!
+//! **1. One breach fired one alert per matching escalation tier.** The `.ts`
+//! loops every tier and fires whenever `burnRate >= esc.burnRate`, so an SLO
+//! escalating at 1× warning / 2× critical / 5× page produces *three* alerts at a
+//! burn rate of 6 — and one of them pages a human, three times, for a single
+//! breach. [`escalate_to`] returns the **highest matching tier, once**, which is
+//! what an escalation ladder means.
+//!
+//! **2. Alert ids collided.** `alert-${Date.now()}` is unique only if no two
+//! alerts fire in the same millisecond, and a burn-rate breach fires several
+//! alerts in the same tick by construction — so the defects compounded, with the
+//! duplicates overwriting each other in the `Map`. Ids are supplied here, for the
+//! same reason trace ids are: a core has no clock and should not invent identity.
+//!
+//! Neither is a translation choice. A faithful port would have carried both
+//! across, and `cargo check` would have been perfectly happy with them.
+
+use std::collections::BTreeMap;
+
+/// How loud an alert is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AlertSeverity {
+    /// Informational. No action expected.
+    Info,
+    /// Someone should look when convenient.
+    Warning,
+    /// Someone should look now.
+    Critical,
+    /// Wake a human.
+    Page,
+}
+
+impl AlertSeverity {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Info => "info",
+            Self::Warning => "warning",
+            Self::Critical => "critical",
+            Self::Page => "page",
+        }
+    }
+}
+
+/// Where an alert is in its life.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlertState {
+    /// Currently breaching.
+    Firing,
+    /// Breaching but inside its grace period.
+    Pending,
+    /// No longer breaching.
+    Resolved,
+}
+
+impl AlertState {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Firing => "firing",
+            Self::Pending => "pending",
+            Self::Resolved => "resolved",
+        }
+    }
+}
+
+/// Which metric an SLO tracks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SloMetric {
+    /// Fraction of requests served.
+    Availability,
+    /// 99th-percentile latency.
+    LatencyP99,
+    /// Fraction of requests that errored.
+    ErrorRate,
+    /// Fraction of requests that succeeded.
+    SuccessRate,
+}
+
+impl SloMetric {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Availability => "availability",
+            Self::LatencyP99 => "latency_p99",
+            Self::ErrorRate => "error_rate",
+            Self::SuccessRate => "success_rate",
+        }
+    }
+}
+
+/// One rung of an escalation ladder.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Escalation {
+    /// Burn rate at or above which this rung applies.
+    pub burn_rate: f64,
+    /// How loud to be at this rung.
+    pub severity: AlertSeverity,
+}
+
+/// A service-level objective.
+#[derive(Debug, Clone)]
+pub struct SloDefinition {
+    /// Stable id.
+    pub id: String,
+    /// Human name.
+    pub name: String,
+    /// Target percentage, e.g. `99.9`.
+    pub target: f64,
+    /// Window in hours, e.g. `720` for 30 days.
+    pub window_hours: u32,
+    /// Which metric this tracks.
+    pub metric: SloMetric,
+    /// Which mini-apps it covers.
+    pub mini_apps: Vec<String>,
+    /// The escalation ladder. Order does not matter — the highest match wins.
+    pub escalation: Vec<Escalation>,
+}
+
+/// A fired alert.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Alert {
+    /// Stable id, supplied by the host.
+    pub id: String,
+    /// The SLO this came from, when it came from one.
+    pub slo_id: Option<String>,
+    /// Human name.
+    pub name: String,
+    /// How loud.
+    pub severity: AlertSeverity,
+    /// Where it is in its life.
+    pub state: AlertState,
+    /// What happened, in words.
+    pub message: String,
+    /// When it fired, in milliseconds since the Unix epoch.
+    pub fired_at_ms: f64,
+    /// When it resolved.
+    pub resolved_at_ms: Option<f64>,
+    /// Components implicated.
+    ///
+    /// Supplied by the host. The `.ts` falls back to
+    /// `document.querySelectorAll("[data-portal]")`, which is DOM access — the
+    /// host's business, and meaningless in a Worker or a native shell.
+    pub affected_components: Vec<String>,
+    /// Mini-apps implicated.
+    pub affected_mini_apps: Vec<String>,
+    /// Who has been told.
+    pub notified: Vec<String>,
+    /// Where the runbook is.
+    pub runbook_url: Option<String>,
+}
+
+/// Error-budget burn rate for an observed value against a target.
+///
+/// Returns `0.0` while the objective is being met, and otherwise how many times
+/// over the budget the breach is: a target of 99.9 observed at 99.8 has consumed
+/// its whole 0.1 budget once, so the rate is 1.0.
+///
+/// # A 100% target
+///
+/// `100 - target` is the budget, and a target of 100 leaves none — so any breach
+/// is infinitely over it. The `.ts` divides straight through and yields
+/// `Infinity`, which then compares `>=` true against every escalation rung and
+/// pages immediately. That is arguably the right answer for an SLO that admits no
+/// failure, but it arrives by accident. Here it is explicit: an unmeetable
+/// objective returns [`f64::INFINITY`] deliberately, and a caller can decide
+/// whether that objective was a mistake.
+#[must_use]
+pub fn burn_rate(observed: f64, target: f64) -> f64 {
+    let remaining = observed - target;
+    if remaining >= 0.0 {
+        return 0.0;
+    }
+    let budget = 100.0 - target;
+    if budget <= 0.0 {
+        return f64::INFINITY;
+    }
+    remaining.abs() / budget
+}
+
+/// The single rung an escalation ladder reaches at this burn rate.
+///
+/// Returns the **highest** matching rung, or `None` when none match. This is the
+/// fix for the `.ts`'s per-rung firing: an escalation ladder describes one
+/// response that gets louder, not a set of independent triggers, and treating it
+/// as the latter pages a human once per rung they configured.
+///
+/// Ties on `burn_rate` break toward the louder severity, because under-alerting a
+/// breach is the worse error.
+#[must_use]
+pub fn escalate_to(escalation: &[Escalation], burn_rate: f64) -> Option<Escalation> {
+    escalation
+        .iter()
+        .filter(|e| burn_rate >= e.burn_rate)
+        .copied()
+        .max_by(|a, b| {
+            a.burn_rate
+                .partial_cmp(&b.burn_rate)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.severity.cmp(&b.severity))
+        })
+}
+
+/// Evaluate one SLO against an observed value.
+///
+/// Returns at most ONE alert, which is the whole point. `id` and `fired_at_ms`
+/// are supplied because a core has neither a counter nor a clock.
+#[must_use]
+pub fn evaluate_slo(
+    slo: &SloDefinition,
+    observed: f64,
+    id: impl Into<String>,
+    fired_at_ms: f64,
+) -> Option<Alert> {
+    let rate = burn_rate(observed, slo.target);
+    let rung = escalate_to(&slo.escalation, rate)?;
+    Some(Alert {
+        id: id.into(),
+        slo_id: Some(slo.id.clone()),
+        name: format!("SLO breach: {}", slo.name),
+        severity: rung.severity,
+        state: AlertState::Firing,
+        message: format!(
+            "{} burn rate {rate:.2}x (threshold: {}x). Current: {observed}%, target: {}%",
+            slo.name, rung.burn_rate, slo.target
+        ),
+        fired_at_ms,
+        resolved_at_ms: None,
+        affected_components: Vec::new(),
+        affected_mini_apps: slo.mini_apps.clone(),
+        notified: Vec::new(),
+        runbook_url: Some(format!("https://mzizi.dev/runbooks/{}", slo.id)),
+    })
+}
+
+/// The set of alerts a host is tracking.
+///
+/// Ordered, so "the active alerts" is a stable list rather than whatever order a
+/// hash map happened to produce — a dashboard that reshuffles between polls is
+/// one nobody trusts.
+#[derive(Debug, Clone, Default)]
+pub struct AlertLog {
+    alerts: BTreeMap<String, Alert>,
+}
+
+impl AlertLog {
+    /// An empty log.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a fired alert, returning the previous one with that id if any.
+    ///
+    /// Returning the displaced alert rather than dropping it is deliberate: with
+    /// the `.ts`'s colliding `Date.now()` ids this silently destroyed alerts, and
+    /// a caller that ignores the return value at least had the chance not to.
+    pub fn fire(&mut self, alert: Alert) -> Option<Alert> {
+        self.alerts.insert(alert.id.clone(), alert)
+    }
+
+    /// Mark an alert resolved. Returns false if the id is unknown.
+    pub fn resolve(&mut self, id: &str, resolved_at_ms: f64) -> bool {
+        match self.alerts.get_mut(id) {
+            Some(alert) => {
+                alert.state = AlertState::Resolved;
+                alert.resolved_at_ms = Some(resolved_at_ms);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Every alert currently firing.
+    #[must_use]
+    pub fn active(&self) -> Vec<&Alert> {
+        self.alerts
+            .values()
+            .filter(|a| a.state == AlertState::Firing)
+            .collect()
+    }
+
+    /// Every alert, resolved or not.
+    #[must_use]
+    pub fn all(&self) -> Vec<&Alert> {
+        self.alerts.values().collect()
+    }
+
+    /// How many alerts are held.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.alerts.len()
+    }
+
+    /// Whether the log is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.alerts.is_empty()
+    }
+}

--- a/components/registry/n8-assurance/mzizi-api-probe.rs
+++ b/components/registry/n8-assurance/mzizi-api-probe.rs
@@ -1,0 +1,226 @@
+//! Mzizi N8 assurance — endpoint health classification.
+//!
+//! The Rust implementation of `mzizi-api-probe`.
+//!
+//! # What this owns
+//!
+//! What a response *means*: healthy, degraded, down or timed out. Not the
+//! request. The `.ts` sibling's `runApiProbe` performs `fetch` with an
+//! `AbortController`, which is I/O and therefore the host's — the same boundary
+//! the exporter draws at sending and the probe draws at driving a browser.
+//!
+//! # Two defects in the TypeScript, fixed here
+//!
+//! **1. A timeout was detected by string-matching the error.** The `.ts` writes
+//! `String(err).includes("abort")`, and the text of an abort differs by runtime:
+//! *"The operation was aborted"*, *"This operation was aborted"*, *"signal is
+//! aborted without reason"*. So the same timeout classifies as `timeout` in one
+//! host and `down` in another — and `down` pages people while `timeout` often
+//! does not. The caller always knows whether it aborted, so [`Outcome`] carries
+//! the fact instead of the core guessing at prose.
+//!
+//! **2. The degraded threshold ignored the timeout.** 2000 ms was hardcoded while
+//! the request timeout was configurable at 5000. Set the timeout below 2000 and
+//! nothing can ever be `Degraded`: the request aborts before it can be slow. The
+//! threshold is a parameter here, and [`degraded_threshold_for`] derives a
+//! sensible one from the timeout so the two cannot contradict each other.
+//!
+//! # One field that never had a producer
+//!
+//! `EndpointStatus` declares `"unknown"` and nothing in the `.ts` ever returns
+//! it. It is kept, because a host that has not yet probed an endpoint needs a way
+//! to say so — and a dashboard rendering "unknown" is honest where rendering
+//! "healthy" by default is not.
+
+/// What a probe made of an endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EndpointStatus {
+    /// Responded, and quickly enough.
+    Healthy,
+    /// Responded, but slowly.
+    Degraded,
+    /// Responded with a failure, or the connection failed.
+    Down,
+    /// Did not respond inside the allotted time.
+    Timeout,
+    /// Not yet probed. Never inferred — only stated.
+    Unknown,
+}
+
+impl EndpointStatus {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Healthy => "healthy",
+            Self::Degraded => "degraded",
+            Self::Down => "down",
+            Self::Timeout => "timeout",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// Whether this status should worry somebody.
+    #[must_use]
+    pub const fn is_unhealthy(self) -> bool {
+        matches!(self, Self::Degraded | Self::Down | Self::Timeout)
+    }
+}
+
+/// What the host's request actually did.
+///
+/// An enum rather than an error string, so a timeout is a *fact the caller
+/// reports* instead of something this module infers from prose it did not write.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// The request completed with an HTTP status.
+    Responded {
+        /// The HTTP status code.
+        status_code: u16,
+    },
+    /// The request was aborted for exceeding its deadline.
+    TimedOut,
+    /// The request failed before producing a status.
+    Failed {
+        /// Whatever the host can say about why.
+        error: String,
+    },
+}
+
+/// An endpoint to probe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Endpoint {
+    /// Full URL.
+    pub url: String,
+    /// Which component it reports for.
+    pub component_name: String,
+    /// Which helix node that component belongs to.
+    pub node: u32,
+}
+
+/// One probe's finding.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EndpointCheck {
+    /// Which endpoint.
+    pub url: String,
+    /// Which component.
+    pub component_name: String,
+    /// Which node.
+    pub node: u32,
+    /// The verdict.
+    pub status: EndpointStatus,
+    /// HTTP status, when there was one.
+    pub status_code: Option<u16>,
+    /// How long it took.
+    pub latency_ms: f64,
+    /// When, in milliseconds since the Unix epoch.
+    pub checked_at_ms: f64,
+    /// Why it failed, when it did.
+    pub error: Option<String>,
+}
+
+/// A slow-but-alive threshold that cannot contradict the timeout.
+///
+/// Returns 40% of the timeout, floored at 250 ms. The `.ts`'s fixed 2000 ms was
+/// meaningless whenever the timeout was lower, because the request aborted before
+/// it could ever be classified slow — the `Degraded` state simply became
+/// unreachable, silently.
+#[must_use]
+pub fn degraded_threshold_for(timeout_ms: f64) -> f64 {
+    (timeout_ms * 0.4).max(250.0)
+}
+
+/// Classify one outcome.
+///
+/// A 2xx/3xx response is healthy unless it was slow; anything else is down. The
+/// latency test applies only to a successful response, because a slow 500 is
+/// down, not degraded — reporting it as degraded would understate an outage.
+#[must_use]
+pub fn classify(outcome: &Outcome, latency_ms: f64, degraded_above_ms: f64) -> EndpointStatus {
+    match outcome {
+        Outcome::TimedOut => EndpointStatus::Timeout,
+        Outcome::Failed { .. } => EndpointStatus::Down,
+        Outcome::Responded { status_code } => {
+            if (200..400).contains(status_code) {
+                if latency_ms > degraded_above_ms {
+                    EndpointStatus::Degraded
+                } else {
+                    EndpointStatus::Healthy
+                }
+            } else {
+                EndpointStatus::Down
+            }
+        }
+    }
+}
+
+/// Build a check from an endpoint and what the host's request did.
+#[must_use]
+pub fn check(
+    endpoint: &Endpoint,
+    outcome: &Outcome,
+    latency_ms: f64,
+    checked_at_ms: f64,
+    degraded_above_ms: f64,
+) -> EndpointCheck {
+    EndpointCheck {
+        url: endpoint.url.clone(),
+        component_name: endpoint.component_name.clone(),
+        node: endpoint.node,
+        status: classify(outcome, latency_ms, degraded_above_ms),
+        status_code: match outcome {
+            Outcome::Responded { status_code } => Some(*status_code),
+            _ => None,
+        },
+        latency_ms,
+        checked_at_ms,
+        error: match outcome {
+            Outcome::Failed { error } => Some(error.clone()),
+            Outcome::TimedOut => Some(format!("timed out after {latency_ms:.0}ms")),
+            Outcome::Responded { .. } => None,
+        },
+    }
+}
+
+/// The default endpoints, mirroring the `.ts`.
+///
+/// A starting set, not a registry. The `.ts` carries a comment saying production
+/// discovers these from a `component_backlinks` view — which remains true, and is
+/// the host's job because it is a database read.
+#[must_use]
+pub fn default_endpoints(base_url: &str) -> Vec<Endpoint> {
+    let base = base_url.trim_end_matches('/');
+    [
+        ("nyuchi-tokens", 1),
+        ("nyuchi-section", 5),
+        ("nyuchi-wallet-gate", 4),
+        ("wallet-page", 6),
+    ]
+    .into_iter()
+    .map(|(name, node)| Endpoint {
+        url: format!("{base}/api/health/{name}"),
+        component_name: name.to_owned(),
+        node,
+    })
+    .collect()
+}
+
+/// The worst status in a set of checks.
+///
+/// "Worst" rather than "most common", because one endpoint being down is an
+/// outage even when nine are healthy — an average would hide exactly the case
+/// worth seeing.
+#[must_use]
+pub fn worst_status(checks: &[EndpointCheck]) -> EndpointStatus {
+    checks
+        .iter()
+        .map(|c| c.status)
+        .max_by_key(|s| match s {
+            EndpointStatus::Healthy => 0,
+            EndpointStatus::Unknown => 1,
+            EndpointStatus::Degraded => 2,
+            EndpointStatus::Timeout => 3,
+            EndpointStatus::Down => 4,
+        })
+        .unwrap_or(EndpointStatus::Unknown)
+}

--- a/components/registry/n8-assurance/mzizi-chaos.rs
+++ b/components/registry/n8-assurance/mzizi-chaos.rs
@@ -1,0 +1,313 @@
+//! Mzizi N8 assurance — chaos injection and blast-radius diagnosis.
+//!
+//! The Rust implementation of `mzizi-chaos`. The `.tsx` extension is misleading:
+//! all but the last thirty lines of that file are pure functions, and the React
+//! context around them is a thin wrapper. This is the logic half.
+//!
+//! # What this owns
+//!
+//! Whether to inject, into what, and what a set of probe results means. Not the
+//! probing: the host performs the requests, because a core with no I/O is the
+//! whole point of N8 being a shared core.
+//!
+//! # Five defects in the TypeScript, fixed here
+//!
+//! **1. `targetNodes` was declared and never read.** The field is documented
+//! "Nodes to target (empty = all)", and nothing in the file consults it — so a
+//! consumer scoping chaos to N5 got chaos in every node, having taken the
+//! deliberate step of narrowing it. A configuration option that silently does
+//! nothing is worse than an absent one, because it buys confidence. [`ChaosConfig::targets`]
+//! is now the gate and every injection decision takes the node.
+//!
+//! **2. `featureFlag` was declared and never read either.** Documented as a key
+//! "for remote control", with no remote control anywhere in the component. Kept as
+//! [`ChaosConfig::feature_flag`] because a host genuinely can resolve a flag and
+//! pass the result in, and named in the docs as what it is: an input to the host's
+//! decision, not something this core acts on.
+//!
+//! **3. The blast-radius bands could not all be reached, and the unreachable one
+//! was the calm one.** `errorCount < probes.length / 2` gives, for the default two
+//! probes: 0 errors → `isolated`, 1 → `systemic`, 2 → `systemic`. `partial` is
+//! unreachable, so ONE failing endpoint out of two recommended "Activate incident
+//! response". A classifier whose middle band is dead and whose error is toward
+//! paging is one people learn to disregard. [`classify_blast_radius`] uses the
+//! fraction, with the boundaries stated.
+//!
+//! **4. The default endpoint list was app-specific, and it compounded defect 3.**
+//! `/api/weather?lat=-17.83&lon=31.05` is hardcoded into a component anyone can
+//! install. In any app that is not the weather app, that probe fails every time —
+//! one failure out of two — which defect 3 then classifies as a systemic outage.
+//! Installed anywhere else, this component reported a systemic outage on every
+//! single diagnosis. There is no default probe set here: an empty list means
+//! nothing was probed, and [`BlastRadius::Unknown`] says so.
+//!
+//! **5. The report was written to the console on every diagnosis.** A
+//! `console.warn` with `JSON.stringify(report, null, 2)`, unconditionally, in a
+//! component that "runs in production" by its own header — carrying an error
+//! message that is attacker-influenced whenever user input reaches an exception.
+//! This core returns the report; where it goes is the host's.
+//!
+//! # Randomness is supplied, as everywhere in this node
+//!
+//! [`should_inject_error`] takes the draw rather than making it — not for a
+//! security reason, but because a core with no I/O has no entropy source, and a
+//! caller that supplies the draw can test the boundary rather than the odds.
+
+use std::collections::BTreeSet;
+
+/// How chaos is configured.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChaosConfig {
+    /// Whether to inject anything at all.
+    pub enabled: bool,
+    /// Chance of an injected error, per render.
+    pub error_probability: f64,
+    /// Chance of injected latency, per fetch.
+    pub latency_probability: f64,
+    /// The ceiling on injected latency, in milliseconds.
+    pub max_latency_ms: u32,
+    /// Which helix nodes to target. Empty means all.
+    ///
+    /// The `.ts` declares this and never reads it, so narrowing chaos to one node
+    /// had no effect. Uncapped — node numbers are labels (CLAUDE.md §9).
+    pub target_nodes: BTreeSet<u32>,
+    /// A remote flag key the HOST resolves.
+    ///
+    /// This core never fetches it; a flag lookup is I/O. The host resolves the key
+    /// and reflects the answer in [`ChaosConfig::enabled`]. The `.ts` reads it
+    /// nowhere at all, which is not the same thing.
+    pub feature_flag: Option<String>,
+}
+
+impl Default for ChaosConfig {
+    /// The `.ts` defaults: off, 0.1% errors, 0.5% latency, 3s ceiling, all nodes.
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            error_probability: 0.001,
+            latency_probability: 0.005,
+            max_latency_ms: 3000,
+            target_nodes: BTreeSet::new(),
+            feature_flag: None,
+        }
+    }
+}
+
+impl ChaosConfig {
+    /// Whether this node is in scope.
+    ///
+    /// An empty [`ChaosConfig::target_nodes`] means every node, which is what the
+    /// field's own documentation says and what the `.ts` never implemented.
+    #[must_use]
+    pub fn targets(&self, node: u32) -> bool {
+        self.target_nodes.is_empty() || self.target_nodes.contains(&node)
+    }
+}
+
+/// Whether to inject an error into a component on this node.
+///
+/// `draw` is a value in `[0, 1)` from the host.
+#[must_use]
+pub fn should_inject_error(config: &ChaosConfig, node: u32, draw: f64) -> bool {
+    config.enabled && config.targets(node) && draw < config.error_probability
+}
+
+/// Whether to inject latency into a request from this node.
+#[must_use]
+pub fn should_inject_latency(config: &ChaosConfig, node: u32, draw: f64) -> bool {
+    config.enabled && config.targets(node) && draw < config.latency_probability
+}
+
+/// How much latency to inject.
+///
+/// Returns 0 when chaos is disabled. The `.ts` computes a delay regardless, so a
+/// caller reaching for it directly slowed a system with chaos switched off.
+#[must_use]
+pub fn injected_latency_ms(config: &ChaosConfig, draw: f64) -> u32 {
+    if !config.enabled {
+        return 0;
+    }
+    let clamped = draw.clamp(0.0, 1.0);
+    (clamped * f64::from(config.max_latency_ms)).floor() as u32
+}
+
+/// The message an injected error carries.
+///
+/// The prefix is load-bearing: an injected failure that reads like a real one
+/// wastes an on-call hour, and this string is what tells them apart in a log.
+#[must_use]
+pub fn injected_error_message(node: u32, component: &str) -> String {
+    format!("[nyuchi:chaos] Injected error in Node {node} component \"{component}\"")
+}
+
+/// How a probe answered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ProbeStatus {
+    /// Answered, and well.
+    Healthy,
+    /// Answered, badly.
+    Degraded,
+    /// Did not answer in time.
+    Timeout,
+    /// Did not answer.
+    Error,
+}
+
+impl ProbeStatus {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Healthy => "healthy",
+            Self::Degraded => "degraded",
+            Self::Timeout => "timeout",
+            Self::Error => "error",
+        }
+    }
+
+    /// Whether this counts toward the blast radius.
+    ///
+    /// `degraded` does NOT, matching the `.ts`: a slow-but-answering dependency is
+    /// not the same signal as an unreachable one, and folding the two together
+    /// would make every busy afternoon look like an outage.
+    #[must_use]
+    pub const fn is_down(self) -> bool {
+        matches!(self, Self::Timeout | Self::Error)
+    }
+}
+
+/// What one probe found.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProbeResult {
+    /// What was probed.
+    pub target: String,
+    /// How it answered.
+    pub status: ProbeStatus,
+    /// How long it took, in milliseconds.
+    pub latency_ms: f64,
+    /// What went wrong, when something did.
+    pub error: Option<String>,
+}
+
+/// How far a failure reaches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlastRadius {
+    /// Nothing else is down.
+    Isolated,
+    /// Some dependencies are down.
+    Partial,
+    /// Most or all are.
+    Systemic,
+    /// Nothing was probed, so nothing is known.
+    ///
+    /// The `.ts` has no such case: zero probes gives `errorCount === 0`, which is
+    /// `isolated` — "component-level issue, retry should resolve", asserted with
+    /// no evidence whatsoever.
+    Unknown,
+}
+
+impl BlastRadius {
+    /// The wire spelling. `unknown` has no `.ts` counterpart.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Isolated => "isolated",
+            Self::Partial => "partial",
+            Self::Systemic => "systemic",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// What to do about it.
+    #[must_use]
+    pub const fn recommendation(self) -> &'static str {
+        match self {
+            Self::Isolated => "Component-level issue. Retry should resolve.",
+            Self::Partial => "Multiple services affected. Check infrastructure.",
+            Self::Systemic => "Systemic outage. Activate incident response.",
+            Self::Unknown => "No dependencies were probed. Blast radius unknown.",
+        }
+    }
+}
+
+/// The fraction of probes that must be down, EXCLUSIVELY, for a failure to be
+/// systemic. More than half, not half.
+///
+/// The strictness is the whole fix and it is easy to get wrong twice: `>= 0.5`
+/// leaves `partial` exactly as unreachable with two probes as the `.ts`'s
+/// `< length / 2` did — 0 down is isolated, 1 is systemic, 2 is systemic. This
+/// author wrote `>=` first and the test caught it. With `>`, two probes reach all
+/// three bands, which is what the classifier claims to offer.
+pub const SYSTEMIC_FRACTION: f64 = 0.5;
+
+/// Classify a set of probe results.
+///
+/// Nothing down is [`BlastRadius::Isolated`]; MORE than [`SYSTEMIC_FRACTION`] down
+/// is [`BlastRadius::Systemic`]; anything between is [`BlastRadius::Partial`].
+///
+/// The `.ts` writes `errorCount < probes.length / 2`, which for its own default of
+/// two probes makes `partial` unreachable — one failure out of two lands on
+/// `systemic` and recommends activating incident response.
+#[must_use]
+pub fn classify_blast_radius(probes: &[ProbeResult]) -> BlastRadius {
+    if probes.is_empty() {
+        return BlastRadius::Unknown;
+    }
+    let down = probes.iter().filter(|p| p.status.is_down()).count();
+    if down == 0 {
+        return BlastRadius::Isolated;
+    }
+    if (down as f64 / probes.len() as f64) > SYSTEMIC_FRACTION {
+        BlastRadius::Systemic
+    } else {
+        BlastRadius::Partial
+    }
+}
+
+/// What a diagnosis concluded.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiagnosticReport {
+    /// When, milliseconds since the Unix epoch.
+    pub at_ms: f64,
+    /// Which component failed first.
+    pub trigger_component: String,
+    /// What it said.
+    pub trigger_error: String,
+    /// What the dependencies said.
+    pub probes: Vec<ProbeResult>,
+    /// How far it reaches.
+    pub blast_radius: BlastRadius,
+    /// What to do.
+    pub recommendation: String,
+}
+
+/// Turn probe results into a report.
+///
+/// There is no default endpoint list, deliberately. The `.ts` ships
+/// `/api/weather?lat=-17.83&lon=31.05` as a default in a component anyone can
+/// install, so in any app that is not the weather app that probe fails every time
+/// — one failure out of two, which its classifier then calls a systemic outage.
+/// Installed anywhere else, it reported a systemic outage on every diagnosis. The
+/// host names what to probe; probing nothing answers [`BlastRadius::Unknown`].
+///
+/// The report is RETURNED, never logged. The `.ts` writes it to the console on
+/// every diagnosis, in a component whose own header says it runs in production,
+/// carrying an error message that is attacker-influenced whenever user input
+/// reaches an exception.
+#[must_use]
+pub fn diagnose(
+    trigger_component: impl Into<String>,
+    trigger_error: impl Into<String>,
+    probes: Vec<ProbeResult>,
+    at_ms: f64,
+) -> DiagnosticReport {
+    let blast_radius = classify_blast_radius(&probes);
+    DiagnosticReport {
+        at_ms,
+        trigger_component: trigger_component.into(),
+        trigger_error: trigger_error.into(),
+        probes,
+        blast_radius,
+        recommendation: blast_radius.recommendation().to_owned(),
+    }
+}

--- a/components/registry/n8-assurance/mzizi-conformity-check.rs
+++ b/components/registry/n8-assurance/mzizi-conformity-check.rs
@@ -41,6 +41,21 @@
 //! absent from the registry does not make the other findings untrue, and the
 //! aria one is a real accessibility defect either way.
 //!
+//! **4. The `missing_aria` rule could never fire for a `role="button"` element.**
+//! The `.ts` computes `const ariaLabel = el.getAttribute("aria-label") ||
+//! el.getAttribute("role")` and then refuses to report when `ariaLabel` is truthy
+//! — so any element carrying `role="button"` supplies its own "name" and is
+//! exempted by the very attribute that brought it into the rule's scope. The rule
+//! was widened past `<button>` specifically to catch those elements and then
+//! excluded all of them; only a literal `<button>` with no `role`, no `aria-label`
+//! and no text could ever be reported.
+//!
+//! A role is not a name. `mzizi-a11y-audit` had the correct definition all along
+//! — `aria-label`, `aria-labelledby`, or text — and two N8 components disagreeing
+//! about what an accessible name IS meant the same button was a violation on one
+//! surface and a pass on the other. [`ObservedElement::has_accessible_name`] now
+//! matches the audit, `aria-labelledby` included.
+//!
 //! # Two variants that never had a producer
 //!
 //! `version_mismatch` and `missing_slot` are declared in the `.ts` union and
@@ -121,7 +136,10 @@ pub struct ObservedElement {
     pub portal_url: Option<String>,
     /// The `aria-label`, when present.
     pub aria_label: Option<String>,
-    /// The `role`, when present.
+    /// The `aria-labelledby`, when present.
+    pub aria_labelledby: Option<String>,
+    /// The `role`, when present. Decides whether the element is INTERACTIVE; it
+    /// is not a source of an accessible name.
     pub role: Option<String>,
     /// Whether the element has any non-whitespace text.
     pub has_text: bool,
@@ -135,9 +153,12 @@ impl ObservedElement {
     }
 
     /// Whether a screen reader would announce a name for it.
+    ///
+    /// `role` is deliberately absent. Counting it — as the `.ts` does — makes the
+    /// rule unfireable for the `role="button"` elements it exists to cover.
     #[must_use]
     pub fn has_accessible_name(&self) -> bool {
-        self.aria_label.is_some() || self.role.is_some() || self.has_text
+        self.aria_label.is_some() || self.aria_labelledby.is_some() || self.has_text
     }
 }
 

--- a/components/registry/n8-assurance/mzizi-conformity-check.rs
+++ b/components/registry/n8-assurance/mzizi-conformity-check.rs
@@ -1,0 +1,311 @@
+//! Mzizi N8 assurance — does production match the registry?
+//!
+//! The Rust implementation of `mzizi-conformity-check` (a Conformity Monkey for
+//! the component registry).
+//!
+//! # What this owns
+//!
+//! The rules and the score. Not the DOM walk: the host collects what it sees and
+//! hands over a list of [`ObservedElement`], which is the only part that needs a
+//! browser.
+//!
+//! That split is what makes the check runnable somewhere it never was. The `.ts`
+//! calls `document.querySelectorAll` directly, so conformity could only ever be
+//! assessed inside a live page — never against server-rendered HTML in CI, and
+//! never from the Worker that is supposed to notice when a deploy stops
+//! conforming.
+//!
+//! # Three defects in the TypeScript, fixed here
+//!
+//! **1. `onViolation` fired for one violation type out of four.** The
+//! `unregistered` branch builds its violation object twice — once to push, once
+//! to hand to the callback — and every other branch only pushes. So a consumer
+//! wiring `onViolation` to an alerting path saw unregistered components and
+//! silently never saw a deprecated one, a missing portal link or a missing
+//! accessible name. Structurally impossible here: [`check_conformity`] returns
+//! every violation and the host dispatches, so there is no second code path to
+//! forget.
+//!
+//! **2. The score was wrong whenever a component name repeated.** Conformance was
+//! counted with `violations.filter(v => v.componentName === slot).length === 0`,
+//! which asks "has *any* element with this slot name had a violation" — so one
+//! bad button marks every other button on the page non-conformant. A page with
+//! twenty conformant buttons and one broken one scored zero for all twenty-one.
+//! Counted per element here.
+//!
+//! It was also O(n²): a full scan of the violation list for every element.
+//!
+//! **3. An unregistered component skipped every other check.** The `.ts` returns
+//! early, so an unregistered component that is *also* deprecated and *also*
+//! missing an accessible name reports one violation instead of three. Being
+//! absent from the registry does not make the other findings untrue, and the
+//! aria one is a real accessibility defect either way.
+//!
+//! # Two variants that never had a producer
+//!
+//! `version_mismatch` and `missing_slot` are declared in the `.ts` union and
+//! nothing emits either. They are kept because both describe real conditions a
+//! host can detect — a rendered component whose version differs from the
+//! registry's, and a registry component rendered with no `data-slot` at all —
+//! and a union that can express a finding is better than one that cannot. What
+//! is not kept is any pretence that this module produces them.
+
+use std::collections::BTreeSet;
+
+/// What kind of conformity failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ViolationType {
+    /// Rendered but absent from the registry.
+    Unregistered,
+    /// Missing the `data-portal` backlink.
+    MissingPortal,
+    /// Registered, but deprecated.
+    Deprecated,
+    /// Rendered version differs from the registry's. Never produced here.
+    VersionMismatch,
+    /// An interactive element with no accessible name.
+    MissingAria,
+    /// A registry component rendered without `data-slot`. Never produced here.
+    MissingSlot,
+}
+
+impl ViolationType {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unregistered => "unregistered",
+            Self::MissingPortal => "missing_portal",
+            Self::Deprecated => "deprecated",
+            Self::VersionMismatch => "version_mismatch",
+            Self::MissingAria => "missing_aria",
+            Self::MissingSlot => "missing_slot",
+        }
+    }
+}
+
+/// How much a violation matters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ViolationSeverity {
+    /// Worth knowing.
+    Info,
+    /// Worth fixing.
+    Warning,
+    /// Worth blocking on.
+    Error,
+}
+
+impl ViolationSeverity {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Info => "info",
+            Self::Warning => "warning",
+            Self::Error => "error",
+        }
+    }
+}
+
+/// What the host saw on the page.
+///
+/// One of these per element carrying a `data-slot`. Gathering them is the only
+/// step that needs a browser; everything after is arithmetic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObservedElement {
+    /// The `data-slot` value.
+    pub slot: String,
+    /// The element's tag name, e.g. `BUTTON`.
+    pub tag_name: String,
+    /// The `data-portal` backlink, when present.
+    pub portal_url: Option<String>,
+    /// The `aria-label`, when present.
+    pub aria_label: Option<String>,
+    /// The `role`, when present.
+    pub role: Option<String>,
+    /// Whether the element has any non-whitespace text.
+    pub has_text: bool,
+}
+
+impl ObservedElement {
+    /// Whether this element is interactive in the sense the aria rule means.
+    #[must_use]
+    pub fn is_interactive(&self) -> bool {
+        self.tag_name.eq_ignore_ascii_case("button") || self.role.as_deref() == Some("button")
+    }
+
+    /// Whether a screen reader would announce a name for it.
+    #[must_use]
+    pub fn has_accessible_name(&self) -> bool {
+        self.aria_label.is_some() || self.role.is_some() || self.has_text
+    }
+}
+
+/// One finding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConformityViolation {
+    /// What kind.
+    pub violation_type: ViolationType,
+    /// Which component.
+    pub component_name: String,
+    /// The element's tag.
+    pub element: String,
+    /// A selector that finds it again.
+    pub selector: String,
+    /// What is wrong, in words.
+    pub message: String,
+    /// Where the component's documentation is.
+    pub portal_url: Option<String>,
+    /// How much it matters.
+    pub severity: ViolationSeverity,
+}
+
+/// What a whole page scored.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConformityReport {
+    /// The path checked.
+    pub url: String,
+    /// How many slotted elements were seen.
+    pub total_components: usize,
+    /// How many had no violations of their own.
+    pub conformant: usize,
+    /// Every finding.
+    pub violations: Vec<ConformityViolation>,
+    /// Percentage conformant, 0-100.
+    pub score: u32,
+}
+
+/// A CSS selector for a slot value, with quotes escaped.
+///
+/// A slot containing `"` would otherwise produce a selector that does not parse
+/// — and the selector's whole job is to let somebody find the element again.
+#[must_use]
+pub fn selector_for(slot: &str) -> String {
+    format!(
+        "[data-slot=\"{}\"]",
+        slot.replace('\\', "\\\\").replace('"', "\\\"")
+    )
+}
+
+/// Check one element against the registry.
+///
+/// Returns every violation it has, not the first. An unregistered component that
+/// is also missing its accessible name has two problems, and the second is a real
+/// accessibility defect regardless of the first.
+#[must_use]
+pub fn check_element(
+    element: &ObservedElement,
+    registry: Option<&BTreeSet<String>>,
+    deprecated: &BTreeSet<String>,
+) -> Vec<ConformityViolation> {
+    let mut violations = Vec::new();
+    let selector = selector_for(&element.slot);
+
+    let base = |violation_type: ViolationType,
+                message: String,
+                severity: ViolationSeverity,
+                portal_url: Option<String>| ConformityViolation {
+        violation_type,
+        component_name: element.slot.clone(),
+        element: element.tag_name.clone(),
+        selector: selector.clone(),
+        message,
+        portal_url,
+        severity,
+    };
+
+    if let Some(registry) = registry
+        && !registry.contains(&element.slot)
+    {
+        violations.push(base(
+            ViolationType::Unregistered,
+            format!(
+                "Component \"{}\" is not in the design registry",
+                element.slot
+            ),
+            ViolationSeverity::Warning,
+            None,
+        ));
+    }
+
+    if element.portal_url.is_none() {
+        violations.push(base(
+            ViolationType::MissingPortal,
+            format!(
+                "Component \"{}\" missing data-portal attribute",
+                element.slot
+            ),
+            ViolationSeverity::Info,
+            None,
+        ));
+    }
+
+    if deprecated.contains(&element.slot) {
+        violations.push(base(
+            ViolationType::Deprecated,
+            format!("Component \"{}\" is deprecated", element.slot),
+            ViolationSeverity::Error,
+            element.portal_url.clone(),
+        ));
+    }
+
+    if element.is_interactive() && !element.has_accessible_name() {
+        violations.push(base(
+            ViolationType::MissingAria,
+            format!(
+                "Interactive element in \"{}\" missing accessible name",
+                element.slot
+            ),
+            ViolationSeverity::Warning,
+            element.portal_url.clone(),
+        ));
+    }
+
+    violations
+}
+
+/// Check a whole page.
+///
+/// Conformance is counted PER ELEMENT. The `.ts` counts per slot NAME, so one
+/// broken button marks every other button non-conformant — a page with twenty
+/// good buttons and one bad one scored zero for all twenty-one.
+#[must_use]
+pub fn check_conformity(
+    url: impl Into<String>,
+    elements: &[ObservedElement],
+    registry: Option<&BTreeSet<String>>,
+    deprecated: &BTreeSet<String>,
+) -> ConformityReport {
+    let mut violations = Vec::new();
+    let mut conformant = 0usize;
+
+    for element in elements {
+        let found = check_element(element, registry, deprecated);
+        if found.is_empty() {
+            conformant += 1;
+        }
+        violations.extend(found);
+    }
+
+    let total = elements.len();
+    ConformityReport {
+        url: url.into(),
+        total_components: total,
+        conformant,
+        violations,
+        // An empty page is fully conformant rather than a division by zero. It
+        // has nothing wrong with it, which is different from being untested —
+        // `total_components` says which.
+        score: if total == 0 {
+            100
+        } else {
+            ((conformant as f64 / total as f64) * 100.0).round() as u32
+        },
+    }
+}
+
+/// The worst severity present, for a single go/no-go answer.
+#[must_use]
+pub fn worst_severity(violations: &[ConformityViolation]) -> Option<ViolationSeverity> {
+    violations.iter().map(|v| v.severity).max()
+}

--- a/components/registry/n8-assurance/mzizi-error-tracker.rs
+++ b/components/registry/n8-assurance/mzizi-error-tracker.rs
@@ -1,0 +1,353 @@
+//! Mzizi N8 assurance — structured error collection, deduplication and blast radius.
+//!
+//! The Rust implementation of `mzizi-error-tracker`.
+//!
+//! # What this owns
+//!
+//! Classification, deduplication, eviction and auto-resolution — everything that
+//! decides *what an error means* and *which errors are still live*. Not the DOM
+//! walk that discovers a blast radius, not the clock, not the delivery of a
+//! report; those are the host's, as everywhere else in this node.
+//!
+//! # Three defects in the TypeScript, addressed rather than ported
+//!
+//! **1. `autoResolveMinutes` was documented, defaulted, and never read.** The
+//! `.ts` declares it, `Required<>` fills it with 60, and no code path consults
+//! it — so every error stayed unresolved forever and "unresolved errors" grew
+//! without bound as a dashboard number. A configuration option that does nothing
+//! is worse than an absent one, because it is *believed*. Implemented here as
+//! [`ErrorLog::auto_resolve`], which the host calls with its own clock.
+//!
+//! **2. Eviction sorted the entire map on every insert past the cap.** At 500
+//! errors that is a full `O(n log n)` sort per tracked error — and the cap is
+//! only exceeded during an error storm, so the slow path engaged at precisely the
+//! worst moment. Finding the oldest entry is a single linear scan.
+//!
+//! **3. Undeduplicated ids collided.** With `dedup: false` the key is
+//! `Date.now().toString()`, unique only if no two errors arrive in the same
+//! millisecond — which an error storm violates by construction. Ids are supplied
+//! here for the same reason they are in the alert engine and the exporter.
+//!
+//! # One thing left alone, deliberately
+//!
+//! [`classify_severity`] tests the error *message* for `"TypeError"`, which is
+//! usually the error's `name` rather than anything in its message — so that
+//! branch rarely fires and the neighbouring `"Cannot read"` test is what actually
+//! catches those. It is preserved because changing it would silently reclassify
+//! live errors, which is a product decision rather than a porting one. The
+//! observation is recorded here instead of being quietly fixed or quietly
+//! carried.
+
+use std::collections::BTreeMap;
+
+/// How bad an error is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Severity {
+    /// Noise, or a well-handled edge.
+    Low,
+    /// Worth looking at.
+    Medium,
+    /// Degrades something users touch.
+    High,
+    /// A core guarantee broke.
+    Critical,
+}
+
+impl Severity {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Critical => "critical",
+        }
+    }
+}
+
+/// Where an error happened, as much as the host can say.
+#[derive(Debug, Clone, Default)]
+pub struct ErrorContext {
+    /// The component's `data-slot` name.
+    pub component_name: Option<String>,
+    /// Which helix node it belongs to.
+    pub node: Option<u32>,
+    /// Which mini-app was running.
+    pub mini_app: Option<String>,
+    /// The path the user was on.
+    pub url: Option<String>,
+    /// Components in the same render tree that may be affected.
+    ///
+    /// Supplied, not discovered: the `.ts` finds these by walking
+    /// `document.querySelectorAll("[data-slot]")`, and a Worker or native shell
+    /// has no document.
+    pub blast_radius: Vec<String>,
+}
+
+/// One deduplicated error, with its recurrence history.
+///
+/// `PartialEq` but not `Eq`: the timestamps are `f64`, and floats have no total
+/// equality. Deriving `Eq` here would be claiming a property the type does not
+/// have.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TrackedError {
+    /// Dedup key or supplied id.
+    pub id: String,
+    /// The error message.
+    pub message: String,
+    /// Stack trace, when the host captured one.
+    pub stack: Option<String>,
+    /// The component blamed.
+    pub component_name: Option<String>,
+    /// Which helix node.
+    pub node: Option<u32>,
+    /// Which mini-app.
+    pub mini_app: Option<String>,
+    /// The path the user was on.
+    pub url: String,
+    /// How many times this has been seen.
+    pub count: u32,
+    /// First occurrence, milliseconds since the Unix epoch.
+    pub first_seen_ms: f64,
+    /// Most recent occurrence.
+    pub last_seen_ms: f64,
+    /// Components that may be affected.
+    pub blast_radius: Vec<String>,
+    /// How bad.
+    pub severity: Severity,
+    /// Whether it is considered settled.
+    pub resolved: bool,
+}
+
+/// Classify an error's severity.
+///
+/// Pure, and ordered so the strongest signal wins: a broken token or safety node
+/// is critical regardless of anything else, because N1 and N4 are core
+/// guarantees — if design values or safety gates fail, everything downstream is
+/// already wrong.
+#[must_use]
+pub fn classify_severity(message: &str, node: Option<u32>, blast_radius: usize) -> Severity {
+    // N1 tokens and N4 safety are core guarantees. Their failure is never minor.
+    if node == Some(1) || node == Some(4) {
+        return Severity::Critical;
+    }
+    // N7 is the shell: the product stops holding together.
+    if node == Some(7) {
+        return Severity::High;
+    }
+    if blast_radius > 10 {
+        return Severity::High;
+    }
+    if message.contains("TypeError") || message.contains("Cannot read") {
+        return Severity::Medium;
+    }
+    Severity::Low
+}
+
+/// Configuration for a log.
+#[derive(Debug, Clone)]
+pub struct ErrorLogConfig {
+    /// How many distinct errors to retain.
+    pub max_errors: usize,
+    /// Whether to group recurrences of the same message + component.
+    pub dedup: bool,
+    /// Minutes without recurrence after which an error auto-resolves.
+    ///
+    /// Actually consulted here — see the module docs for why that is worth
+    /// saying out loud.
+    pub auto_resolve_minutes: f64,
+}
+
+impl Default for ErrorLogConfig {
+    fn default() -> Self {
+        Self {
+            max_errors: 500,
+            dedup: true,
+            auto_resolve_minutes: 60.0,
+        }
+    }
+}
+
+/// What tracking an error did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tracked {
+    /// A new distinct error was recorded.
+    New,
+    /// An existing error recurred; its count went up.
+    Recurrence,
+}
+
+/// The set of errors a host is holding.
+#[derive(Debug, Clone, Default)]
+pub struct ErrorLog {
+    config: ErrorLogConfig,
+    errors: BTreeMap<String, TrackedError>,
+}
+
+impl ErrorLog {
+    /// A log with the given configuration.
+    #[must_use]
+    pub fn new(config: ErrorLogConfig) -> Self {
+        Self {
+            config,
+            errors: BTreeMap::new(),
+        }
+    }
+
+    /// The dedup key for a message and component.
+    ///
+    /// When dedup is off the caller's `id` is used instead — the `.ts` reaches
+    /// for `Date.now()` there, which collides during exactly the error storms
+    /// that make dedup worth turning off.
+    #[must_use]
+    pub fn dedup_key(message: &str, component_name: Option<&str>) -> String {
+        format!("{message}:{}", component_name.unwrap_or("unknown"))
+    }
+
+    /// Record an occurrence.
+    ///
+    /// `id` is used only when dedup is off. `now_ms` is supplied because a core
+    /// has no clock.
+    pub fn track(
+        &mut self,
+        message: impl Into<String>,
+        stack: Option<String>,
+        context: &ErrorContext,
+        id: impl Into<String>,
+        now_ms: f64,
+    ) -> (Tracked, &TrackedError) {
+        let message = message.into();
+        let key = if self.config.dedup {
+            Self::dedup_key(&message, context.component_name.as_deref())
+        } else {
+            id.into()
+        };
+
+        let severity = classify_severity(&message, context.node, context.blast_radius.len());
+
+        // The mutation and the returned reference are separated deliberately.
+        // Returning `&TrackedError` out of both branches of a `&mut self` method
+        // needs borrow-checker support Rust does not have yet (polonius), so the
+        // borrow is taken once, at the end, after every mutation is finished.
+        let outcome = if let Some(existing) = self.errors.get_mut(&key) {
+            existing.count += 1;
+            existing.last_seen_ms = now_ms;
+            // A recurrence un-resolves: an error that came back was not settled.
+            existing.resolved = false;
+            existing.severity = severity;
+            Tracked::Recurrence
+        } else {
+            self.errors.insert(
+                key.clone(),
+                TrackedError {
+                    id: key.clone(),
+                    message,
+                    stack,
+                    component_name: context.component_name.clone(),
+                    node: context.node,
+                    mini_app: context.mini_app.clone(),
+                    url: context.url.clone().unwrap_or_default(),
+                    count: 1,
+                    first_seen_ms: now_ms,
+                    last_seen_ms: now_ms,
+                    blast_radius: context.blast_radius.clone(),
+                    severity,
+                    resolved: false,
+                },
+            );
+            self.evict_if_over_cap(&key);
+            Tracked::New
+        };
+
+        (
+            outcome,
+            self.errors
+                .get(&key)
+                .expect("just tracked, and eviction never removes the new key"),
+        )
+    }
+
+    /// Drop the least recently seen error when over the cap.
+    ///
+    /// A single linear scan rather than sorting the whole map. The `.ts` sorts on
+    /// every insert past the cap, which means the expensive path runs during an
+    /// error storm — the one moment the tracker should be cheapest.
+    ///
+    /// The just-inserted key is never the victim, even if the cap is 1: evicting
+    /// what you were asked to record is not eviction, it is a silent drop.
+    fn evict_if_over_cap(&mut self, keep: &str) {
+        if self.errors.len() <= self.config.max_errors {
+            return;
+        }
+        let oldest = self
+            .errors
+            .iter()
+            .filter(|(k, _)| k.as_str() != keep)
+            .min_by(|a, b| {
+                a.1.last_seen_ms
+                    .partial_cmp(&b.1.last_seen_ms)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .map(|(k, _)| k.clone());
+        if let Some(key) = oldest {
+            self.errors.remove(&key);
+        }
+    }
+
+    /// Resolve everything untouched for longer than the configured window.
+    ///
+    /// Returns how many were resolved. This is the option the `.ts` declared and
+    /// never implemented.
+    pub fn auto_resolve(&mut self, now_ms: f64) -> usize {
+        let window_ms = self.config.auto_resolve_minutes * 60_000.0;
+        let mut resolved = 0;
+        for error in self.errors.values_mut() {
+            if !error.resolved && now_ms - error.last_seen_ms >= window_ms {
+                error.resolved = true;
+                resolved += 1;
+            }
+        }
+        resolved
+    }
+
+    /// Mark one error resolved. Returns false if the id is unknown.
+    pub fn resolve(&mut self, id: &str) -> bool {
+        match self.errors.get_mut(id) {
+            Some(error) => {
+                error.resolved = true;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Every error held.
+    #[must_use]
+    pub fn all(&self) -> Vec<&TrackedError> {
+        self.errors.values().collect()
+    }
+
+    /// Every error not yet resolved.
+    #[must_use]
+    pub fn unresolved(&self) -> Vec<&TrackedError> {
+        self.errors.values().filter(|e| !e.resolved).collect()
+    }
+
+    /// How many distinct errors are held.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.errors.len()
+    }
+
+    /// Whether the log is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.errors.is_empty()
+    }
+
+    /// Forget everything.
+    pub fn clear(&mut self) {
+        self.errors.clear();
+    }
+}

--- a/components/registry/n8-assurance/mzizi-incident-manager.rs
+++ b/components/registry/n8-assurance/mzizi-incident-manager.rs
@@ -1,0 +1,592 @@
+//! Mzizi N8 assurance — the incident lifecycle, from detection to postmortem.
+//!
+//! The Rust implementation of `mzizi-incident-manager`. The state machine, the
+//! timings, and the postmortem document; not the storage, the clock, or the
+//! delivery.
+//!
+//! # Six defects in the TypeScript, fixed here
+//!
+//! **1. The incident id was a clock read.** `inc-${Date.now().toString(36)}` gives
+//! two incidents created in the same millisecond the same id, and `incidents.set`
+//! then OVERWRITES the first — so the incident vanishes, along with its timeline,
+//! and nobody is told. Detection is exactly when a burst arrives: one outage
+//! trips several alerts at once, which is the case this identifier scheme cannot
+//! survive. Ids are supplied by the host here, and [`IncidentLog::open`] refuses a
+//! duplicate rather than silently replacing.
+//!
+//! **2. `ttdMinutes` was declared and never computed.** The field is documented as
+//! a duration and nothing ever assigns it, so every incident reports time-to-detect
+//! as absent — which reads on a dashboard as "we do not measure detection" or, worse,
+//! as zero. Time to detect needs a moment the impact STARTED, which the `.ts` never
+//! records. [`Incident::impact_started_at_ms`] is that moment, and TTD is computed
+//! only when it is known.
+//!
+//! **3. Every mutation silently did nothing for an unknown id.** `if (!inc) return`
+//! — so transitioning, annotating or root-causing a typo'd incident succeeded from
+//! the caller's point of view and changed nothing. Each of those returns a
+//! [`Result`] here.
+//!
+//! **4. Resolving an already-resolved incident re-resolved it.** No guard on the
+//! current state, so `resolved → resolved` rewrote `resolvedAt`, recomputed TTR
+//! from the new timestamp, and fired `onResolved` again — a duplicate page, and a
+//! TTR that grows every time somebody clicks. A transition to the state an
+//! incident is already in is [`Transitioned::NoChange`] and touches nothing.
+//! Re-entering `resolved` after a genuine regression still works, because that is
+//! a real thing that happens.
+//!
+//! **5. The postmortem interpolated untrusted text into Markdown.** Titles come
+//! from alerts, alerts come from error messages, and error messages carry user
+//! input. A newline plus `##` in a title forges a section; a `|` or a newline in a
+//! timeline detail escapes its bullet; a `)` in a portal URL terminates the link
+//! early and dumps the rest into prose. This is content forgery in a document
+//! people read to decide what happened, which is the document where a forged line
+//! does the most damage.
+//!
+//! **6. A component with no portal URL rendered `[name](undefined)`.** The `.ts`
+//! interpolates `c.portalUrl` unconditionally, so an affected component that has
+//! no documentation link gets a link to a relative path called `undefined`. Plain
+//! text when there is no URL.
+//!
+//! # What is deliberately NOT constrained
+//!
+//! Any state may follow any other. That is not an oversight: `monitoring →
+//! mitigating` is a regression, `resolved → triaging` is a reopen, and an incident
+//! tool that refuses either is one people work around. What IS enforced is that a
+//! transition to the current state is a no-op (defect 4).
+
+use std::collections::BTreeMap;
+
+/// How bad, in the usual descending scale — `sev1` is worst.
+///
+/// Ordered so `max()` finds the worst; the `Ord` derive follows declaration
+/// order, so [`Sev4`](Self::Sev4) is declared first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IncidentSeverity {
+    /// Minor, no user impact.
+    Sev4,
+    /// Degraded, with a workaround.
+    Sev3,
+    /// Significant user impact.
+    Sev2,
+    /// Critical — a core guarantee is broken.
+    Sev1,
+}
+
+impl IncidentSeverity {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Sev1 => "sev1",
+            Self::Sev2 => "sev2",
+            Self::Sev3 => "sev3",
+            Self::Sev4 => "sev4",
+        }
+    }
+}
+
+/// Where an incident is in its lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IncidentState {
+    /// Something fired.
+    Detected,
+    /// Working out what it is.
+    Triaging,
+    /// Working on stopping the bleeding.
+    Mitigating,
+    /// Mitigated, watching.
+    Monitoring,
+    /// Over.
+    Resolved,
+    /// Written up.
+    Postmortem,
+}
+
+impl IncidentState {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Detected => "detected",
+            Self::Triaging => "triaging",
+            Self::Mitigating => "mitigating",
+            Self::Monitoring => "monitoring",
+            Self::Resolved => "resolved",
+            Self::Postmortem => "postmortem",
+        }
+    }
+
+    /// Whether an incident in this state still needs somebody.
+    #[must_use]
+    pub const fn is_active(self) -> bool {
+        !matches!(self, Self::Resolved | Self::Postmortem)
+    }
+}
+
+/// One thing that happened, and when.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TimelineEntry {
+    /// When, milliseconds since the Unix epoch.
+    pub at_ms: f64,
+    /// Who or what did it.
+    pub actor: String,
+    /// What they did.
+    pub action: String,
+    /// Any detail.
+    pub details: Option<String>,
+}
+
+/// A component caught up in an incident.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AffectedComponent {
+    /// The component name.
+    pub name: String,
+    /// Which helix node it belongs to. Uncapped — node numbers are labels.
+    pub node: u32,
+    /// Where its documentation is, when it has any.
+    pub portal_url: Option<String>,
+}
+
+/// Something somebody has to do afterwards.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActionItem {
+    /// What.
+    pub description: String,
+    /// Who.
+    pub owner: String,
+    /// By when.
+    pub due_date: Option<String>,
+    /// Whether it is done.
+    pub done: bool,
+}
+
+/// What is being opened.
+///
+/// `PartialEq` without `Eq`: `impact_started_at_ms` is an `f64`, and floats have
+/// no total equality.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct NewIncident {
+    /// One-line summary.
+    pub title: String,
+    /// Components implicated.
+    pub affected_components: Vec<AffectedComponent>,
+    /// Mini-apps implicated.
+    pub affected_mini_apps: Vec<String>,
+    /// The alert that fired, when there was one.
+    pub alert_id: Option<String>,
+    /// Who is running it.
+    pub commander: Option<String>,
+    /// When the impact actually began, if known.
+    ///
+    /// Time to detect is measured from HERE, not from detection — the `.ts`
+    /// declares `ttdMinutes` and never has a value to compute it from.
+    pub impact_started_at_ms: Option<f64>,
+}
+
+/// One incident.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Incident {
+    /// Supplied by the host, not derived from a clock. See defect 1.
+    pub id: String,
+    /// One-line summary.
+    pub title: String,
+    /// How bad.
+    pub severity: IncidentSeverity,
+    /// Where it is.
+    pub state: IncidentState,
+    /// When it was detected, milliseconds since the Unix epoch.
+    pub detected_at_ms: f64,
+    /// When the impact began, if known.
+    pub impact_started_at_ms: Option<f64>,
+    /// When it was resolved.
+    pub resolved_at_ms: Option<f64>,
+    /// Components implicated.
+    pub affected_components: Vec<AffectedComponent>,
+    /// Mini-apps implicated.
+    pub affected_mini_apps: Vec<String>,
+    /// Who ran it.
+    pub commander: Option<String>,
+    /// Everything that happened.
+    pub timeline: Vec<TimelineEntry>,
+    /// What caused it.
+    pub root_cause: Option<String>,
+    /// What to do about it.
+    pub action_items: Vec<ActionItem>,
+    /// The alert that fired.
+    pub alert_id: Option<String>,
+}
+
+impl Incident {
+    /// Minutes from impact starting to it being detected.
+    ///
+    /// [`None`] when nobody recorded when the impact began, which is honest —
+    /// the `.ts` leaves the field undefined in every case and calls it a duration.
+    #[must_use]
+    pub fn ttd_minutes(&self) -> Option<f64> {
+        let started = self.impact_started_at_ms?;
+        Some(((self.detected_at_ms - started) / 60_000.0).round())
+    }
+
+    /// Minutes from detection to resolution.
+    #[must_use]
+    pub fn ttr_minutes(&self) -> Option<f64> {
+        let resolved = self.resolved_at_ms?;
+        Some(((resolved - self.detected_at_ms) / 60_000.0).round())
+    }
+}
+
+/// Why a mutation did not happen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IncidentError {
+    /// No incident with that id.
+    NotFound,
+    /// An incident with that id is already open.
+    DuplicateId,
+}
+
+/// What a transition did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Transitioned {
+    /// The state changed.
+    Moved {
+        /// Where it was.
+        from: IncidentState,
+        /// Where it is.
+        to: IncidentState,
+    },
+    /// It was already in that state. Nothing recorded, nothing fired.
+    ///
+    /// The `.ts` has no such case: `resolved → resolved` rewrites `resolvedAt`,
+    /// recomputes TTR from the new timestamp and fires `onResolved` again.
+    NoChange(IncidentState),
+}
+
+impl Transitioned {
+    /// Whether this transition entered [`IncidentState::Resolved`] — the one
+    /// moment a resolution notification should fire.
+    #[must_use]
+    pub const fn resolved_now(self) -> bool {
+        matches!(
+            self,
+            Self::Moved {
+                to: IncidentState::Resolved,
+                ..
+            }
+        )
+    }
+}
+
+/// Every open and closed incident.
+#[derive(Debug, Clone, Default)]
+pub struct IncidentLog {
+    incidents: BTreeMap<String, Incident>,
+}
+
+impl IncidentLog {
+    /// An empty log.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Open an incident under a host-supplied id.
+    ///
+    /// # Errors
+    ///
+    /// [`IncidentError::DuplicateId`] when that id is already in use. The `.ts`
+    /// derives the id from `Date.now()` and overwrites on collision, which loses
+    /// an entire incident in exactly the burst that produces one.
+    pub fn open(
+        &mut self,
+        id: impl Into<String>,
+        severity: IncidentSeverity,
+        new: NewIncident,
+        now_ms: f64,
+    ) -> Result<&Incident, IncidentError> {
+        let id = id.into();
+        if self.incidents.contains_key(&id) {
+            return Err(IncidentError::DuplicateId);
+        }
+        let incident = Incident {
+            id: id.clone(),
+            title: new.title,
+            severity,
+            state: IncidentState::Detected,
+            detected_at_ms: now_ms,
+            impact_started_at_ms: new.impact_started_at_ms,
+            resolved_at_ms: None,
+            affected_components: new.affected_components,
+            affected_mini_apps: new.affected_mini_apps,
+            commander: new.commander,
+            timeline: vec![TimelineEntry {
+                at_ms: now_ms,
+                actor: "system".to_owned(),
+                action: "Incident created".to_owned(),
+                details: Some(format!("Severity: {}", severity.as_str())),
+            }],
+            root_cause: None,
+            action_items: Vec::new(),
+            alert_id: new.alert_id,
+        };
+        Ok(self.incidents.entry(id).or_insert(incident))
+    }
+
+    /// Move an incident to a new state.
+    ///
+    /// # Errors
+    ///
+    /// [`IncidentError::NotFound`] when no incident has that id — which the `.ts`
+    /// answers by returning `undefined` and doing nothing.
+    pub fn transition(
+        &mut self,
+        id: &str,
+        to: IncidentState,
+        actor: impl Into<String>,
+        details: Option<String>,
+        now_ms: f64,
+    ) -> Result<Transitioned, IncidentError> {
+        let incident = self.incidents.get_mut(id).ok_or(IncidentError::NotFound)?;
+        let from = incident.state;
+        if from == to {
+            return Ok(Transitioned::NoChange(from));
+        }
+
+        incident.state = to;
+        incident.timeline.push(TimelineEntry {
+            at_ms: now_ms,
+            actor: actor.into(),
+            action: format!("State → {}", to.as_str()),
+            details,
+        });
+        if to == IncidentState::Resolved {
+            incident.resolved_at_ms = Some(now_ms);
+        }
+        Ok(Transitioned::Moved { from, to })
+    }
+
+    /// Add a note to the timeline.
+    ///
+    /// # Errors
+    ///
+    /// [`IncidentError::NotFound`] when no incident has that id.
+    pub fn note(
+        &mut self,
+        id: &str,
+        actor: impl Into<String>,
+        action: impl Into<String>,
+        details: Option<String>,
+        now_ms: f64,
+    ) -> Result<(), IncidentError> {
+        let incident = self.incidents.get_mut(id).ok_or(IncidentError::NotFound)?;
+        incident.timeline.push(TimelineEntry {
+            at_ms: now_ms,
+            actor: actor.into(),
+            action: action.into(),
+            details,
+        });
+        Ok(())
+    }
+
+    /// Record what caused it.
+    ///
+    /// # Errors
+    ///
+    /// [`IncidentError::NotFound`] when no incident has that id.
+    pub fn set_root_cause(
+        &mut self,
+        id: &str,
+        root_cause: impl Into<String>,
+    ) -> Result<(), IncidentError> {
+        let incident = self.incidents.get_mut(id).ok_or(IncidentError::NotFound)?;
+        incident.root_cause = Some(root_cause.into());
+        Ok(())
+    }
+
+    /// Add something somebody has to do.
+    ///
+    /// # Errors
+    ///
+    /// [`IncidentError::NotFound`] when no incident has that id.
+    pub fn add_action_item(&mut self, id: &str, item: ActionItem) -> Result<(), IncidentError> {
+        let incident = self.incidents.get_mut(id).ok_or(IncidentError::NotFound)?;
+        incident.action_items.push(item);
+        Ok(())
+    }
+
+    /// One incident.
+    #[must_use]
+    pub fn get(&self, id: &str) -> Option<&Incident> {
+        self.incidents.get(id)
+    }
+
+    /// Every incident still needing somebody.
+    #[must_use]
+    pub fn active(&self) -> Vec<&Incident> {
+        self.incidents
+            .values()
+            .filter(|i| i.state.is_active())
+            .collect()
+    }
+
+    /// Every incident.
+    #[must_use]
+    pub fn all(&self) -> Vec<&Incident> {
+        self.incidents.values().collect()
+    }
+
+    /// The worst severity among the active incidents — the one-glance answer.
+    #[must_use]
+    pub fn worst_active(&self) -> Option<IncidentSeverity> {
+        self.active().iter().map(|i| i.severity).max()
+    }
+}
+
+/// Escape a value going into a Markdown line.
+///
+/// A newline lets a value start its own block — `\n## Root Cause` forges a
+/// section in a document people read to decide what happened. A `|` forges table
+/// columns. Backslashes go first, or the escapes this adds are themselves
+/// escapable.
+#[must_use]
+pub fn escape_markdown(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '|' => out.push_str("\\|"),
+            '\n' | '\r' => out.push(' '),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// Render a link, or plain text when there is no URL.
+///
+/// The `.ts` interpolates `c.portalUrl` unconditionally, so a component with no
+/// documentation link renders `[name](undefined)` — a link to a relative path
+/// called `undefined`. Angle brackets are Markdown's literal-URL form, so a `)`
+/// inside the URL cannot terminate the link early.
+#[must_use]
+pub fn component_link(component: &AffectedComponent) -> String {
+    let name = escape_markdown(&component.name);
+    match component
+        .portal_url
+        .as_deref()
+        .filter(|url| !url.trim().is_empty())
+    {
+        Some(url) => format!("[{name}](<{}>)", url.replace(['<', '>', '\n', '\r'], "")),
+        None => name,
+    }
+}
+
+/// The postmortem, in Markdown.
+///
+/// Timestamps are milliseconds since the epoch: formatting them for humans needs
+/// a locale and a timezone, which is a host concern, and the `.ts`'s bare
+/// `toISOString()` was neither.
+#[must_use]
+pub fn postmortem(incident: &Incident) -> String {
+    let mut doc = format!(
+        "# Incident Postmortem: {}\n\n",
+        escape_markdown(&incident.title)
+    );
+    doc.push_str(&format!("**Severity:** {}\n", incident.severity.as_str()));
+    doc.push_str(&format!("**State:** {}\n", incident.state.as_str()));
+    doc.push_str(&format!("**Detected:** {}\n", incident.detected_at_ms));
+    doc.push_str(&match incident.resolved_at_ms {
+        Some(at) => format!("**Resolved:** {at}\n"),
+        None => "**Resolved:** Ongoing\n".to_owned(),
+    });
+    doc.push_str(&match incident.ttd_minutes() {
+        Some(ttd) => format!("**TTD:** {ttd} minutes\n"),
+        // Not "0", and not silence. Nobody recorded when the impact began.
+        None => "**TTD:** not measured — impact start unrecorded\n".to_owned(),
+    });
+    doc.push_str(&match incident.ttr_minutes() {
+        Some(ttr) => format!("**TTR:** {ttr} minutes\n"),
+        None => "**TTR:** N/A\n".to_owned(),
+    });
+    doc.push_str(&format!(
+        "**Commander:** {}\n",
+        incident
+            .commander
+            .as_deref()
+            .map_or_else(|| "Unassigned".to_owned(), escape_markdown)
+    ));
+
+    doc.push_str("\n## Affected Components\n");
+    if incident.affected_components.is_empty() {
+        doc.push_str("_None recorded_\n");
+    } else {
+        for component in &incident.affected_components {
+            doc.push_str(&format!(
+                "- {} (Node {})\n",
+                component_link(component),
+                component.node
+            ));
+        }
+    }
+
+    doc.push_str("\n## Affected Mini-Apps\n");
+    if incident.affected_mini_apps.is_empty() {
+        doc.push_str("_None recorded_\n");
+    } else {
+        doc.push_str(&format!(
+            "{}\n",
+            incident
+                .affected_mini_apps
+                .iter()
+                .map(|app| escape_markdown(app))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+
+    doc.push_str("\n## Timeline\n");
+    if incident.timeline.is_empty() {
+        doc.push_str("_Empty_\n");
+    } else {
+        for entry in &incident.timeline {
+            doc.push_str(&format!(
+                "- **{}** [{}] {}{}\n",
+                entry.at_ms,
+                escape_markdown(&entry.actor),
+                escape_markdown(&entry.action),
+                entry
+                    .details
+                    .as_deref()
+                    .map(|d| format!(" — {}", escape_markdown(d)))
+                    .unwrap_or_default()
+            ));
+        }
+    }
+
+    doc.push_str(&format!(
+        "\n## Root Cause\n{}\n",
+        incident
+            .root_cause
+            .as_deref()
+            .map_or_else(|| "_To be determined_".to_owned(), escape_markdown)
+    ));
+
+    doc.push_str("\n## Action Items\n");
+    if incident.action_items.is_empty() {
+        doc.push_str("_None yet_\n");
+    } else {
+        for item in &incident.action_items {
+            doc.push_str(&format!(
+                "- [{}] {} (Owner: {}{})\n",
+                if item.done { "x" } else { " " },
+                escape_markdown(&item.description),
+                escape_markdown(&item.owner),
+                item.due_date
+                    .as_deref()
+                    .map(|due| format!(", Due: {}", escape_markdown(due)))
+                    .unwrap_or_default()
+            ));
+        }
+    }
+
+    doc
+}

--- a/components/registry/n8-assurance/mzizi-otel.rs
+++ b/components/registry/n8-assurance/mzizi-otel.rs
@@ -446,82 +446,21 @@ pub fn build_trace_request(
 
 // ── the N8 probe bridge ────────────────────────────────────────────────────
 
-/// Outcome of one probe step.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StepStatus {
-    /// The step asserted what it set out to assert.
-    Pass,
-    /// The step failed.
-    Fail,
-}
-
-/// Outcome of a whole probe run.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ProbeStatus {
-    /// Every step passed.
-    Pass,
-    /// At least one step failed.
-    Fail,
-    /// The run exceeded its allotted time.
-    Timeout,
-    /// The runner itself could not complete.
-    Error,
-}
-
-impl ProbeStatus {
-    /// Whether this outcome should surface as an OTLP `ERROR` status.
-    #[must_use]
-    pub const fn is_failure(self) -> bool {
-        !matches!(self, Self::Pass)
-    }
-
-    /// The wire spelling, matching the `.ts` sibling's string union.
-    #[must_use]
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Pass => "pass",
-            Self::Fail => "fail",
-            Self::Timeout => "timeout",
-            Self::Error => "error",
-        }
-    }
-}
-
-/// One step of a probe run.
-#[derive(Debug, Clone)]
-pub struct ProbeStep {
-    /// What the step checked, used as the span name.
-    pub description: String,
-    /// Whether it passed.
-    pub status: StepStatus,
-    /// How long it took.
-    pub duration_ms: f64,
-    /// Why it failed, when it did.
-    ///
-    /// Carried onto the wire as `error.message` rather than left in prose,
-    /// because the consumer acting on it is usually not a human. A render check
-    /// that failed because the URL sat behind an auth wall is not the same
-    /// incident as a page that rendered empty, and fundi filing an issue for the
-    /// first would be a false positive.
-    pub error: Option<String>,
-}
-
-/// The result of a probe run — the contract `mzizi-synthetic-probe` declares.
-#[derive(Debug, Clone)]
-pub struct ProbeResult {
-    /// Which journey ran. A collector groups on this.
-    pub journey_id: String,
-    /// When the run started, in milliseconds since the Unix epoch.
-    pub started_at_ms: f64,
-    /// Where it ran from.
-    pub region: String,
-    /// The run's outcome.
-    pub status: ProbeStatus,
-    /// Total run duration.
-    pub duration_ms: f64,
-    /// Each step, in order.
-    pub steps: Vec<ProbeStep>,
-}
+// The probe types are NOT redefined here. `mzizi-synthetic-probe` owns them, and
+// this module borrows them exactly as the `.ts` sibling does with its
+// `import type { ProbeResult } from "./mzizi-synthetic-probe"` and its declared
+// `registryDependencies` entry.
+//
+// The first draft of this file defined its own, which duplicated the contract and
+// got it subtly wrong within one sitting: the `.ts` has TWO step shapes — the
+// input `ProbeStep` a runner executes, and an anonymous outcome shape inside
+// `ProbeResult` — and the copy here collapsed them into one. Two definitions of a
+// wire contract drift; one does not.
+//
+// Rust has no type-only import, so this is a real intra-crate dependency rather
+// than an erased one. That is fine and is the distribution model: a Rust consumer
+// takes the crate, where the `.ts` consumer takes two installed files.
+use super::mzizi_synthetic_probe::{ProbeResult, StepStatus};
 
 /// Turn a [`ProbeResult`] into a run span plus one child span per step.
 ///

--- a/components/registry/n8-assurance/mzizi-otel.rs
+++ b/components/registry/n8-assurance/mzizi-otel.rs
@@ -1,0 +1,646 @@
+//! Mzizi N8 assurance — the OTLP exporter core.
+//!
+//! The Rust implementation of `mzizi-otel`. Its `.ts` sibling is the per-target
+//! shim; this is the shared core, and the split between them is the whole point
+//! of N8 being a Rust node rather than a TypeScript one.
+//!
+//! # This core is PURE. It does not send.
+//!
+//! `build_trace_request` returns a [`TraceRequest`] — a URL, headers and a body —
+//! and the host does the sending: `fetch` in a browser, `fetch` or the Browser
+//! Run binding in a Cloudflare Worker, whatever a native shell uses.
+//!
+//! That is not a limitation worked around, it is the correct boundary:
+//!
+//! * **Every target sends differently and computes identically.** Payload
+//!   shape, attribute typing, nanosecond conversion, endpoint resolution and the
+//!   span tree are the parts that must not vary, so they are the parts that live
+//!   here once.
+//! * **The never-throw rule becomes structural instead of promised.** The `.ts`
+//!   version had to wrap `fetch` in a `try/catch` and hand back
+//!   `{ exported: false, reason }`, because a probe reporting "failed" merely
+//!   because its collector was unreachable manufactures an incident out of an
+//!   exporter outage. With no I/O in the core there is nothing to catch — the
+//!   host owns the failure and the verdict, and cannot conflate them.
+//! * **No HTTP dependency.** `reqwest` would pull a TLS stack into a WASM module
+//!   whose host already has one.
+//!
+//! # Randomness is supplied, never chosen
+//!
+//! [`TraceId`] and [`SpanId`] are constructed from bytes the caller provides. A
+//! shared core must not pick the host's CSPRNG: in a browser or Worker the right
+//! source is `crypto.getRandomValues`, natively it is the OS, and a WASM build
+//! that reaches for `getrandom` needs a backend configured per target — a
+//! well-known footgun that turns into a link error at the worst moment.
+//!
+//! `Math.random()` and its equivalents are wrong here for a reason that is not
+//! style: trace ids are correlation keys across services, so a predictable one
+//! lets an unrelated caller collide with, or forge, a trace.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// Span status, matching the OTLP enum exactly.
+///
+/// Named rather than inlined because a bare `2` in a payload is unreadable and
+/// the two non-zero values are easy to transpose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusCode {
+    /// No status was set. The OTLP default.
+    Unset = 0,
+    /// The operation completed successfully.
+    Ok = 1,
+    /// The operation failed. This is the variant fundi acts on.
+    Error = 2,
+}
+
+/// Span kind, matching the OTLP enum.
+///
+/// Only the two kinds this node emits are modelled. A probe *step* calls
+/// something external so it is [`SpanKind::Client`]; the *run* calls nothing
+/// itself so it is [`SpanKind::Internal`]. Reversing them makes a collector draw
+/// service-dependency edges that do not exist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpanKind {
+    /// The operation is internal to this process.
+    Internal = 1,
+    /// The operation called something outside this process.
+    Client = 3,
+}
+
+/// A typed attribute value.
+///
+/// OTLP tags every attribute with its type; a bare JSON value is rejected. The
+/// integer case is serialised as a **string** because JSON cannot hold an int64
+/// exactly — a float64 silently loses precision above 2^53, which is where a
+/// nanosecond timestamp lives.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AttributeValue {
+    /// A string attribute.
+    Str(String),
+    /// An integer attribute. Crosses the wire as a quoted string.
+    Int(i64),
+    /// A floating-point attribute.
+    Double(f64),
+    /// A boolean attribute.
+    Bool(bool),
+}
+
+impl From<&str> for AttributeValue {
+    fn from(v: &str) -> Self {
+        Self::Str(v.to_owned())
+    }
+}
+impl From<String> for AttributeValue {
+    fn from(v: String) -> Self {
+        Self::Str(v)
+    }
+}
+impl From<i64> for AttributeValue {
+    fn from(v: i64) -> Self {
+        Self::Int(v)
+    }
+}
+impl From<u32> for AttributeValue {
+    fn from(v: u32) -> Self {
+        Self::Int(i64::from(v))
+    }
+}
+impl From<f64> for AttributeValue {
+    fn from(v: f64) -> Self {
+        Self::Double(v)
+    }
+}
+impl From<bool> for AttributeValue {
+    fn from(v: bool) -> Self {
+        Self::Bool(v)
+    }
+}
+
+/// A 16-byte trace id. Renders as 32 lowercase hex characters.
+///
+/// A collector rejects any other length outright, and it does so by dropping the
+/// span rather than by returning an error — so the length is enforced by the type
+/// instead of being checked at the edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TraceId([u8; 16]);
+
+impl TraceId {
+    /// Build a trace id from 16 bytes supplied by the host's CSPRNG.
+    #[must_use]
+    pub const fn new(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl fmt::Display for TraceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in self.0 {
+            write!(f, "{b:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+/// An 8-byte span id. Renders as 16 lowercase hex characters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SpanId([u8; 8]);
+
+impl SpanId {
+    /// Build a span id from 8 bytes supplied by the host's CSPRNG.
+    #[must_use]
+    pub const fn new(bytes: [u8; 8]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl fmt::Display for SpanId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in self.0 {
+            write!(f, "{b:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Where the exporter sends, and what identifies the sender.
+///
+/// There is deliberately **no default endpoint**. `mzizi-rum` defaulted to
+/// `https://mzizi.dev/api/rum`, a route that returns 404 and has never existed,
+/// and every consumer who installed it without setting an endpoint posted into a
+/// void that looked exactly like working telemetry. Inventing a destination for
+/// someone else's telemetry is not a sane default even when the destination
+/// works.
+#[derive(Debug, Clone, Default)]
+pub struct OtelConfig {
+    /// Base endpoint. The signal path `/v1/traces` is appended.
+    pub endpoint: Option<String>,
+    /// Complete traces endpoint, used verbatim with **no** path appended.
+    ///
+    /// The asymmetry with [`OtelConfig::endpoint`] is the OTLP spec's, not ours,
+    /// and it is the detail people get wrong: appending to this one produces
+    /// `/v1/traces/v1/traces` and a 404 that reads like a broken collector.
+    pub traces_endpoint: Option<String>,
+    /// `service.name`. Required by the OTel resource conventions.
+    pub service_name: String,
+    /// `service.version`, when the host knows it.
+    pub service_version: Option<String>,
+    /// Deployment environment — `production`, `preview`, `local`.
+    pub environment: Option<String>,
+    /// Extra headers: an API key, a tenant id.
+    pub headers: BTreeMap<String, String>,
+}
+
+/// One span, before it is turned into a payload.
+#[derive(Debug, Clone)]
+pub struct Span {
+    /// Span name, as a collector displays it.
+    pub name: String,
+    /// Span kind.
+    pub kind: SpanKind,
+    /// This span's own id.
+    pub span_id: SpanId,
+    /// The parent span's id, when this span has one.
+    pub parent_span_id: Option<SpanId>,
+    /// Start time in milliseconds since the Unix epoch.
+    pub start_time_ms: f64,
+    /// End time in milliseconds since the Unix epoch.
+    pub end_time_ms: f64,
+    /// Typed attributes. Ordered so a payload is byte-stable across runs.
+    pub attributes: BTreeMap<String, AttributeValue>,
+    /// Status code.
+    pub status: StatusCode,
+    /// Status message. Carried only when there is something to say.
+    pub status_message: Option<String>,
+}
+
+/// Everything the host needs to make one HTTP request, and nothing it does not.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceRequest {
+    /// Fully resolved URL to POST to.
+    pub url: String,
+    /// Headers, including `Content-Type: application/json`.
+    pub headers: BTreeMap<String, String>,
+    /// The OTLP/HTTP JSON body.
+    pub body: String,
+}
+
+/// Why no request was produced.
+///
+/// Not an error type in the "something went wrong" sense: the common variant is
+/// a consumer who simply runs no collector, and for them this must be inert
+/// rather than noisy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NotExported {
+    /// There were no spans to send.
+    NoSpans,
+    /// No endpoint is configured, so nothing should be sent anywhere.
+    NoEndpoint,
+}
+
+impl fmt::Display for NotExported {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoSpans => f.write_str("no spans"),
+            Self::NoEndpoint => f.write_str(
+                "no OTLP endpoint configured (set OTEL_EXPORTER_OTLP_ENDPOINT or \
+                 OtelConfig::endpoint) — nothing was sent",
+            ),
+        }
+    }
+}
+
+/// Milliseconds, possibly fractional, to an integer nanosecond count.
+///
+/// Returned as a string by the serialiser for the int64 reason above. Rounding
+/// rather than truncating keeps a duration from drifting shorter every hop.
+fn to_unix_nano(ms: f64) -> u128 {
+    // Milliseconds since the epoch are positive in every case this handles; a
+    // negative value would mean a clock before 1970, which is not a span.
+    let ns = (ms * 1_000_000.0).round();
+    if ns <= 0.0 { 0 } else { ns as u128 }
+}
+
+/// Resolve the traces URL, honouring the spec's base/complete asymmetry.
+///
+/// Returns `None` when nothing is configured, which is the inert case rather
+/// than a failure.
+#[must_use]
+pub fn resolve_traces_url(config: &OtelConfig) -> Option<String> {
+    if let Some(explicit) = config.traces_endpoint.as_deref().filter(|s| !s.is_empty()) {
+        return Some(explicit.to_owned());
+    }
+    let base = config.endpoint.as_deref().filter(|s| !s.is_empty())?;
+    Some(format!("{}/v1/traces", base.trim_end_matches('/')))
+}
+
+/// Escape a string for a JSON document.
+///
+/// Hand-written rather than pulled from `serde_json`, for the same reason the
+/// `.ts` sibling hand-builds its payload: this compiles into a WASM shared core
+/// where every dependency is paid for by each consumer, and OTLP/HTTP JSON is a
+/// small, fully documented shape. The escape set is the one JSON requires —
+/// quote, backslash, the two-character forms, and every remaining control
+/// character as `\u00XX`.
+fn escape_json(s: &str, out: &mut String) {
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{8}' => out.push_str("\\b"),
+            '\u{c}' => out.push_str("\\f"),
+            c if c.is_control() => {
+                let _ = fmt::Write::write_fmt(out, format_args!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+}
+
+fn write_string(value: &str, out: &mut String) {
+    out.push('"');
+    escape_json(value, out);
+    out.push('"');
+}
+
+/// Serialise one attribute as an OTLP `KeyValue`.
+fn write_attribute(key: &str, value: &AttributeValue, out: &mut String) {
+    out.push_str("{\"key\":");
+    write_string(key, out);
+    out.push_str(",\"value\":{");
+    match value {
+        AttributeValue::Str(v) => {
+            out.push_str("\"stringValue\":");
+            write_string(v, out);
+        }
+        // Quoted: JSON has no int64, so the OTLP JSON mapping specifies a string.
+        AttributeValue::Int(v) => {
+            let _ = fmt::Write::write_fmt(out, format_args!("\"intValue\":\"{v}\""));
+        }
+        AttributeValue::Double(v) => {
+            let _ = fmt::Write::write_fmt(out, format_args!("\"doubleValue\":{v}"));
+        }
+        AttributeValue::Bool(v) => {
+            let _ = fmt::Write::write_fmt(out, format_args!("\"boolValue\":{v}"));
+        }
+    }
+    out.push_str("}}");
+}
+
+fn write_attributes(attributes: &BTreeMap<String, AttributeValue>, out: &mut String) {
+    out.push('[');
+    for (i, (key, value)) in attributes.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        write_attribute(key, value, out);
+    }
+    out.push(']');
+}
+
+/// Build the OTLP/HTTP JSON body for a set of spans.
+///
+/// Exported separately from [`build_trace_request`] so a caller can inspect,
+/// queue or persist the payload without committing to sending it.
+#[must_use]
+pub fn build_trace_body(spans: &[Span], config: &OtelConfig, trace_id: TraceId) -> String {
+    let mut resource: BTreeMap<String, AttributeValue> = BTreeMap::new();
+    resource.insert(
+        "service.name".to_owned(),
+        AttributeValue::Str(config.service_name.clone()),
+    );
+    if let Some(v) = &config.service_version {
+        resource.insert("service.version".to_owned(), AttributeValue::Str(v.clone()));
+    }
+    if let Some(v) = &config.environment {
+        resource.insert(
+            "deployment.environment.name".to_owned(),
+            AttributeValue::Str(v.clone()),
+        );
+    }
+    resource.insert(
+        "telemetry.sdk.name".to_owned(),
+        AttributeValue::Str("mzizi-otel".to_owned()),
+    );
+    resource.insert(
+        "telemetry.sdk.language".to_owned(),
+        AttributeValue::Str("rust".to_owned()),
+    );
+
+    let mut out = String::with_capacity(512 + spans.len() * 256);
+    out.push_str("{\"resourceSpans\":[{\"resource\":{\"attributes\":");
+    write_attributes(&resource, &mut out);
+    out.push_str("},\"scopeSpans\":[{\"scope\":{\"name\":\"mzizi.n8.assurance\"},\"spans\":[");
+
+    for (i, span) in spans.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push_str("{\"traceId\":");
+        write_string(&trace_id.to_string(), &mut out);
+        out.push_str(",\"spanId\":");
+        write_string(&span.span_id.to_string(), &mut out);
+        if let Some(parent) = span.parent_span_id {
+            out.push_str(",\"parentSpanId\":");
+            write_string(&parent.to_string(), &mut out);
+        }
+        out.push_str(",\"name\":");
+        write_string(&span.name, &mut out);
+        let _ = fmt::Write::write_fmt(
+            &mut out,
+            format_args!(
+                ",\"kind\":{},\"startTimeUnixNano\":\"{}\",\"endTimeUnixNano\":\"{}\"",
+                span.kind as u8,
+                to_unix_nano(span.start_time_ms),
+                to_unix_nano(span.end_time_ms),
+            ),
+        );
+        out.push_str(",\"attributes\":");
+        write_attributes(&span.attributes, &mut out);
+        let _ = fmt::Write::write_fmt(
+            &mut out,
+            format_args!(",\"status\":{{\"code\":{}", span.status as u8),
+        );
+        if let Some(message) = &span.status_message {
+            out.push_str(",\"message\":");
+            write_string(message, &mut out);
+        }
+        out.push_str("}}");
+    }
+
+    out.push_str("]}]}]}");
+    out
+}
+
+/// Build the request a host should POST, or say why there is nothing to send.
+///
+/// # Errors
+///
+/// Returns [`NotExported`] when there are no spans, or when no endpoint is
+/// configured. Neither is a malfunction — see that type's documentation.
+pub fn build_trace_request(
+    spans: &[Span],
+    config: &OtelConfig,
+    trace_id: TraceId,
+) -> Result<TraceRequest, NotExported> {
+    if spans.is_empty() {
+        return Err(NotExported::NoSpans);
+    }
+    let url = resolve_traces_url(config).ok_or(NotExported::NoEndpoint)?;
+
+    let mut headers = BTreeMap::new();
+    headers.insert("Content-Type".to_owned(), "application/json".to_owned());
+    for (k, v) in &config.headers {
+        headers.insert(k.clone(), v.clone());
+    }
+
+    Ok(TraceRequest {
+        url,
+        headers,
+        body: build_trace_body(spans, config, trace_id),
+    })
+}
+
+// ── the N8 probe bridge ────────────────────────────────────────────────────
+
+/// Outcome of one probe step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StepStatus {
+    /// The step asserted what it set out to assert.
+    Pass,
+    /// The step failed.
+    Fail,
+}
+
+/// Outcome of a whole probe run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeStatus {
+    /// Every step passed.
+    Pass,
+    /// At least one step failed.
+    Fail,
+    /// The run exceeded its allotted time.
+    Timeout,
+    /// The runner itself could not complete.
+    Error,
+}
+
+impl ProbeStatus {
+    /// Whether this outcome should surface as an OTLP `ERROR` status.
+    #[must_use]
+    pub const fn is_failure(self) -> bool {
+        !matches!(self, Self::Pass)
+    }
+
+    /// The wire spelling, matching the `.ts` sibling's string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pass => "pass",
+            Self::Fail => "fail",
+            Self::Timeout => "timeout",
+            Self::Error => "error",
+        }
+    }
+}
+
+/// One step of a probe run.
+#[derive(Debug, Clone)]
+pub struct ProbeStep {
+    /// What the step checked, used as the span name.
+    pub description: String,
+    /// Whether it passed.
+    pub status: StepStatus,
+    /// How long it took.
+    pub duration_ms: f64,
+    /// Why it failed, when it did.
+    ///
+    /// Carried onto the wire as `error.message` rather than left in prose,
+    /// because the consumer acting on it is usually not a human. A render check
+    /// that failed because the URL sat behind an auth wall is not the same
+    /// incident as a page that rendered empty, and fundi filing an issue for the
+    /// first would be a false positive.
+    pub error: Option<String>,
+}
+
+/// The result of a probe run — the contract `mzizi-synthetic-probe` declares.
+#[derive(Debug, Clone)]
+pub struct ProbeResult {
+    /// Which journey ran. A collector groups on this.
+    pub journey_id: String,
+    /// When the run started, in milliseconds since the Unix epoch.
+    pub started_at_ms: f64,
+    /// Where it ran from.
+    pub region: String,
+    /// The run's outcome.
+    pub status: ProbeStatus,
+    /// Total run duration.
+    pub duration_ms: f64,
+    /// Each step, in order.
+    pub steps: Vec<ProbeStep>,
+}
+
+/// Turn a [`ProbeResult`] into a run span plus one child span per step.
+///
+/// Span ids are supplied rather than generated, for the reason in the module
+/// documentation: `ids[0]` is the run, `ids[1..]` the steps. Fewer ids than
+/// steps truncates rather than inventing one, because a duplicated span id
+/// corrupts the trace a collector assembles.
+///
+/// `ProbeResult` carries a duration per step but no per-step timestamp, so steps
+/// are laid end to end from the run start. The durations are measured; the
+/// offsets are reconstructed, and saying so here is the difference between an
+/// approximation and a false claim.
+#[must_use]
+pub fn probe_result_to_spans(
+    result: &ProbeResult,
+    ids: &[SpanId],
+    extra: &BTreeMap<String, AttributeValue>,
+) -> Vec<Span> {
+    let Some((&run_id, step_ids)) = ids.split_first() else {
+        return Vec::new();
+    };
+
+    let failed_steps = result
+        .steps
+        .iter()
+        .filter(|s| s.status == StepStatus::Fail)
+        .count();
+
+    let mut run_attrs: BTreeMap<String, AttributeValue> = BTreeMap::new();
+    run_attrs.insert("mzizi.node".to_owned(), AttributeValue::Int(8));
+    run_attrs.insert(
+        "mzizi.probe.journey".to_owned(),
+        AttributeValue::Str(result.journey_id.clone()),
+    );
+    run_attrs.insert(
+        "mzizi.probe.status".to_owned(),
+        AttributeValue::Str(result.status.as_str().to_owned()),
+    );
+    run_attrs.insert(
+        "mzizi.probe.region".to_owned(),
+        AttributeValue::Str(result.region.clone()),
+    );
+    run_attrs.insert(
+        "mzizi.probe.steps".to_owned(),
+        AttributeValue::Int(result.steps.len() as i64),
+    );
+    run_attrs.insert(
+        "mzizi.probe.steps_failed".to_owned(),
+        AttributeValue::Int(failed_steps as i64),
+    );
+    for (k, v) in extra {
+        run_attrs.insert(k.clone(), v.clone());
+    }
+
+    let failed = result.status.is_failure();
+    let mut spans = Vec::with_capacity(1 + result.steps.len());
+    spans.push(Span {
+        name: format!("probe {}", result.journey_id),
+        kind: SpanKind::Internal,
+        span_id: run_id,
+        parent_span_id: None,
+        start_time_ms: result.started_at_ms,
+        end_time_ms: result.started_at_ms + result.duration_ms,
+        attributes: run_attrs,
+        status: if failed {
+            StatusCode::Error
+        } else {
+            StatusCode::Ok
+        },
+        status_message: failed
+            .then(|| format!("probe {} {}", result.journey_id, result.status.as_str())),
+    });
+
+    let mut cursor = result.started_at_ms;
+    for (step, &span_id) in result.steps.iter().zip(step_ids) {
+        let start = cursor;
+        cursor += step.duration_ms;
+
+        let mut attrs: BTreeMap<String, AttributeValue> = BTreeMap::new();
+        attrs.insert("mzizi.node".to_owned(), AttributeValue::Int(8));
+        attrs.insert(
+            "mzizi.probe.journey".to_owned(),
+            AttributeValue::Str(result.journey_id.clone()),
+        );
+        attrs.insert(
+            "mzizi.probe.step_status".to_owned(),
+            AttributeValue::Str(
+                match step.status {
+                    StepStatus::Pass => "pass",
+                    StepStatus::Fail => "fail",
+                }
+                .to_owned(),
+            ),
+        );
+        if let Some(err) = &step.error {
+            attrs.insert("error.message".to_owned(), AttributeValue::Str(err.clone()));
+        }
+
+        let step_failed = step.status == StepStatus::Fail;
+        spans.push(Span {
+            name: step.description.clone(),
+            kind: SpanKind::Client,
+            span_id,
+            parent_span_id: Some(run_id),
+            start_time_ms: start,
+            end_time_ms: cursor,
+            attributes: attrs,
+            status: if step_failed {
+                StatusCode::Error
+            } else {
+                StatusCode::Ok
+            },
+            status_message: step_failed.then(|| {
+                step.error
+                    .clone()
+                    .unwrap_or_else(|| "step failed".to_owned())
+            }),
+        });
+    }
+
+    spans
+}

--- a/components/registry/n8-assurance/mzizi-otel.ts
+++ b/components/registry/n8-assurance/mzizi-otel.ts
@@ -5,21 +5,31 @@
    ═══════════════════════════════════════════════════════════════ */
 
 /**
- * STOPGAP — N8 IS A RUST NODE AND THIS FILE IS TYPESCRIPT.
+ * THE RUST CORE HAS LANDED. THIS FILE IS THE JAVASCRIPT SHIM OVER IT.
  *
- * N4, N5, N8 and N9 are the core: the nodes holding logic rather than UI, and
- * doctrine puts them in Rust — N4/N5/N8 as a WASM shared core, N9 as a
- * `workers-rs` edge worker. Today none of them are; there are zero `.rs` files
- * under those four directories.
+ * This block used to say N8 was a Rust node with zero `.rs` files under it, and
+ * to call this file a stopgap for a core nobody had started. That is no longer
+ * true: `mzizi-otel.rs` sits beside this file, every N8 and N9 component now has
+ * a Rust core, and the `mzizi-assurance` / `mzizi-fundi` crates compile them
+ * under `cargo check`, `clippy -D warnings` and a contract suite in CI.
  *
- * When the core lands, the split is: payload construction, id generation,
- * endpoint resolution and the never-throw contract are shared-core logic and
- * move to Rust. What stays per-target is only the thin call that sends.
+ * The split the old note promised is the split that shipped. Payload
+ * construction, id handling, endpoint resolution, the nanosecond conversion and
+ * the never-throw contract are shared-core logic and live in the `.rs`. What
+ * belongs here is the thin call that actually sends — `fetch` in a browser,
+ * `fetch` or the Browser Run binding in a Worker.
  *
- * This exists in TypeScript because a consumer app's browser has to be able to
- * emit at all, and because two live defects were found through building it. It
- * is not the pattern to copy for a new N4/N5/N8/N9 component. See
- * `docs/n8-telemetry.md`.
+ * So this file is NOT deprecated and NOT a stopgap: it is the per-target shim,
+ * and a consumer app whose runtime is JavaScript installs it rather than a WASM
+ * module. What it must not do is drift. The `.rs` is where a rule changes; if
+ * you edit a threshold, an attribute key or a payload shape here and not there,
+ * the contract suite in `mzizi-rs/crates/mzizi-assurance/tests/contract.rs`
+ * reads this file on disk and fails. See `docs/n8-telemetry.md`.
+ *
+ * Still outstanding, and stated plainly so nobody reads "the core landed" as
+ * more than it is: the core is pure logic with no I/O, so there is no WASM build
+ * wired into any consumer yet and this file does not call one. The two
+ * implementations agree by contract test, not by sharing a binary.
  *
  * WHY THIS EXISTS.
  *

--- a/components/registry/n8-assurance/mzizi-perf-probe.rs
+++ b/components/registry/n8-assurance/mzizi-perf-probe.rs
@@ -1,0 +1,388 @@
+//! Mzizi N8 assurance — Web Vitals rating and per-component performance.
+//!
+//! The Rust implementation of `mzizi-perf-probe`. The thresholds, the ratings, the
+//! CLS fold and the report; not `PerformanceObserver`, not `performance.memory`,
+//! not the sampling draw.
+//!
+//! # Four defects in the TypeScript, fixed here
+//!
+//! **1. An unknown metric was rated `good`.** `rateMetric` looks the name up in a
+//! `Record<string, …>` and returns `"good"` when the lookup misses — so a typo, a
+//! metric added ahead of its threshold, or anything the table does not know about
+//! reports as healthy. This is the fail-open shape CLAUDE.md §14 forbids for
+//! entitlement, and it is no better here: "we have no threshold for this" must not
+//! resolve to "this is fine". [`Vital`] is a closed enum and [`rate`] matches it
+//! totally, so the case cannot arise; [`Rating::Unrated`] exists for a host that
+//! measured something this core has no threshold for.
+//!
+//! **2. Per-component metrics were three literal zeros.** `renderTimeMs: 0,
+//! rerenderCount: 0, mountTimeMs: 0` for every component on the page — and
+//! `usePerfMark` writes `performance.mark` entries that nothing ever reads, since
+//! `performance.measure` is never called and the marks are never collected. So the
+//! component half of the probe measures nothing and reports zeros as though it
+//! had. A table showing every component rendering in 0ms is not an empty dashboard,
+//! it is a dashboard saying everything is perfect. Every measurement here is an
+//! [`Option`], and [`ComponentPerf::from_marks`] is the only thing that fills one.
+//!
+//! **3. `totalRenderTimeMs` was `performance.now()`** — milliseconds since the
+//! page started, read inside a `setTimeout(…, 5000)`. So it was the age of the
+//! page, never below 5000, and had nothing to do with rendering. Here it is the
+//! sum of what was actually measured, and [`None`] when nothing was.
+//!
+//! **4. CLS was recorded once per observer batch.** `recordMetric("CLS", clsValue)`
+//! fires inside the observer callback, so `vitals` accumulates one CLS entry per
+//! batch, each carrying the running cumulative total, and `onMetric` fires
+//! repeatedly for one metric. Anyone averaging that array gets a number that means
+//! nothing. CLS is cumulative by definition — [`VitalsAccumulator`] folds it and
+//! keeps ONE value.
+//!
+//! # Preserved
+//!
+//! `memoryUsageMB` stays optional and absent rather than zero. `performance.memory`
+//! is Chromium-only, and the `.ts` had already been fixed to stop dividing
+//! `undefined` by 1048576 and reporting **NaN** on every other browser — a
+//! number-shaped value that poisons any average computed from it. Same rule, same
+//! reason: absent is the honest answer.
+
+use std::collections::BTreeMap;
+
+/// A Web Vital this core can rate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Vital {
+    /// Largest Contentful Paint, milliseconds.
+    Lcp,
+    /// First Input Delay, milliseconds.
+    Fid,
+    /// Cumulative Layout Shift, unitless.
+    Cls,
+    /// Interaction to Next Paint, milliseconds.
+    Inp,
+    /// Time To First Byte, milliseconds.
+    Ttfb,
+    /// First Contentful Paint, milliseconds.
+    Fcp,
+}
+
+impl Vital {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Lcp => "LCP",
+            Self::Fid => "FID",
+            Self::Cls => "CLS",
+            Self::Inp => "INP",
+            Self::Ttfb => "TTFB",
+            Self::Fcp => "FCP",
+        }
+    }
+
+    /// Parse a wire spelling.
+    ///
+    /// Returns [`None`] for anything unknown, which the caller must handle — the
+    /// `.ts` resolves the same situation to a `good` rating. See defect 1.
+    ///
+    /// Deliberately not `FromStr`: that trait's `Err` would have to name a type,
+    /// and "this is not a vital I have a threshold for" is an absence rather than
+    /// an error.
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "LCP" => Some(Self::Lcp),
+            "FID" => Some(Self::Fid),
+            "CLS" => Some(Self::Cls),
+            "INP" => Some(Self::Inp),
+            "TTFB" => Some(Self::Ttfb),
+            "FCP" => Some(Self::Fcp),
+            _ => None,
+        }
+    }
+
+    /// The `good` ceiling and the `poor` floor, from web.dev.
+    #[must_use]
+    pub const fn thresholds(self) -> (f64, f64) {
+        match self {
+            Self::Lcp => (2500.0, 4000.0),
+            Self::Fid => (100.0, 300.0),
+            Self::Cls => (0.1, 0.25),
+            Self::Inp => (200.0, 500.0),
+            Self::Ttfb => (800.0, 1800.0),
+            Self::Fcp => (1800.0, 3000.0),
+        }
+    }
+
+    /// Whether this vital accumulates across the page's life.
+    ///
+    /// Only CLS does, and that is why it needs folding rather than appending.
+    #[must_use]
+    pub const fn is_cumulative(self) -> bool {
+        matches!(self, Self::Cls)
+    }
+
+    /// Every vital this core rates.
+    #[must_use]
+    pub const fn all() -> [Self; 6] {
+        [
+            Self::Lcp,
+            Self::Fid,
+            Self::Cls,
+            Self::Inp,
+            Self::Ttfb,
+            Self::Fcp,
+        ]
+    }
+}
+
+/// How a measurement scores against its thresholds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Rating {
+    /// Within the good ceiling.
+    Good,
+    /// Between the two.
+    NeedsImprovement,
+    /// At or beyond the poor floor.
+    Poor,
+    /// Measured, but this core has no threshold for it.
+    ///
+    /// Deliberately NOT `Good`. The `.ts` returns `"good"` on a threshold miss,
+    /// so an unrecognised metric reports as healthy.
+    Unrated,
+}
+
+impl Rating {
+    /// The wire spelling. `unrated` has no `.ts` counterpart, because the `.ts`
+    /// has no way to express it.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Good => "good",
+            Self::NeedsImprovement => "needs-improvement",
+            Self::Poor => "poor",
+            Self::Unrated => "unrated",
+        }
+    }
+}
+
+/// Rate a measurement against its vital's thresholds.
+///
+/// The boundaries match the `.ts`: `<= good` is good, `>= poor` is poor, and the
+/// band between them is `needs-improvement`.
+#[must_use]
+pub fn rate(vital: Vital, value: f64) -> Rating {
+    let (good, poor) = vital.thresholds();
+    if value.is_nan() {
+        // A NaN compares false against everything, so every branch below would
+        // fall through to `needs-improvement` — a rating invented from a
+        // non-measurement.
+        return Rating::Unrated;
+    }
+    if value <= good {
+        Rating::Good
+    } else if value >= poor {
+        Rating::Poor
+    } else {
+        Rating::NeedsImprovement
+    }
+}
+
+/// One rated measurement.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VitalsMetric {
+    /// Which vital.
+    pub vital: Vital,
+    /// The measurement.
+    pub value: f64,
+    /// How it scores.
+    pub rating: Rating,
+    /// The PATH, never a full URL — a query string carries session tokens and
+    /// search terms, and this probe collects no PII.
+    pub url: String,
+    /// When, milliseconds since the Unix epoch.
+    pub at_ms: f64,
+}
+
+/// The vitals seen so far on one page.
+///
+/// Cumulative vitals are FOLDED, not appended. The `.ts` pushes a fresh CLS entry
+/// on every `layout-shift` batch, each holding the running total, so a page with
+/// twelve shift batches reports twelve CLS metrics.
+#[derive(Debug, Clone, Default)]
+pub struct VitalsAccumulator {
+    metrics: BTreeMap<Vital, VitalsMetric>,
+}
+
+impl VitalsAccumulator {
+    /// An empty accumulator.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a measurement, returning the value now held for that vital.
+    ///
+    /// A cumulative vital replaces its previous value — that value already
+    /// includes everything before it. A non-cumulative one also replaces, which
+    /// matches the browser: LCP is reported repeatedly and the last is the answer.
+    pub fn record(&mut self, vital: Vital, value: f64, url: &str, at_ms: f64) -> &VitalsMetric {
+        self.metrics.insert(
+            vital,
+            VitalsMetric {
+                vital,
+                value,
+                rating: rate(vital, value),
+                url: url.to_owned(),
+                at_ms,
+            },
+        );
+        &self.metrics[&vital]
+    }
+
+    /// What is held for one vital.
+    #[must_use]
+    pub fn get(&self, vital: Vital) -> Option<&VitalsMetric> {
+        self.metrics.get(&vital)
+    }
+
+    /// Every vital held, one entry each.
+    #[must_use]
+    pub fn metrics(&self) -> Vec<&VitalsMetric> {
+        self.metrics.values().collect()
+    }
+
+    /// The worst rating present — the one-glance answer.
+    ///
+    /// [`Rating::Unrated`] does not win: it is an absence of judgement, not a bad
+    /// one, and letting it outrank `Poor` would hide a real failure behind an
+    /// unknown metric.
+    #[must_use]
+    pub fn worst_rating(&self) -> Option<Rating> {
+        self.metrics
+            .values()
+            .map(|m| m.rating)
+            .filter(|r| *r != Rating::Unrated)
+            .max()
+    }
+}
+
+/// A `performance.mark` pair for one component.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MarkPair {
+    /// When the component mounted, milliseconds on the performance timeline.
+    pub mount_ms: f64,
+    /// When it unmounted, if it has.
+    pub unmount_ms: Option<f64>,
+}
+
+/// What a component actually cost.
+///
+/// Every measurement is optional, because the honest answer to "how long did this
+/// take" is frequently "nobody measured". The `.ts` answers `0`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ComponentPerf {
+    /// The `data-slot` value.
+    pub component_name: String,
+    /// Which helix node. Uncapped.
+    pub node: Option<u32>,
+    /// Where its documentation is.
+    pub portal_url: Option<String>,
+    /// How long it was mounted for.
+    pub mount_duration_ms: Option<f64>,
+    /// How long its render took.
+    pub render_time_ms: Option<f64>,
+    /// How many times it re-rendered.
+    pub rerender_count: Option<u32>,
+}
+
+impl ComponentPerf {
+    /// A component that was seen on the page but never measured.
+    ///
+    /// This is what the `.ts` produces for every component; the difference is that
+    /// here it says so rather than reporting three zeros.
+    #[must_use]
+    pub fn observed(component_name: impl Into<String>) -> Self {
+        Self {
+            component_name: component_name.into(),
+            node: None,
+            portal_url: None,
+            mount_duration_ms: None,
+            render_time_ms: None,
+            rerender_count: None,
+        }
+    }
+
+    /// Fill in what a mark pair says.
+    ///
+    /// An unmount mark that precedes its mount is discarded rather than reported
+    /// as a negative duration: clocks and mark ordering are the host's business,
+    /// and a negative lifetime is a measurement error, not a fast component.
+    #[must_use]
+    pub fn from_marks(component_name: impl Into<String>, marks: MarkPair) -> Self {
+        let mut perf = Self::observed(component_name);
+        perf.mount_duration_ms = marks
+            .unmount_ms
+            .map(|end| end - marks.mount_ms)
+            .filter(|d| *d >= 0.0);
+        perf
+    }
+
+    /// Whether anything at all was measured.
+    #[must_use]
+    pub fn is_measured(&self) -> bool {
+        self.mount_duration_ms.is_some()
+            || self.render_time_ms.is_some()
+            || self.rerender_count.is_some()
+    }
+}
+
+/// One page's performance.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PerfReport {
+    /// The path measured.
+    pub url: String,
+    /// When, milliseconds since the Unix epoch.
+    pub at_ms: f64,
+    /// One entry per vital.
+    pub vitals: Vec<VitalsMetric>,
+    /// One entry per component seen.
+    pub components: Vec<ComponentPerf>,
+    /// The sum of the render times that were MEASURED.
+    ///
+    /// [`None`] when none were — which the `.ts` answers with `performance.now()`,
+    /// the age of the page, read inside a five-second timeout.
+    pub total_render_time_ms: Option<f64>,
+    /// Heap in megabytes, when the runtime reports it. Chromium only.
+    pub memory_usage_mb: Option<f64>,
+}
+
+/// Assemble a report from what was gathered.
+#[must_use]
+pub fn build_report(
+    url: impl Into<String>,
+    at_ms: f64,
+    vitals: &VitalsAccumulator,
+    components: Vec<ComponentPerf>,
+    memory_usage_mb: Option<f64>,
+) -> PerfReport {
+    let measured: Vec<f64> = components.iter().filter_map(|c| c.render_time_ms).collect();
+    PerfReport {
+        url: url.into(),
+        at_ms,
+        vitals: vitals.metrics().into_iter().cloned().collect(),
+        total_render_time_ms: (!measured.is_empty()).then(|| measured.iter().sum()),
+        components,
+        memory_usage_mb,
+    }
+}
+
+/// The default sample rate, matching the `.ts`.
+pub const DEFAULT_SAMPLE_RATE: f64 = 0.1;
+
+/// Whether this pageload is sampled.
+///
+/// `draw` is a value in `[0, 1)` supplied by the host, for the same reason as in
+/// `mzizi-rum`: a core with no I/O has no entropy source, and a supplied draw is
+/// testable at both boundaries.
+#[must_use]
+pub fn should_sample(draw: f64, sample_rate: f64) -> bool {
+    draw < sample_rate
+}

--- a/components/registry/n8-assurance/mzizi-platform-health.rs
+++ b/components/registry/n8-assurance/mzizi-platform-health.rs
@@ -1,0 +1,205 @@
+//! Mzizi N8 assurance — what a set of service statuses adds up to.
+//!
+//! The Rust core behind `mzizi-platform-health`. The component is a UI surface and
+//! gets a Dioxus alternative rather than an implementation (CLAUDE.md §6.2); what
+//! lives here is the part that is not UI at all — the rollup from a list of
+//! services to the single line at the top of the panel, and the status → label
+//! mapping that has to agree across every target.
+//!
+//! Putting it here is what makes that agreement possible. In the `.tsx` the rollup
+//! is three chained ternaries inside the render, so a Swift panel and a Dioxus
+//! panel would each re-derive it, and the three would drift silently — the failure
+//! being that two dashboards showing the same services disagree about whether
+//! anything is wrong.
+//!
+//! # Three defects in the TypeScript, fixed here
+//!
+//! **1. An empty service list reported "All Systems Operational", in green.**
+//! `services.every(…)` is `true` for an empty array, so a panel that fetched
+//! nothing — the request failed, the list has not loaded, the config is wrong —
+//! renders exactly like a healthy platform. This is the worst possible failure for
+//! a status page: it is the one surface whose entire job is to be trusted at a
+//! glance, and knowing nothing renders as knowing everything is fine.
+//! [`Overall::Unknown`] is what nothing adds up to.
+//!
+//! **2. Planned maintenance was reported as "Issues Detected".** `allOk` is false
+//! for any non-`operational` status, and the fallback branch is `degraded` — so a
+//! service someone deliberately took down on a schedule turns the header amber and
+//! announces a problem. Maintenance is a state the operator chose; a status page
+//! that cries about it is one people stop reading.
+//!
+//! **3. `unknown` was folded into `degraded` too.** Same fallback branch. "We
+//! could not determine this service's state" and "this service is impaired" are
+//! different claims, and a status page that cannot tell them apart cannot be used
+//! to decide anything. [`Overall::Unknown`] carries it separately.
+//!
+//! # Colours are not here, deliberately
+//!
+//! `STATUS_CONFIG` in the `.tsx` pairs each status with `var(--health-operational,
+//! #22C55E)` and friends. The variable reference is right and the hex fallback is
+//! a design value defined outside N1, which §7.4 forbids — but the fix is a token,
+//! not a Rust constant. Duplicating the hex here would put the same wrong value in
+//! a second place. Each target reads `--health-<status>`; this core answers which
+//! status applies.
+
+/// How one service is doing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ServiceStatus {
+    /// Working.
+    Operational,
+    /// Taken down on purpose.
+    Maintenance,
+    /// State could not be determined.
+    Unknown,
+    /// Working badly.
+    Degraded,
+    /// Not working.
+    Outage,
+}
+
+impl ServiceStatus {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Operational => "operational",
+            Self::Degraded => "degraded",
+            Self::Outage => "outage",
+            Self::Maintenance => "maintenance",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// The human label, matching the `.tsx`'s `STATUS_CONFIG`.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Operational => "Operational",
+            Self::Degraded => "Degraded",
+            Self::Outage => "Outage",
+            Self::Maintenance => "Maintenance",
+            Self::Unknown => "Unknown",
+        }
+    }
+
+    /// The CSS custom property a target reads for this status's colour.
+    ///
+    /// The property, not the value. See the module docs.
+    #[must_use]
+    pub const fn color_var(self) -> &'static str {
+        match self {
+            Self::Operational => "--health-operational",
+            Self::Degraded => "--health-degraded",
+            Self::Outage => "--health-outage",
+            Self::Maintenance => "--health-maintenance",
+            Self::Unknown => "--color-muted-foreground",
+        }
+    }
+
+    /// Whether this status means something is wrong.
+    ///
+    /// `maintenance` is NOT a problem — it is a state an operator chose — and
+    /// `unknown` is not a problem either, it is an absence of information.
+    #[must_use]
+    pub const fn is_problem(self) -> bool {
+        matches!(self, Self::Degraded | Self::Outage)
+    }
+}
+
+/// One service on the panel.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ServiceHealth {
+    /// What it is called.
+    pub name: String,
+    /// How it is doing.
+    pub status: ServiceStatus,
+    /// How fast it answered, when that was measured.
+    pub latency_ms: Option<f64>,
+    /// Anything worth saying about it.
+    pub message: Option<String>,
+}
+
+/// What the whole panel says in one line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Overall {
+    /// Everything is working.
+    Operational,
+    /// Nothing is broken, but something is deliberately down.
+    UnderMaintenance,
+    /// Something is impaired.
+    Degraded,
+    /// Something is down.
+    Outage,
+    /// Nothing is known — no services were reported.
+    ///
+    /// The `.tsx` has no such case: `[].every(…)` is `true`, so an empty list
+    /// renders green and says "All Systems Operational".
+    Unknown,
+}
+
+impl Overall {
+    /// The headline.
+    #[must_use]
+    pub const fn headline(self) -> &'static str {
+        match self {
+            Self::Operational => "All Systems Operational",
+            Self::UnderMaintenance => "Planned Maintenance",
+            Self::Degraded | Self::Outage => "Issues Detected",
+            Self::Unknown => "Status Unavailable",
+        }
+    }
+
+    /// The CSS custom property the header dot and text read.
+    #[must_use]
+    pub const fn color_var(self) -> &'static str {
+        match self {
+            Self::Operational => ServiceStatus::Operational.color_var(),
+            Self::UnderMaintenance => ServiceStatus::Maintenance.color_var(),
+            Self::Degraded => ServiceStatus::Degraded.color_var(),
+            Self::Outage => ServiceStatus::Outage.color_var(),
+            Self::Unknown => ServiceStatus::Unknown.color_var(),
+        }
+    }
+
+    /// Whether this warrants somebody looking.
+    #[must_use]
+    pub const fn needs_attention(self) -> bool {
+        matches!(self, Self::Degraded | Self::Outage)
+    }
+}
+
+/// Roll a list of services up into the one line at the top of the panel.
+///
+/// Worst wins, with the bands ordered outage → degraded → unknown → maintenance →
+/// operational. `unknown` outranks `maintenance` because an unmeasured service
+/// might be down, and a scheduled one is known not to be.
+#[must_use]
+pub fn overall(services: &[ServiceHealth]) -> Overall {
+    if services.is_empty() {
+        // Nothing measured is not the same as nothing wrong. See defect 1: this
+        // is the case that made a broken fetch look like a healthy platform.
+        return Overall::Unknown;
+    }
+    if services.iter().any(|s| s.status == ServiceStatus::Outage) {
+        return Overall::Outage;
+    }
+    if services.iter().any(|s| s.status == ServiceStatus::Degraded) {
+        return Overall::Degraded;
+    }
+    if services.iter().any(|s| s.status == ServiceStatus::Unknown) {
+        return Overall::Unknown;
+    }
+    if services
+        .iter()
+        .any(|s| s.status == ServiceStatus::Maintenance)
+    {
+        return Overall::UnderMaintenance;
+    }
+    Overall::Operational
+}
+
+/// How many services are in each state, for a summary line.
+#[must_use]
+pub fn tally(services: &[ServiceHealth], status: ServiceStatus) -> usize {
+    services.iter().filter(|s| s.status == status).count()
+}

--- a/components/registry/n8-assurance/mzizi-rum.rs
+++ b/components/registry/n8-assurance/mzizi-rum.rs
@@ -1,0 +1,277 @@
+//! Mzizi N8 assurance — real user monitoring: sampling, classification, batching.
+//!
+//! The Rust implementation of `mzizi-rum`. Privacy-first: no PII, and nothing
+//! here can reach for any, because the core never touches a browser.
+//!
+//! # What this owns
+//!
+//! Whether to sample, what a viewport means, and how events accumulate into a
+//! batch. Not `window`, not `performance`, not `navigator`, not the POST — the
+//! host gathers the numbers and sends them.
+//!
+//! # Two defects in the TypeScript, fixed here
+//!
+//! **1. An unsampled collector still accumulated events, forever.** The `.ts`
+//! constructor returns early when `Math.random() > sampleRate`, *before* calling
+//! `init()` — so no flush timer is ever created. But `record()` stays public and
+//! still pushes onto `this.events`, so any consumer calling it by hand on an
+//! unsampled collector grows an array that nothing will ever drain. At the
+//! default 10% sample rate that is nine sessions in ten.
+//!
+//! Here sampling is decided once, by [`should_sample`], and an unsampled
+//! [`RumBuffer`] *discards* rather than silently hoarding.
+//!
+//! **2. The buffer had no ceiling even when sampled.** Events drain on a 30-second
+//! timer, and a flush that fails is swallowed by design — correctly, since RUM
+//! must never surface its own network error to the user it measures. Correct, and
+//! unbounded: a collector whose endpoint is down accumulates for the life of the
+//! session. [`RumBuffer`] caps and drops oldest, which loses the least recent
+//! data rather than the whole tab.
+//!
+//! # Randomness is supplied, as everywhere in this node
+//!
+//! [`should_sample`] takes the random draw rather than making it. Not for the
+//! security reason that applies to trace ids — sampling is not a correlation key
+//! — but because a core with no I/O has no entropy source either, and a caller
+//! that supplies the draw can write a deterministic test for the boundary.
+
+/// What kind of device, derived from the viewport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Device {
+    /// Narrow viewport.
+    Mobile,
+    /// Mid-width viewport.
+    Tablet,
+    /// Wide viewport.
+    Desktop,
+}
+
+impl Device {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Mobile => "mobile",
+            Self::Tablet => "tablet",
+            Self::Desktop => "desktop",
+        }
+    }
+}
+
+/// Effective connection type, as the Network Information API reports it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Connection {
+    /// 4g or better.
+    FourG,
+    /// 3g.
+    ThreeG,
+    /// 2g.
+    TwoG,
+    /// Slower than 2g.
+    SlowTwoG,
+    /// Reported as wifi.
+    Wifi,
+    /// Not reported. Safari does not implement the API at all.
+    Unknown,
+}
+
+impl Connection {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::FourG => "4g",
+            Self::ThreeG => "3g",
+            Self::TwoG => "2g",
+            Self::SlowTwoG => "slow-2g",
+            Self::Wifi => "wifi",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// Parse what the host read, defaulting to [`Connection::Unknown`].
+    #[must_use]
+    pub fn from_str_or_unknown(value: &str) -> Self {
+        match value {
+            "4g" => Self::FourG,
+            "3g" => Self::ThreeG,
+            "2g" => Self::TwoG,
+            "slow-2g" => Self::SlowTwoG,
+            "wifi" => Self::Wifi,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// What kind of thing was measured.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RumEventType {
+    /// The initial page load.
+    Pageload,
+    /// A user interaction.
+    Interaction,
+    /// A client-side navigation.
+    Navigation,
+    /// A network request.
+    Network,
+    /// An error.
+    Error,
+}
+
+impl RumEventType {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pageload => "pageload",
+            Self::Interaction => "interaction",
+            Self::Navigation => "navigation",
+            Self::Network => "network",
+            Self::Error => "error",
+        }
+    }
+}
+
+/// One measurement.
+///
+/// `url` is a PATH, never a full URL: a query string carries session tokens,
+/// reset links and search terms, and this component's whole premise is that it
+/// collects no PII.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RumEvent {
+    /// What kind.
+    pub event_type: RumEventType,
+    /// When, in milliseconds since the Unix epoch.
+    pub timestamp_ms: f64,
+    /// The path, without query or fragment.
+    pub url: String,
+    /// Which mini-app.
+    pub mini_app: Option<String>,
+    /// Device class.
+    pub device: Device,
+    /// Connection class.
+    pub connection: Connection,
+    /// The numbers.
+    pub metrics: Vec<(String, f64)>,
+}
+
+/// The viewport width below which a device is [`Device::Mobile`].
+pub const MOBILE_MAX_WIDTH: u32 = 640;
+/// The viewport width below which a device is [`Device::Tablet`].
+pub const TABLET_MAX_WIDTH: u32 = 1024;
+
+/// Classify a viewport width.
+#[must_use]
+pub fn device_for(viewport_width: u32) -> Device {
+    if viewport_width < MOBILE_MAX_WIDTH {
+        Device::Mobile
+    } else if viewport_width < TABLET_MAX_WIDTH {
+        Device::Tablet
+    } else {
+        Device::Desktop
+    }
+}
+
+/// Whether this session is sampled.
+///
+/// `draw` is a value in `[0, 1)` from the host. The comparison matches the
+/// `.ts`'s `Math.random() > sampleRate` inverted, so a rate of `0.0` samples
+/// nothing and `1.0` samples everything — both exactly, which a `>=` on either
+/// side would get wrong at one end.
+#[must_use]
+pub fn should_sample(draw: f64, sample_rate: f64) -> bool {
+    draw < sample_rate
+}
+
+/// Strip a URL to the path RUM is allowed to keep.
+///
+/// A query string is where session tokens, password-reset links and search terms
+/// live. The `.ts` uses `window.location.pathname`, which already excludes them;
+/// this exists so a host that has a full URL cannot accidentally hand one over.
+#[must_use]
+pub fn path_only(url: &str) -> String {
+    let without_fragment = url.split('#').next().unwrap_or("");
+    let without_query = without_fragment.split('?').next().unwrap_or("");
+    // Keep the path from an absolute URL, dropping scheme and host.
+    match without_query.find("://") {
+        Some(scheme_end) => {
+            let rest = &without_query[scheme_end + 3..];
+            match rest.find('/') {
+                Some(path_start) => rest[path_start..].to_owned(),
+                None => "/".to_owned(),
+            }
+        }
+        None => without_query.to_owned(),
+    }
+}
+
+/// A bounded batch of events awaiting flush.
+#[derive(Debug, Clone)]
+pub struct RumBuffer {
+    /// Whether this session is sampled at all.
+    sampled: bool,
+    /// How many events to hold before dropping the oldest.
+    max_events: usize,
+    events: Vec<RumEvent>,
+}
+
+impl RumBuffer {
+    /// A buffer for a session that has already been sampled in or out.
+    ///
+    /// An unsampled buffer DISCARDS. The `.ts` leaves `record()` callable on an
+    /// unsampled collector whose flush timer was never started, so events pile up
+    /// with nothing to drain them — in nine sessions out of ten at the default
+    /// rate.
+    #[must_use]
+    pub fn new(sampled: bool, max_events: usize) -> Self {
+        Self {
+            sampled,
+            max_events,
+            events: Vec::new(),
+        }
+    }
+
+    /// Whether this session is collecting.
+    #[must_use]
+    pub const fn is_sampled(&self) -> bool {
+        self.sampled
+    }
+
+    /// Record an event. Returns whether it was kept.
+    pub fn record(&mut self, event: RumEvent) -> bool {
+        if !self.sampled {
+            return false;
+        }
+        self.events.push(event);
+        // Dropping the oldest loses the least recent measurement rather than
+        // growing until the tab does. A flush that fails is swallowed by design
+        // — RUM must never surface its own network error to the user it measures
+        // — so without a ceiling an unreachable endpoint accumulates for the
+        // whole session.
+        if self.events.len() > self.max_events {
+            self.events.remove(0);
+        }
+        true
+    }
+
+    /// Take everything pending, leaving the buffer empty.
+    ///
+    /// The batch is handed over BEFORE the host tries to send it, matching the
+    /// `.ts`. A send that fails loses that batch rather than retrying, which is
+    /// the deliberate trade for never blocking or surfacing an error.
+    pub fn drain(&mut self) -> Vec<RumEvent> {
+        std::mem::take(&mut self.events)
+    }
+
+    /// How many events are pending.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+
+    /// Whether anything is pending.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+}

--- a/components/registry/n8-assurance/mzizi-synthetic-probe.rs
+++ b/components/registry/n8-assurance/mzizi-synthetic-probe.rs
@@ -1,0 +1,378 @@
+//! Mzizi N8 assurance — synthetic journeys: the probe contract and its pure parts.
+//!
+//! The Rust implementation of `mzizi-synthetic-probe`.
+//!
+//! # What this owns, and what it deliberately does not
+//!
+//! It owns the **contract** — what a journey is, what a run produced, when a
+//! failure is worth waking somebody for — and every decision derivable from a
+//! finished run. It does **not** own execution.
+//!
+//! That is the same boundary [`super::mzizi_otel`] draws at sending, and for the
+//! same reason: driving a browser is I/O, and every host does it differently. A
+//! Cloudflare Worker cannot spawn a browser process at all and reaches Browser
+//! Run over `fetch`; a laptop can drive Chromium directly; a native shell has its
+//! own harness. What must *not* vary is what counts as a pass, how step outcomes
+//! roll up into a run outcome, and when an alert fires.
+//!
+//! The `.ts` sibling is honest about this in a way worth preserving: its
+//! `executeSyntheticJourney` is a stub whose body says *"in a real implementation
+//! this would use Puppeteer/Playwright — here we define the contract that the
+//! probe runner implements."* Porting that stub to Rust would have carried a
+//! placeholder across as though it were an implementation. The contract is the
+//! real content, so the contract is what moved.
+//!
+//! One correction landed on the way: that comment names Puppeteer/Playwright, and
+//! **fundi is a Cloudflare Worker**, which can run neither. The runner that
+//! actually exists (`scripts/kitesurf.ts`) is a `fetch` against Browser Run for
+//! exactly that reason.
+
+use std::collections::BTreeMap;
+
+/// What a step does when a runner executes it.
+///
+/// A closed set rather than a string, because a runner has to exhaustively
+/// handle every variant — and an unknown step type should fail to compile rather
+/// than be silently skipped at 3am.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeStepType {
+    /// Go to a path.
+    Navigate,
+    /// Click a selector.
+    Click,
+    /// Type a value into a selector.
+    Input,
+    /// Assert a selector is present.
+    Assert,
+    /// Wait, either for a selector or for a duration.
+    Wait,
+    /// Capture a screenshot.
+    Screenshot,
+}
+
+impl ProbeStepType {
+    /// The wire spelling, matching the `.ts` string union exactly.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Navigate => "navigate",
+            Self::Click => "click",
+            Self::Input => "input",
+            Self::Assert => "assert",
+            Self::Wait => "wait",
+            Self::Screenshot => "screenshot",
+        }
+    }
+}
+
+/// One step a runner should perform.
+///
+/// This is the INPUT shape. The outcome of running it is [`StepResult`], which is
+/// a different type carrying different fields — the `.ts` names this one
+/// `ProbeStep` and leaves the outcome shape anonymous inside `ProbeResult`, which
+/// is how the two came to be conflated in the first Rust draft.
+#[derive(Debug, Clone)]
+pub struct ProbeStep {
+    /// What to do.
+    pub step_type: ProbeStepType,
+    /// Selector or path, depending on the step type.
+    pub target: Option<String>,
+    /// Value to enter, for [`ProbeStepType::Input`].
+    pub value: Option<String>,
+    /// Per-step timeout in milliseconds.
+    pub timeout_ms: Option<u32>,
+    /// Human description. Becomes the step's span name, so it is not decoration.
+    pub description: String,
+}
+
+/// A journey a runner can execute on a schedule.
+#[derive(Debug, Clone)]
+pub struct SyntheticJourney {
+    /// Stable id. A collector groups runs on this, so it must not drift.
+    pub id: String,
+    /// Human name.
+    pub name: String,
+    /// Which mini-app this journey exercises.
+    pub mini_app: Option<String>,
+    /// Which helix nodes the journey traverses.
+    ///
+    /// Uncapped on purpose: node numbers are labels, not a sequence, and any
+    /// upper bound here would be the defect rather than its current value.
+    pub nodes: Vec<u32>,
+    /// The steps, in order.
+    pub steps: Vec<ProbeStep>,
+    /// Cron expression, when scheduled.
+    pub schedule: Option<String>,
+    /// Regions to run from.
+    pub regions: Vec<String>,
+    /// Whether a failure should raise an alert.
+    pub alert_on_failure: bool,
+}
+
+/// Outcome of one executed step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StepStatus {
+    /// The step asserted what it set out to assert.
+    Pass,
+    /// The step failed.
+    Fail,
+}
+
+impl StepStatus {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pass => "pass",
+            Self::Fail => "fail",
+        }
+    }
+}
+
+/// Outcome of a whole run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeStatus {
+    /// Every step passed.
+    Pass,
+    /// At least one step failed.
+    Fail,
+    /// The run exceeded its allotted time.
+    Timeout,
+    /// The runner itself could not complete — distinct from the journey failing.
+    Error,
+}
+
+impl ProbeStatus {
+    /// Whether this outcome should surface as an OTLP `ERROR` status.
+    #[must_use]
+    pub const fn is_failure(self) -> bool {
+        !matches!(self, Self::Pass)
+    }
+
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pass => "pass",
+            Self::Fail => "fail",
+            Self::Timeout => "timeout",
+            Self::Error => "error",
+        }
+    }
+}
+
+/// The outcome of one executed step.
+#[derive(Debug, Clone)]
+pub struct StepResult {
+    /// The step's description, carried through so a reader need not re-join.
+    pub description: String,
+    /// Whether it passed.
+    pub status: StepStatus,
+    /// How long it took.
+    pub duration_ms: f64,
+    /// Why it failed, when it did.
+    ///
+    /// Carried onto the wire as `error.message` rather than left in prose,
+    /// because the consumer acting on it is usually not a human. A render check
+    /// that failed because the URL sat behind an auth wall is not the same
+    /// incident as a page that rendered empty, and fundi filing an issue for the
+    /// first would be a false positive.
+    pub error: Option<String>,
+}
+
+/// What one run produced. The contract every runner returns.
+#[derive(Debug, Clone)]
+pub struct ProbeResult {
+    /// Which journey ran.
+    pub journey_id: String,
+    /// When the run started, in milliseconds since the Unix epoch.
+    ///
+    /// Milliseconds rather than the `.ts`'s ISO-8601 string, because a core has
+    /// no clock and no timezone database and should not grow a date parser to
+    /// avoid needing one. The host formats for display; the core does arithmetic.
+    pub started_at_ms: f64,
+    /// Where it ran from.
+    pub region: String,
+    /// The run's outcome.
+    pub status: ProbeStatus,
+    /// Total run duration.
+    pub duration_ms: f64,
+    /// Each step, in order.
+    pub steps: Vec<StepResult>,
+}
+
+impl ProbeResult {
+    /// Roll finished steps up into a run.
+    ///
+    /// The status is DERIVED, never passed in. A runner that reported a passing
+    /// run containing a failed step would be believed, and this is the one place
+    /// that can prevent it — so the invariant lives in a constructor rather than
+    /// in a rule somebody has to remember.
+    #[must_use]
+    pub fn from_steps(
+        journey_id: impl Into<String>,
+        region: impl Into<String>,
+        started_at_ms: f64,
+        duration_ms: f64,
+        steps: Vec<StepResult>,
+    ) -> Self {
+        let status = if steps.iter().any(|s| s.status == StepStatus::Fail) {
+            ProbeStatus::Fail
+        } else {
+            ProbeStatus::Pass
+        };
+        Self {
+            journey_id: journey_id.into(),
+            started_at_ms,
+            region: region.into(),
+            status,
+            duration_ms,
+            steps,
+        }
+    }
+
+    /// How many steps failed.
+    #[must_use]
+    pub fn failed_step_count(&self) -> usize {
+        self.steps
+            .iter()
+            .filter(|s| s.status == StepStatus::Fail)
+            .count()
+    }
+
+    /// The first failure's reason, for a summary line.
+    #[must_use]
+    pub fn first_failure(&self) -> Option<&StepResult> {
+        self.steps.iter().find(|s| s.status == StepStatus::Fail)
+    }
+}
+
+/// Whether this run should raise an alert.
+///
+/// Pure, and separate from the run itself, because "did it fail" and "should
+/// somebody be woken" are different questions. A journey that fails constantly in
+/// a known-degraded region and one that fails for the first time in production
+/// produce the same [`ProbeStatus`] and warrant different responses; keeping the
+/// decision here means a host can change it without touching a runner.
+#[must_use]
+pub fn should_alert(journey: &SyntheticJourney, result: &ProbeResult) -> bool {
+    journey.alert_on_failure && result.status.is_failure()
+}
+
+/// Attributes describing a run, for whatever the host reports it through.
+///
+/// Lives here rather than in the exporter so that a host reporting to something
+/// other than OTLP still gets the same facts under the same names.
+#[must_use]
+pub fn run_attributes(result: &ProbeResult) -> BTreeMap<String, String> {
+    let mut attrs = BTreeMap::new();
+    attrs.insert("mzizi.probe.journey".to_owned(), result.journey_id.clone());
+    attrs.insert(
+        "mzizi.probe.status".to_owned(),
+        result.status.as_str().to_owned(),
+    );
+    attrs.insert("mzizi.probe.region".to_owned(), result.region.clone());
+    attrs
+}
+
+// ── journey templates ──────────────────────────────────────────────────────
+
+/// The auth journey for a mini-app.
+///
+/// The credentials are the `.ts`'s, unchanged, and they are placeholders for a
+/// seeded probe account rather than anything that opens a real door. Kept
+/// identical so the two implementations exercise the same path; a host wanting
+/// real credentials substitutes them, and should not be reading them from here.
+#[must_use]
+pub fn auth_flow(mini_app: &str) -> SyntheticJourney {
+    SyntheticJourney {
+        id: format!("auth-{mini_app}"),
+        name: format!("{mini_app} Auth Flow"),
+        mini_app: Some(mini_app.to_owned()),
+        nodes: vec![6, 4, 7],
+        steps: vec![
+            step(
+                ProbeStepType::Navigate,
+                Some("/login"),
+                None,
+                "Navigate to login",
+            ),
+            step(
+                ProbeStepType::Input,
+                Some("[name=email]"),
+                Some("probe@nyuchi.com"),
+                "Enter email",
+            ),
+            step(
+                ProbeStepType::Input,
+                Some("[name=password]"),
+                Some("probe-pass"),
+                "Enter password",
+            ),
+            step(
+                ProbeStepType::Click,
+                Some("[type=submit]"),
+                None,
+                "Submit login",
+            ),
+            step(
+                ProbeStepType::Assert,
+                Some("[data-slot=nyuchi-header]"),
+                None,
+                "Verify header renders",
+            ),
+        ],
+        schedule: None,
+        regions: Vec::new(),
+        alert_on_failure: true,
+    }
+}
+
+/// The wallet-balance journey.
+#[must_use]
+pub fn wallet_flow() -> SyntheticJourney {
+    SyntheticJourney {
+        id: "wallet-balance".to_owned(),
+        name: "Wallet Balance Check".to_owned(),
+        mini_app: Some("wallet".to_owned()),
+        nodes: vec![6, 4, 3, 2],
+        steps: vec![
+            step(
+                ProbeStepType::Navigate,
+                Some("/wallet"),
+                None,
+                "Navigate to wallet",
+            ),
+            step(
+                ProbeStepType::Assert,
+                Some("[data-slot=wallet-page]"),
+                None,
+                "Verify wallet page renders",
+            ),
+            step(
+                ProbeStepType::Assert,
+                Some("[data-slot=kpi-card]"),
+                None,
+                "Verify balance card renders",
+            ),
+        ],
+        schedule: None,
+        regions: Vec::new(),
+        alert_on_failure: true,
+    }
+}
+
+fn step(
+    step_type: ProbeStepType,
+    target: Option<&str>,
+    value: Option<&str>,
+    description: &str,
+) -> ProbeStep {
+    ProbeStep {
+        step_type,
+        target: target.map(ToOwned::to_owned),
+        value: value.map(ToOwned::to_owned),
+        timeout_ms: None,
+        description: description.to_owned(),
+    }
+}

--- a/components/registry/n8-assurance/rtl-conformity-check.rs
+++ b/components/registry/n8-assurance/rtl-conformity-check.rs
@@ -1,0 +1,630 @@
+//! Mzizi N8 assurance — is this layout actually right-to-left correct?
+//!
+//! The Rust implementation of `rtl-conformity-check`. Five rules over what the
+//! host observed; the host walks the DOM and reads the computed styles, because
+//! that is the only part that needs a browser.
+//!
+//! # Six defects in the TypeScript, fixed here
+//!
+//! **1. The most serious rule did not affect the score.** `direction-attribute` —
+//! "`<html>` has no `dir`, so RTL locales fall back to LTR", the one finding that
+//! is about the whole page rather than one element — is pushed AFTER the element
+//! loop, and `passes` is only ever incremented inside it. So a page whose sole
+//! defect is that RTL does not work at all scores 100. [`audit`] counts it.
+//!
+//! **2. The icon rule only ran when the page was already RTL.** `docDir === "rtl"`
+//! gates it, so the check that finds icons needing mirroring never fires on the
+//! LTR build — which is the build almost everyone audits. And the finding is a
+//! property of the icon, not of the current render: a chevron with no mirroring
+//! hint will be wrong in RTL whether or not you are looking at RTL right now. The
+//! direction is still reported; it no longer decides whether to look.
+//!
+//! **3. Name matching was substring matching, in both directions.**
+//! `"research-icon".includes("search-icon")` is true, so `research-icon` inherited
+//! the non-mirroring exemption meant for the magnifying glass. And
+//! `isDirectionalIcon` matches `"back"`, so `background-icon` is reported as a
+//! directional icon needing mirroring. Both are matched on hyphen-separated
+//! segments here.
+//!
+//! **4. The bidi detector missed most real Arabic and Hebrew.** The range list
+//! covers the base blocks and stops, so Arabic Supplement (U+0750-U+077F), Arabic
+//! Extended-A (U+08A0-U+08FF) and — the big one — the Presentation Forms
+//! (U+FB1D-U+FDFF, U+FE70-U+FEFF) all read as non-bidi. Presentation forms are
+//! where a great deal of real-world Arabic arrives, particularly out of PDFs and
+//! older systems, so the rule passed exactly the content most likely to need it.
+//!
+//! **5. The selector broke on an id that is not an identifier.** `#${el.id}` raw,
+//! same as `mzizi-a11y-audit`, and the selector's only job is to find the element
+//! again.
+//!
+//! **6. The node guess can only answer 2, 3 or 6.** Same heuristic as
+//! `mzizi-a11y-audit`, same consequence: an N7 shell component is labelled N6 and
+//! routed to the wrong owner. The registry wins; the heuristic is the fallback.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+/// The direction a document declares.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Direction {
+    /// Left to right.
+    #[default]
+    Ltr,
+    /// Right to left.
+    Rtl,
+    /// Per-element, decided by the browser.
+    Auto,
+}
+
+impl Direction {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ltr => "ltr",
+            Self::Rtl => "rtl",
+            Self::Auto => "auto",
+        }
+    }
+
+    /// Parse a `dir` attribute value.
+    ///
+    /// [`None`] means the attribute was absent, which is what
+    /// [`RtlRule::DirectionAttribute`] is about — distinct from a `dir` that says
+    /// `ltr`, which is a deliberate answer.
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "ltr" => Some(Self::Ltr),
+            "rtl" => Some(Self::Rtl),
+            "auto" => Some(Self::Auto),
+            _ => None,
+        }
+    }
+}
+
+/// How much an RTL violation matters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RtlLevel {
+    /// Advisory.
+    Minor,
+    /// Wrong for some content.
+    Moderate,
+    /// Wrong for a whole locale.
+    Serious,
+    /// Unusable.
+    Critical,
+}
+
+impl RtlLevel {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Critical => "critical",
+            Self::Serious => "serious",
+            Self::Moderate => "moderate",
+            Self::Minor => "minor",
+        }
+    }
+}
+
+/// Which rule produced a finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RtlRule {
+    /// A physical CSS property where a logical one belongs.
+    LogicalProperties,
+    /// Bidi text with no `lang` or `dir`.
+    BidiText,
+    /// A directional icon with no mirroring hint.
+    IconMirroring,
+    /// `text-align: left` or `right`.
+    TextAlignment,
+    /// `<html>` carries no `dir`.
+    DirectionAttribute,
+}
+
+impl RtlRule {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LogicalProperties => "logical-properties",
+            Self::BidiText => "bidi-text",
+            Self::IconMirroring => "icon-mirroring",
+            Self::TextAlignment => "text-alignment",
+            Self::DirectionAttribute => "direction-attribute",
+        }
+    }
+
+    /// Every rule.
+    ///
+    /// One list. The `.ts` writes the rule names twice — once in the type union
+    /// and once in the runtime default array — so adding a rule to one and not
+    /// the other is a silently disabled rule.
+    #[must_use]
+    pub fn all() -> BTreeSet<Self> {
+        [
+            Self::LogicalProperties,
+            Self::BidiText,
+            Self::IconMirroring,
+            Self::TextAlignment,
+            Self::DirectionAttribute,
+        ]
+        .into_iter()
+        .collect()
+    }
+}
+
+/// The physical CSS properties that have logical counterparts.
+pub const PHYSICAL_PROPERTIES: [&str; 12] = [
+    "margin-left",
+    "margin-right",
+    "padding-left",
+    "padding-right",
+    "left",
+    "right",
+    "border-left",
+    "border-right",
+    "border-top-left-radius",
+    "border-top-right-radius",
+    "border-bottom-left-radius",
+    "border-bottom-right-radius",
+];
+
+/// Icon names that must NOT mirror in RTL.
+pub const NON_MIRRORING_ICONS: [&str; 15] = [
+    "search-icon",
+    "play-icon",
+    "pause-icon",
+    "volume-icon",
+    "mute-icon",
+    "clock-icon",
+    "calendar-icon",
+    "check-icon",
+    "x-icon",
+    "heart-icon",
+    "star-icon",
+    "info-icon",
+    "warning-icon",
+    "error-icon",
+    "success-icon",
+];
+
+/// Name fragments that mark an icon as directional.
+pub const DIRECTIONAL_FRAGMENTS: [&str; 11] = [
+    "arrow", "chevron", "caret", "back", "forward", "next", "prev", "undo", "redo", "reply", "send",
+];
+
+/// Split a name into hyphen- and underscore-separated segments, lowercased.
+///
+/// Segment matching, not substring matching. `"research-icon".includes("search")`
+/// is true and `"background-icon".includes("back")` is true, which is how the
+/// `.ts` exempts a research icon from mirroring and demands that a background
+/// image be mirrored.
+#[must_use]
+pub fn segments(name: &str) -> Vec<String> {
+    name.split(['-', '_', ' ', '.', '/'])
+        .filter(|s| !s.is_empty())
+        .map(str::to_ascii_lowercase)
+        .collect()
+}
+
+/// Whether this icon is on the never-mirror list.
+///
+/// Compared segment-wise: `search-icon` exempts `search-icon` and `icon-search`,
+/// and does not exempt `research-icon`.
+#[must_use]
+pub fn is_non_mirroring(name: &str, non_mirroring: &BTreeSet<String>) -> bool {
+    let parts: BTreeSet<String> = segments(name).into_iter().collect();
+    non_mirroring
+        .iter()
+        .any(|entry| segments(entry).iter().all(|seg| parts.contains(seg)))
+}
+
+/// Whether this icon points somewhere, and so may need mirroring.
+#[must_use]
+pub fn is_directional(name: &str) -> bool {
+    let parts = segments(name);
+    DIRECTIONAL_FRAGMENTS
+        .iter()
+        .any(|fragment| parts.iter().any(|seg| seg == fragment))
+}
+
+/// Whether a string contains characters from a right-to-left script.
+///
+/// Covers what the `.ts` covers PLUS Arabic Supplement, Arabic Extended-A and the
+/// Presentation Forms — the blocks a great deal of real-world Arabic and Hebrew
+/// actually arrives in, and which the `.ts` reads as non-bidi.
+#[must_use]
+pub fn has_bidi_chars(text: &str) -> bool {
+    text.chars().any(|c| {
+        matches!(c as u32,
+            0x0590..=0x05FF   // Hebrew
+            | 0x0600..=0x06FF // Arabic
+            | 0x0700..=0x074F // Syriac
+            | 0x0750..=0x077F // Arabic Supplement — missing from the .ts
+            | 0x0780..=0x07BF // Thaana
+            | 0x07C0..=0x07FF // NKo
+            | 0x0800..=0x083F // Samaritan
+            | 0x0840..=0x085F // Mandaic
+            | 0x08A0..=0x08FF // Arabic Extended-A — missing from the .ts
+            | 0xFB1D..=0xFB4F // Hebrew Presentation Forms — missing
+            | 0xFB50..=0xFDFF // Arabic Presentation Forms-A — missing
+            | 0xFE70..=0xFEFF // Arabic Presentation Forms-B — missing
+        )
+    })
+}
+
+/// One element as the host observed it.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ObservedNode {
+    /// Uppercase tag name.
+    pub tag_name: String,
+    /// The `id`.
+    pub id: Option<String>,
+    /// The first class.
+    pub first_class: Option<String>,
+    /// The `data-slot` value.
+    pub data_slot: Option<String>,
+    /// The `data-portal` backlink.
+    pub data_portal: Option<String>,
+    /// The `aria-label`.
+    pub aria_label: Option<String>,
+    /// The `lang` attribute.
+    pub lang: Option<String>,
+    /// The `dir` attribute.
+    pub dir: Option<String>,
+    /// Rendered text.
+    pub text: Option<String>,
+    /// Inline style declarations the host read, property to value.
+    pub inline_styles: BTreeMap<String, String>,
+    /// The `data-rtl-mirror` marker.
+    pub rtl_mirror_hint: Option<String>,
+}
+
+impl ObservedNode {
+    /// The name this element's icon goes by.
+    #[must_use]
+    pub fn icon_name(&self) -> String {
+        self.data_slot
+            .clone()
+            .or_else(|| self.aria_label.clone())
+            .unwrap_or_default()
+    }
+
+    /// Whether this element is an icon.
+    #[must_use]
+    pub fn is_icon(&self) -> bool {
+        self.data_slot.as_deref() == Some("icon") || self.tag_name.eq_ignore_ascii_case("svg")
+    }
+
+    /// Whether bidi text here would need a `lang` or `dir`.
+    #[must_use]
+    pub fn carries_prose(&self) -> bool {
+        ["P", "SPAN", "DIV"]
+            .iter()
+            .any(|tag| self.tag_name.eq_ignore_ascii_case(tag))
+    }
+}
+
+/// One finding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RtlViolation {
+    /// Which rule.
+    pub rule: RtlRule,
+    /// How much it matters.
+    pub level: RtlLevel,
+    /// What is wrong.
+    pub message: String,
+    /// The element's tag.
+    pub element: String,
+    /// A selector that finds it again.
+    pub selector: String,
+    /// Which helix node, when known.
+    pub node: Option<u32>,
+    /// The `data-slot` value.
+    pub component_name: Option<String>,
+    /// Where the documentation is.
+    pub portal_url: Option<String>,
+    /// How to fix it.
+    pub fix: String,
+}
+
+/// What a page scored.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RtlAuditResult {
+    /// The URL audited.
+    pub url: String,
+    /// What `<html dir>` said, when it said anything.
+    pub direction: Option<Direction>,
+    /// How many elements were observed.
+    pub total_elements: usize,
+    /// Every finding.
+    pub violations: Vec<RtlViolation>,
+    /// How many checks passed.
+    pub passes: usize,
+    /// Percentage passing, 0-100.
+    pub score: u32,
+}
+
+/// What to check.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RtlConfig {
+    /// Which rules to run. [`None`] means all; an empty set means none.
+    pub rules: Option<BTreeSet<RtlRule>>,
+    /// Icons that must never mirror.
+    pub non_mirroring_icons: BTreeSet<String>,
+}
+
+impl Default for RtlConfig {
+    fn default() -> Self {
+        Self {
+            rules: None,
+            non_mirroring_icons: NON_MIRRORING_ICONS
+                .iter()
+                .map(|s| (*s).to_owned())
+                .collect(),
+        }
+    }
+}
+
+impl RtlConfig {
+    /// Whether a rule is enabled.
+    #[must_use]
+    pub fn runs(&self, rule: RtlRule) -> bool {
+        self.rules.as_ref().is_none_or(|set| set.contains(&rule))
+    }
+}
+
+/// Whether a string is usable bare after `#` in a selector.
+fn is_plain_ident(value: &str) -> bool {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(first) if first.is_ascii_alphabetic() || first == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+fn escape_attr(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// A selector that finds this element again.
+#[must_use]
+pub fn css_selector(node: &ObservedNode) -> String {
+    if let Some(id) = node.id.as_deref().filter(|s| !s.is_empty()) {
+        return if is_plain_ident(id) {
+            format!("#{id}")
+        } else {
+            format!("[id=\"{}\"]", escape_attr(id))
+        };
+    }
+    if let Some(slot) = node.data_slot.as_deref().filter(|s| !s.is_empty()) {
+        return format!("[data-slot=\"{}\"]", escape_attr(slot));
+    }
+    let tag = node.tag_name.to_ascii_lowercase();
+    match node.first_class.as_deref().filter(|s| !s.is_empty()) {
+        Some(class) if is_plain_ident(class) => format!("{tag}.{class}"),
+        Some(class) => format!("{tag}[class~=\"{}\"]", escape_attr(class)),
+        None => tag,
+    }
+}
+
+/// The `.ts`'s slot heuristic. Can only answer 2, 3 or 6 — prefer [`resolve_node`].
+#[must_use]
+pub fn guess_node_from_slot(slot: &str) -> Option<u32> {
+    if slot.is_empty() {
+        return None;
+    }
+    if slot.starts_with("nyuchi-") && !slot.contains("page") {
+        return Some(3);
+    }
+    if slot.contains("page") || slot.contains("layout") {
+        return Some(6);
+    }
+    Some(2)
+}
+
+/// Which node owns the component in this slot. The registry wins.
+#[must_use]
+pub fn resolve_node(slot: Option<&str>, registry: &BTreeMap<String, u32>) -> Option<u32> {
+    let slot = slot?;
+    registry
+        .get(slot)
+        .copied()
+        .or_else(|| guess_node_from_slot(slot))
+}
+
+fn violation(
+    node: &ObservedNode,
+    helix_node: Option<u32>,
+    rule: RtlRule,
+    level: RtlLevel,
+    message: String,
+    fix: String,
+) -> RtlViolation {
+    RtlViolation {
+        rule,
+        level,
+        message,
+        element: node.tag_name.clone(),
+        selector: css_selector(node),
+        node: helix_node,
+        component_name: node.data_slot.clone().filter(|s| !s.is_empty()),
+        portal_url: node.data_portal.clone().filter(|s| !s.is_empty()),
+        fix,
+    }
+}
+
+/// Check one element against every enabled rule.
+///
+/// Returns every physical property found, not the first — matching the `.ts`,
+/// which is right: twelve wrong properties on one element are twelve edits.
+#[must_use]
+pub fn check_node(
+    node: &ObservedNode,
+    config: &RtlConfig,
+    registry: &BTreeMap<String, u32>,
+) -> Vec<RtlViolation> {
+    let mut found = Vec::new();
+    let helix_node = resolve_node(node.data_slot.as_deref(), registry);
+
+    if config.runs(RtlRule::LogicalProperties) {
+        for property in PHYSICAL_PROPERTIES {
+            if node
+                .inline_styles
+                .get(property)
+                .is_some_and(|v| !v.trim().is_empty())
+            {
+                found.push(violation(
+                    node,
+                    helix_node,
+                    RtlRule::LogicalProperties,
+                    RtlLevel::Serious,
+                    format!(
+                        "Inline style uses physical \"{property}\" — use logical equivalent \
+                         (margin-inline-start, padding-inline-end, inset-inline-start, etc.)"
+                    ),
+                    format!("Replace {property} with its inline-/block- logical counterpart"),
+                ));
+            }
+        }
+    }
+
+    if config.runs(RtlRule::BidiText)
+        && node.carries_prose()
+        && node.lang.is_none()
+        && node.dir.is_none()
+        && node.text.as_deref().is_some_and(has_bidi_chars)
+    {
+        found.push(violation(
+            node,
+            helix_node,
+            RtlRule::BidiText,
+            RtlLevel::Moderate,
+            "Element contains bidi text but is missing lang or dir attribute".to_owned(),
+            "Add lang=\"ar\" (or appropriate) or dir=\"auto\" so the browser can render bidi \
+             correctly"
+                .to_owned(),
+        ));
+    }
+
+    // Evaluated whatever the document direction is. The .ts gates this on
+    // `docDir === "rtl"`, so it never fires on the LTR build almost everyone
+    // audits — and whether a chevron has a mirroring hint is a property of the
+    // icon, not of the render you happen to be looking at.
+    if config.runs(RtlRule::IconMirroring) && node.is_icon() {
+        let name = node.icon_name();
+        let has_hint = node.rtl_mirror_hint.is_some()
+            || node
+                .inline_styles
+                .get("transform")
+                .is_some_and(|v| !v.trim().is_empty());
+        if !has_hint
+            && is_directional(&name)
+            && !is_non_mirroring(&name, &config.non_mirroring_icons)
+        {
+            found.push(violation(
+                node,
+                helix_node,
+                RtlRule::IconMirroring,
+                RtlLevel::Minor,
+                format!("Directional icon \"{name}\" may need mirroring in RTL contexts"),
+                "Add data-rtl-mirror=\"true\" or apply CSS [dir=rtl] & { transform: scaleX(-1) }"
+                    .to_owned(),
+            ));
+        }
+    }
+
+    if config.runs(RtlRule::TextAlignment)
+        && let Some(align) = node.inline_styles.get("text-align")
+        && matches!(align.trim(), "left" | "right")
+    {
+        let align = align.trim();
+        let logical = if align == "left" { "start" } else { "end" };
+        found.push(violation(
+            node,
+            helix_node,
+            RtlRule::TextAlignment,
+            RtlLevel::Moderate,
+            format!(
+                "text-align: {align} is physical — use \"start\" or \"end\" for RTL-aware alignment"
+            ),
+            format!("Replace text-align: {align} with text-align: {logical}"),
+        ));
+    }
+
+    found
+}
+
+/// Audit a page.
+///
+/// `document_dir` is what `<html dir>` said, or [`None`] when it said nothing —
+/// which is itself the [`RtlRule::DirectionAttribute`] finding.
+///
+/// The document-level rule COUNTS toward the score. In the `.ts` it is pushed
+/// after the element loop and `passes` only ever moves inside it, so a page whose
+/// sole defect is that RTL does not work at all scored 100.
+#[must_use]
+pub fn audit(
+    url: impl Into<String>,
+    document_dir: Option<Direction>,
+    nodes: &[ObservedNode],
+    config: &RtlConfig,
+    registry: &BTreeMap<String, u32>,
+) -> RtlAuditResult {
+    let mut violations = Vec::new();
+    let mut passes = 0usize;
+    // The document-level rule is one check in its own right, so the denominator
+    // is elements plus one whenever it runs.
+    let mut checks = nodes.len();
+
+    for node in nodes {
+        let found = check_node(node, config, registry);
+        if found.is_empty() {
+            passes += 1;
+        }
+        violations.extend(found);
+    }
+
+    if config.runs(RtlRule::DirectionAttribute) {
+        checks += 1;
+        if document_dir.is_none() {
+            violations.push(RtlViolation {
+                rule: RtlRule::DirectionAttribute,
+                level: RtlLevel::Serious,
+                message: "<html> element has no dir attribute — RTL locales will fall back to LTR"
+                    .to_owned(),
+                element: "HTML".to_owned(),
+                selector: "html".to_owned(),
+                node: None,
+                component_name: None,
+                portal_url: None,
+                fix: "Add dir=\"ltr\" or dir=\"rtl\" (or a direction provider) on <html>"
+                    .to_owned(),
+            });
+        } else {
+            passes += 1;
+        }
+    }
+
+    RtlAuditResult {
+        url: url.into(),
+        direction: document_dir,
+        total_elements: nodes.len(),
+        violations,
+        passes,
+        score: if checks == 0 {
+            100
+        } else {
+            ((passes as f64 / checks as f64) * 100.0).round() as u32
+        },
+    }
+}
+
+/// The worst level present, for a single go/no-go answer.
+#[must_use]
+pub fn worst_level(violations: &[RtlViolation]) -> Option<RtlLevel> {
+    violations.iter().map(|v| v.level).max()
+}

--- a/components/registry/n9-fundi/nyuchi-fundi-learning.rs
+++ b/components/registry/n9-fundi/nyuchi-fundi-learning.rs
@@ -1,0 +1,338 @@
+//! Mzizi N9 fundi — learning from healing outcomes.
+//!
+//! The Rust implementation of `nyuchi-fundi-learning`: what fundi did, whether it
+//! was right, and what that suggests about the next occurrence.
+//!
+//! # What this owns
+//!
+//! Aggregation and the severity suggestion. Not persistence — the `.ts` carries a
+//! comment saying production stores outcomes in `fundi_healing_log` and computes
+//! stats in SQL, which remains true and is the host's, because it is a database.
+//!
+//! # Two defects in the TypeScript, fixed here
+//!
+//! **1. `suggestSeverity` could LOWER the severity of a repeatedly recurring
+//! defect.** The `.ts` returns `"high"` whenever something has recurred more than
+//! twice — so a `critical` issue that keeps coming back is suggested as `high`,
+//! which is exactly backwards. Recurrence is evidence that the first assessment
+//! was too generous, never too harsh. [`suggest_severity`] escalates and never
+//! de-escalates.
+//!
+//! **2. History grew without bound.** `outcomes.push` with no cap, in a component
+//! whose whole purpose is to accumulate. The error tracker next door caps at 500;
+//! this one did not, so a long-lived Worker or session leaks until it dies.
+//!
+//! # One thing preserved rather than "fixed"
+//!
+//! `accuracy` is `fundiWasCorrect / total`, and `total` includes outcomes fundi
+//! never attempted — a human-fixed issue that fundi never claimed still drags the
+//! denominator down. Arguably it should be measured over attempts. That is a
+//! product decision about what the number means, not a porting one, and quietly
+//! changing a published metric is how a dashboard starts lying in the flattering
+//! direction. Preserved, with [`LearningStats::accuracy_over_attempts`] alongside
+//! so the other reading is available without redefining the first.
+
+use std::collections::BTreeMap;
+
+/// Who actually fixed it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolvedBy {
+    /// fundi's plan landed the fix.
+    Fundi,
+    /// A person fixed it.
+    Human,
+    /// Both contributed.
+    Both,
+}
+
+impl ResolvedBy {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Fundi => "fundi",
+            Self::Human => "human",
+            Self::Both => "both",
+        }
+    }
+
+    /// Whether fundi attempted this at all.
+    #[must_use]
+    pub const fn fundi_attempted(self) -> bool {
+        matches!(self, Self::Fundi | Self::Both)
+    }
+}
+
+/// Severity, ordered so escalation is a comparison rather than a lookup table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Severity {
+    /// Noise, or a well-handled edge.
+    Low,
+    /// Worth looking at.
+    Medium,
+    /// Degrades something users touch.
+    High,
+    /// A core guarantee broke.
+    Critical,
+}
+
+impl Severity {
+    /// The wire spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Critical => "critical",
+        }
+    }
+
+    /// Parse a wire spelling, defaulting to [`Severity::Medium`].
+    ///
+    /// Medium rather than Low, because an unrecognised severity is an unknown
+    /// risk and treating the unknown as harmless is how things get missed.
+    #[must_use]
+    pub fn from_str_or_medium(value: &str) -> Self {
+        match value {
+            "low" => Self::Low,
+            "high" => Self::High,
+            "critical" => Self::Critical,
+            _ => Self::Medium,
+        }
+    }
+}
+
+/// What happened to one issue.
+#[derive(Debug, Clone)]
+pub struct HealingOutcome {
+    /// The issue number.
+    pub issue_id: u64,
+    /// Which component.
+    pub component: String,
+    /// Which helix node.
+    pub node: u32,
+    /// What kind of failure.
+    pub error_type: String,
+    /// How bad it was judged.
+    pub severity: Severity,
+    /// What fundi proposed.
+    pub plan_actions: Vec<String>,
+    /// What actually fixed it.
+    pub actual_fix: String,
+    /// Whether fundi's diagnosis was right.
+    pub fundi_was_correct: bool,
+    /// How long it took to resolve.
+    pub time_to_resolve_minutes: f64,
+    /// Whether it came back.
+    pub recurred: bool,
+    /// Who fixed it.
+    pub resolved_by: ResolvedBy,
+    /// When it was recorded, milliseconds since the Unix epoch.
+    pub recorded_at_ms: f64,
+}
+
+/// A ranked count.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ranked {
+    /// The thing being counted.
+    pub name: String,
+    /// How many.
+    pub count: usize,
+}
+
+/// What the history says.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LearningStats {
+    /// How many outcomes are held.
+    pub total_issues: usize,
+    /// How many fundi resolved alone.
+    pub auto_fixed: usize,
+    /// How many it did not.
+    pub human_fixed: usize,
+    /// Correct diagnoses over ALL outcomes — the `.ts`'s definition.
+    pub accuracy: f64,
+    /// Correct diagnoses over the outcomes fundi actually attempted.
+    ///
+    /// The other reading of the same data, offered alongside rather than
+    /// replacing, so neither number has to be silently redefined.
+    pub accuracy_over_attempts: f64,
+    /// Mean minutes to resolve, rounded as the `.ts` does.
+    pub avg_time_to_resolve: f64,
+    /// The components failing most.
+    pub top_failing_components: Vec<Ranked>,
+    /// The error types occurring most.
+    pub top_error_types: Vec<Ranked>,
+    /// Fraction that came back.
+    pub recurrence_rate: f64,
+}
+
+impl LearningStats {
+    /// The empty case.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            total_issues: 0,
+            auto_fixed: 0,
+            human_fixed: 0,
+            accuracy: 0.0,
+            accuracy_over_attempts: 0.0,
+            avg_time_to_resolve: 0.0,
+            top_failing_components: Vec::new(),
+            top_error_types: Vec::new(),
+            recurrence_rate: 0.0,
+        }
+    }
+}
+
+/// Rank a tally, highest first, breaking ties by name.
+///
+/// The tie-break is not cosmetic. The `.ts` sorts a `Map` whose iteration order
+/// is insertion order, so two components with equal counts swap places depending
+/// on which failed first — and a "top failing components" list that reshuffles
+/// between refreshes is one nobody trusts.
+fn rank(counts: &BTreeMap<String, usize>, limit: usize) -> Vec<Ranked> {
+    let mut ranked: Vec<Ranked> = counts
+        .iter()
+        .map(|(name, &count)| Ranked {
+            name: name.clone(),
+            count,
+        })
+        .collect();
+    ranked.sort_by(|a, b| b.count.cmp(&a.count).then(a.name.cmp(&b.name)));
+    ranked.truncate(limit);
+    ranked
+}
+
+/// The accumulated history.
+#[derive(Debug, Clone)]
+pub struct LearningLog {
+    /// How many outcomes to retain. The `.ts` retains all of them, forever.
+    pub max_outcomes: usize,
+    outcomes: Vec<HealingOutcome>,
+}
+
+impl Default for LearningLog {
+    fn default() -> Self {
+        Self::new(1000)
+    }
+}
+
+impl LearningLog {
+    /// A log holding at most `max_outcomes`.
+    #[must_use]
+    pub fn new(max_outcomes: usize) -> Self {
+        Self {
+            max_outcomes,
+            outcomes: Vec::new(),
+        }
+    }
+
+    /// Record an outcome, dropping the oldest if that exceeds the cap.
+    pub fn record(&mut self, outcome: HealingOutcome) {
+        self.outcomes.push(outcome);
+        if self.outcomes.len() > self.max_outcomes {
+            self.outcomes.remove(0);
+        }
+    }
+
+    /// Every outcome held.
+    #[must_use]
+    pub fn outcomes(&self) -> &[HealingOutcome] {
+        &self.outcomes
+    }
+
+    /// Everything recorded for one component.
+    #[must_use]
+    pub fn component_history(&self, component: &str) -> Vec<&HealingOutcome> {
+        self.outcomes
+            .iter()
+            .filter(|o| o.component == component)
+            .collect()
+    }
+
+    /// Aggregate the history.
+    #[must_use]
+    pub fn stats(&self) -> LearningStats {
+        let total = self.outcomes.len();
+        if total == 0 {
+            return LearningStats::empty();
+        }
+
+        let auto_fixed = self
+            .outcomes
+            .iter()
+            .filter(|o| o.resolved_by == ResolvedBy::Fundi)
+            .count();
+        let correct = self.outcomes.iter().filter(|o| o.fundi_was_correct).count();
+        let attempts = self
+            .outcomes
+            .iter()
+            .filter(|o| o.resolved_by.fundi_attempted())
+            .count();
+        let correct_attempts = self
+            .outcomes
+            .iter()
+            .filter(|o| o.fundi_was_correct && o.resolved_by.fundi_attempted())
+            .count();
+        let recurred = self.outcomes.iter().filter(|o| o.recurred).count();
+        let total_f = total as f64;
+
+        let mut components: BTreeMap<String, usize> = BTreeMap::new();
+        let mut error_types: BTreeMap<String, usize> = BTreeMap::new();
+        for outcome in &self.outcomes {
+            *components.entry(outcome.component.clone()).or_insert(0) += 1;
+            *error_types.entry(outcome.error_type.clone()).or_insert(0) += 1;
+        }
+
+        LearningStats {
+            total_issues: total,
+            auto_fixed,
+            human_fixed: total - auto_fixed,
+            accuracy: correct as f64 / total_f,
+            accuracy_over_attempts: if attempts == 0 {
+                0.0
+            } else {
+                correct_attempts as f64 / attempts as f64
+            },
+            avg_time_to_resolve: (self
+                .outcomes
+                .iter()
+                .map(|o| o.time_to_resolve_minutes)
+                .sum::<f64>()
+                / total_f)
+                .round(),
+            top_failing_components: rank(&components, 10),
+            top_error_types: rank(&error_types, 5),
+            recurrence_rate: recurred as f64 / total_f,
+        }
+    }
+
+    /// What severity the next occurrence of this defect probably deserves.
+    ///
+    /// Escalates and never de-escalates. The `.ts` returns `"high"` outright when
+    /// something has recurred more than twice, which *lowers* a `critical` defect
+    /// that keeps coming back — precisely inverted, since recurrence is evidence
+    /// the first assessment was too generous.
+    ///
+    /// With no history the answer is [`Severity::Medium`], as in the `.ts`.
+    #[must_use]
+    pub fn suggest_severity(&self, component: &str, error_type: &str) -> Severity {
+        let history: Vec<&HealingOutcome> = self
+            .outcomes
+            .iter()
+            .filter(|o| o.component == component && o.error_type == error_type)
+            .collect();
+
+        let Some(last) = history.last() else {
+            return Severity::Medium;
+        };
+
+        let recurrences = history.iter().filter(|o| o.recurred).count();
+        if recurrences > 2 {
+            // Escalate from where it already was, rather than to a fixed rung.
+            return last.severity.max(Severity::High);
+        }
+        last.severity
+    }
+}

--- a/components/registry/n9-fundi/nyuchi-fundi-reporter.rs
+++ b/components/registry/n9-fundi/nyuchi-fundi-reporter.rs
@@ -1,0 +1,326 @@
+//! Mzizi N9 fundi — turning an assurance signal into a filed defect.
+//!
+//! The Rust implementation of `nyuchi-fundi-reporter`. This is the **healing**
+//! exit from N8: a named defect a human can merge a fix for. The observation exit
+//! is `mzizi-otel`, and they are not alternatives — see `docs/n8-telemetry.md`.
+//!
+//! # What this owns
+//!
+//! The cooldown decision, the labels, the issue title and body. Not the HTTP
+//! POST: the host files the issue, as everywhere in the core.
+//!
+//! # Three defects in the TypeScript, fixed here
+//!
+//! **1. A failed report still started the cooldown.** The `.ts` records
+//! `cooldowns.set(component, Date.now())` *before* the `fetch`, so a GitHub
+//! outage — or a 401, or a rate limit — suppressed every retry for the next five
+//! minutes. The signal was consumed without ever producing an issue. Here the
+//! cooldown is recorded by [`CooldownLog::record_filed`], which a host calls only
+//! after the file succeeds.
+//!
+//! **2. The cooldown key was the component alone.** A component with a render bug
+//! and a network bug reported one and silently dropped the other for five
+//! minutes, because they share a key. The key is component **and** error type, so
+//! distinct defects on one component are distinct reports.
+//!
+//! **3. The issue body interpolated untrusted text into Markdown.** Every field
+//! goes into a table cell, a code span or a link, and every field ultimately
+//! comes from a runtime error message — which is attacker-influenced whenever any
+//! user input reaches an exception. A backtick in `component` closes the code
+//! span; a `|` in any value forges table columns; a newline plus `---` forges the
+//! provenance footer this very file appends, so an injected report can claim to
+//! have been filed by something it was not. [`escape_markdown_cell`] and
+//! [`escape_code_span`] close that.
+//!
+//! GitHub sanitises rendered HTML, so this is content forgery rather than script
+//! execution — but a fabricated "Filed by" line in an automated issue is exactly
+//! the sort of thing a triager trusts without checking.
+
+use std::collections::BTreeMap;
+
+/// How bad the reported failure is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReportSeverity {
+    /// Noise, or a well-handled edge.
+    Low,
+    /// Worth looking at.
+    Medium,
+    /// Degrades something users touch.
+    High,
+    /// A core guarantee broke.
+    Critical,
+}
+
+impl ReportSeverity {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Critical => "critical",
+        }
+    }
+}
+
+/// What kind of failure this is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorType {
+    /// A component failed to render.
+    Render,
+    /// A request failed.
+    Network,
+    /// Data was missing or malformed.
+    Data,
+    /// An authentication or authorisation failure.
+    Auth,
+    /// A chain interaction failed.
+    Chain,
+    /// A cryptographic operation failed.
+    Crypto,
+    /// An operation exceeded its deadline.
+    Timeout,
+    /// An accessibility conformance failure.
+    A11y,
+    /// A performance budget was exceeded.
+    Perf,
+    /// A conformity check failed.
+    Conformity,
+    /// A service-level objective was breached.
+    Slo,
+}
+
+impl ErrorType {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Render => "render",
+            Self::Network => "network",
+            Self::Data => "data",
+            Self::Auth => "auth",
+            Self::Chain => "chain",
+            Self::Crypto => "crypto",
+            Self::Timeout => "timeout",
+            Self::A11y => "a11y",
+            Self::Perf => "perf",
+            Self::Conformity => "conformity",
+            Self::Slo => "slo",
+        }
+    }
+}
+
+/// A failure worth filing.
+#[derive(Debug, Clone)]
+pub struct FundiReport {
+    /// Which component failed.
+    pub component: String,
+    /// Which helix node it belongs to.
+    pub node: u32,
+    /// How bad.
+    pub severity: ReportSeverity,
+    /// What kind.
+    pub error_type: ErrorType,
+    /// Which N8 component observed it.
+    pub source: String,
+    /// One-line summary.
+    pub title: String,
+    /// The detail.
+    pub description: String,
+    /// Where to see the component.
+    pub portal_url: Option<String>,
+    /// Structured diagnostic, already serialised by the host.
+    pub diagnostic: Option<String>,
+    /// Mini-apps implicated.
+    pub affected_mini_apps: Vec<String>,
+    /// Components that may be affected.
+    pub blast_radius: Vec<String>,
+}
+
+impl FundiReport {
+    /// The cooldown key: component AND error type.
+    ///
+    /// Keying on the component alone — which the `.ts` does — means a render bug
+    /// and a network bug on one component share a bucket, so the second is
+    /// silently dropped for the cooldown window.
+    #[must_use]
+    pub fn cooldown_key(&self) -> String {
+        format!("{}:{}", self.component, self.error_type.as_str())
+    }
+}
+
+/// Escape a value destined for a Markdown table cell.
+///
+/// A `|` forges columns, a newline escapes the row entirely, and a leading `-`
+/// on its own line can start a list or a rule. Backslashes go first, or the
+/// escapes this adds would themselves be escapable.
+#[must_use]
+pub fn escape_markdown_cell(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '|' => out.push_str("\\|"),
+            // A cell cannot contain a line break; a space preserves readability
+            // where a dropped character would silently join two words.
+            '\n' | '\r' => out.push(' '),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// Escape a value destined for a backtick code span.
+///
+/// A backtick closes the span and lets everything after it render as Markdown,
+/// which is how a component name becomes a heading. Replaced rather than
+/// backslash-escaped, because a backslash does not escape a backtick inside a
+/// code span — only widening the fence does, and that cannot be done per value.
+#[must_use]
+pub fn escape_code_span(value: &str) -> String {
+    value.replace('`', "'").replace(['\n', '\r'], " ")
+}
+
+/// The labels an issue carries.
+#[must_use]
+pub fn labels_for(report: &FundiReport) -> Vec<String> {
+    vec![
+        format!("fundi:severity/{}", report.severity.as_str()),
+        format!("fundi:node/{}", report.node),
+        format!("fundi:type/{}", report.error_type.as_str()),
+        format!("fundi:source/{}", escape_code_span(&report.source)),
+    ]
+}
+
+/// The issue title.
+#[must_use]
+pub fn issue_title(report: &FundiReport) -> String {
+    format!(
+        "[{}] {}",
+        escape_code_span(&report.component),
+        report.title.replace(['\n', '\r'], " ")
+    )
+}
+
+/// The issue body, in Markdown.
+#[must_use]
+pub fn issue_body(report: &FundiReport) -> String {
+    let mut b = String::from("## Component Failure Report\n\n| Field | Value |\n|---|---|\n");
+    b.push_str(&format!(
+        "| Component | `{}` |\n",
+        escape_code_span(&report.component)
+    ));
+    b.push_str(&format!("| Node | {} |\n", report.node));
+    b.push_str(&format!("| Severity | {} |\n", report.severity.as_str()));
+    b.push_str(&format!(
+        "| Error Type | {} |\n",
+        report.error_type.as_str()
+    ));
+    b.push_str(&format!(
+        "| Source | {} |\n",
+        escape_markdown_cell(&report.source)
+    ));
+    if let Some(url) = &report.portal_url {
+        // Angle brackets are Markdown's own literal-URL form, so a `)` in the
+        // URL cannot terminate the link early.
+        b.push_str(&format!(
+            "| Portal | [View](<{}>) |\n",
+            url.replace(['<', '>', '\n', '\r'], "")
+        ));
+    }
+    b.push_str(&format!("\n### Description\n\n{}\n", report.description));
+    if !report.affected_mini_apps.is_empty() {
+        b.push_str(&format!(
+            "\n### Affected Mini-Apps\n\n{}\n",
+            report
+                .affected_mini_apps
+                .iter()
+                .map(|m| escape_markdown_cell(m))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if !report.blast_radius.is_empty() {
+        b.push_str(&format!(
+            "\n### Blast Radius\n\n{}\n",
+            report
+                .blast_radius
+                .iter()
+                .map(|c| format!("`{}`", escape_code_span(c)))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if let Some(diagnostic) = &report.diagnostic {
+        // A four-backtick fence, so a three-backtick fence inside the diagnostic
+        // cannot close it and spill the rest into prose.
+        b.push_str(&format!(
+            "\n### Diagnostic\n\n````json\n{}\n````\n",
+            diagnostic.replace("````", "'''")
+        ));
+    }
+    b.push_str("\n---\n*Filed by nyuchi-fundi-reporter (the N8 assurance to N9 fundi bridge)*\n");
+    b
+}
+
+/// Why a report was not filed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotFiled {
+    /// An identical defect was filed recently.
+    InCooldown,
+}
+
+/// Per-defect cooldowns.
+///
+/// The host records a filing only once it has actually succeeded, which is the
+/// fix for the `.ts` consuming a signal it never delivered.
+#[derive(Debug, Clone, Default)]
+pub struct CooldownLog {
+    /// Seconds a defect stays suppressed after a successful filing.
+    pub cooldown_seconds: f64,
+    filed_at_ms: BTreeMap<String, f64>,
+}
+
+impl CooldownLog {
+    /// A log with the `.ts`'s default of five minutes.
+    #[must_use]
+    pub fn new(cooldown_seconds: f64) -> Self {
+        Self {
+            cooldown_seconds,
+            filed_at_ms: BTreeMap::new(),
+        }
+    }
+
+    /// Whether this report may be filed now.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NotFiled::InCooldown`] when an identical defect was filed inside
+    /// the window.
+    pub fn may_file(&self, report: &FundiReport, now_ms: f64) -> Result<(), NotFiled> {
+        match self.filed_at_ms.get(&report.cooldown_key()) {
+            Some(last) if now_ms - last < self.cooldown_seconds * 1000.0 => {
+                Err(NotFiled::InCooldown)
+            }
+            _ => Ok(()),
+        }
+    }
+
+    /// Record that this report WAS filed. Call only on success.
+    pub fn record_filed(&mut self, report: &FundiReport, now_ms: f64) {
+        self.filed_at_ms.insert(report.cooldown_key(), now_ms);
+    }
+
+    /// How many distinct defects are suppressed.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.filed_at_ms.len()
+    }
+
+    /// Whether anything is suppressed.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.filed_at_ms.is_empty()
+    }
+}

--- a/components/registry/n9-fundi/nyuchi-fundi.rs
+++ b/components/registry/n9-fundi/nyuchi-fundi.rs
@@ -1,0 +1,654 @@
+//! Mzizi N9 fundi — the healing decision engine.
+//!
+//! The Rust implementation of `nyuchi-fundi`. N8 assurance observes and finds
+//! problems; N9 receives those observations and decides what to do. Two rungs,
+//! one loop, and this is the hinge between them.
+//!
+//! # What this owns
+//!
+//! The decision: diagnostic in, plan out. Not the execution — a remediation
+//! action clears a cache, opens a circuit or pages somebody, all of which is I/O
+//! and all of which differs per host. [`plan_outcome`] folds the results the host
+//! reports back.
+//!
+//! # Six defects in the TypeScript, fixed here
+//!
+//! **1. "Requires human approval" did not stop anything.** `FundiProvider`
+//! defaults `autoHeal = true`, and the gate reads `if (plan.requiresHumanApproval
+//! && !autoHeal)` — so the flag meaning "a person must look at this" is overridden
+//! by a convenience flag that is on unless somebody turns it off. A systemic-outage
+//! plan disables non-critical features automatically while declaring that it should
+//! not. [`HealingPlan::approval`] is a state a host must clear, not a boolean it can
+//! out-vote, and [`HealingPlan::may_execute`] is the only thing that answers.
+//!
+//! **2. "Never auto-fix auth" was skipped exactly when it mattered most.** The
+//! `errorType === "auth"` branch sits inside the `else` that handles ISOLATED
+//! failures. A partial or systemic auth failure never reaches it — it gets
+//! `degrade-feature` and `reroute` instead. The one rule the file states as
+//! inviolable applied only to the narrowest case. Auth is checked first here,
+//! before the blast radius is consulted at all.
+//!
+//! **3. Chain and crypto failures had the same hole.** Same `else`, same
+//! consequence: a systemic chain failure is rerouted rather than falling back to
+//! the Web2 path.
+//!
+//! **4. Nothing handled "we could not determine the blast radius".** The union is
+//! `isolated | partial | systemic`, so an unknown radius has no representation and
+//! the `else` treats it as isolated — the calmest response, chosen when the least
+//! is known. `mzizi-chaos` now answers `unknown` when nothing was probed, and the
+//! two halves of one loop have to share a vocabulary. [`BlastRadius::Unknown`]
+//! requires approval and escalates.
+//!
+//! **5. The reroute target depended on probe ordering.** `healthyNodes[0]` takes
+//! whichever healthy probe happened to come back first, so two runs over the same
+//! set can reroute to different targets and neither is reproducible. Sorted by
+//! name.
+//!
+//! **6. The plan id was generated inside the engine**, from `Date.now()` plus six
+//! random base-36 characters. Better than the clock alone, and still an I/O
+//! decision made by a core that has neither a clock nor entropy. Host-supplied.
+//!
+//! # One thing recorded rather than changed
+//!
+//! `confidence` is set to 0.8, 0.6 or 0.7 by branch and **nothing reads it** — not
+//! the approval decision, not the executor, not the log. It is preserved because a
+//! host may well surface it, and named here as what it is: a number no code acts
+//! on. If it is to gate anything, that is a decision to make deliberately rather
+//! than by wiring up a value whose scale nobody has defined.
+
+use std::collections::BTreeMap;
+
+/// How far a failure reaches.
+///
+/// Mirrors `mzizi-chaos`'s [`BlastRadius`](../mzizi_chaos/enum.BlastRadius.html)
+/// including its `Unknown`, because the producer and the consumer of a diagnostic
+/// have to share one vocabulary. Mirrored rather than imported: a registry
+/// component must be installable on its own (CLAUDE.md §15.6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlastRadius {
+    /// Nothing else is down.
+    Isolated,
+    /// Some dependencies are down.
+    Partial,
+    /// Most or all are.
+    Systemic,
+    /// Nothing was probed, so nothing is known.
+    Unknown,
+}
+
+impl BlastRadius {
+    /// The wire spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Isolated => "isolated",
+            Self::Partial => "partial",
+            Self::Systemic => "systemic",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// What kind of failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorType {
+    /// A component failed to render.
+    Render,
+    /// A request failed.
+    Network,
+    /// Data was missing or malformed.
+    Data,
+    /// An authentication or authorisation failure.
+    Auth,
+    /// A chain interaction failed.
+    Chain,
+    /// A cryptographic operation failed.
+    Crypto,
+    /// An operation exceeded its deadline.
+    Timeout,
+}
+
+impl ErrorType {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Render => "render",
+            Self::Network => "network",
+            Self::Data => "data",
+            Self::Auth => "auth",
+            Self::Chain => "chain",
+            Self::Crypto => "crypto",
+            Self::Timeout => "timeout",
+        }
+    }
+
+    /// Whether fundi is forbidden from acting on this by itself.
+    ///
+    /// Auth, and only auth. The `.ts` states the rule — "never auto-fix auth" —
+    /// and then only reaches it on an isolated failure.
+    #[must_use]
+    pub const fn is_never_auto_fixed(self) -> bool {
+        matches!(self, Self::Auth)
+    }
+}
+
+/// How severe an escalation is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum EscalationSeverity {
+    /// Worth knowing.
+    Low,
+    /// Worth looking at.
+    Medium,
+    /// Worth waking somebody.
+    High,
+    /// Worth waking everybody.
+    Critical,
+}
+
+impl EscalationSeverity {
+    /// The wire spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Critical => "critical",
+        }
+    }
+}
+
+/// How far a feature is degraded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DegradeLevel {
+    /// Reduced.
+    Partial,
+    /// Static content only.
+    Static,
+    /// Off.
+    Disabled,
+}
+
+impl DegradeLevel {
+    /// The wire spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Partial => "partial",
+            Self::Static => "static",
+            Self::Disabled => "disabled",
+        }
+    }
+}
+
+/// What a cache clear covers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheScope {
+    /// This client.
+    Local,
+    /// The edge.
+    Edge,
+    /// Everything.
+    All,
+}
+
+impl CacheScope {
+    /// The wire spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Local => "local",
+            Self::Edge => "edge",
+            Self::All => "all",
+        }
+    }
+}
+
+/// One thing to do about a failure.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RemediationAction {
+    /// Stop calling a service for a while.
+    CircuitBreak {
+        /// Which service.
+        service: String,
+        /// For how long.
+        duration_ms: u32,
+    },
+    /// Move traffic from one path to another.
+    FallbackSwitch {
+        /// The failing path.
+        from: String,
+        /// The path to use instead.
+        to: String,
+    },
+    /// Throw a cache away.
+    CacheClear {
+        /// How much of it.
+        scope: CacheScope,
+    },
+    /// Send work to a different node.
+    Reroute {
+        /// Where it was going.
+        from_node: String,
+        /// Where it goes now.
+        to_node: String,
+    },
+    /// Try again, more slowly each time.
+    RetryWithBackoff {
+        /// Which service.
+        service: String,
+        /// How many attempts.
+        max_retries: u32,
+    },
+    /// Turn a feature down.
+    DegradeFeature {
+        /// Which feature.
+        feature: String,
+        /// How far.
+        level: DegradeLevel,
+    },
+    /// Ask for more or less of something.
+    ScaleRequest {
+        /// Which way.
+        up: bool,
+        /// What.
+        resource: String,
+    },
+    /// Tell a person.
+    Escalate {
+        /// How loudly.
+        severity: EscalationSeverity,
+        /// What to say.
+        message: String,
+    },
+}
+
+impl RemediationAction {
+    /// The action's `type` tag, matching the `.ts` discriminant.
+    #[must_use]
+    pub const fn type_str(&self) -> &'static str {
+        match self {
+            Self::CircuitBreak { .. } => "circuit-break",
+            Self::FallbackSwitch { .. } => "fallback-switch",
+            Self::CacheClear { .. } => "cache-clear",
+            Self::Reroute { .. } => "reroute",
+            Self::RetryWithBackoff { .. } => "retry-with-backoff",
+            Self::DegradeFeature { .. } => "degrade-feature",
+            Self::ScaleRequest { .. } => "scale-request",
+            Self::Escalate { .. } => "escalate",
+        }
+    }
+
+    /// Whether this action only informs, changing nothing about the system.
+    ///
+    /// Load-bearing for [`HealingPlan::may_execute`]: a plan awaiting approval may
+    /// still page somebody, because holding the page until a human notices defeats
+    /// the point of paging.
+    #[must_use]
+    pub const fn is_notification_only(&self) -> bool {
+        matches!(self, Self::Escalate { .. })
+    }
+}
+
+/// How a probe answered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeStatus {
+    /// Answered, and well.
+    Healthy,
+    /// Answered, badly.
+    Degraded,
+    /// Did not answer.
+    Error,
+    /// Did not answer in time.
+    Timeout,
+}
+
+impl ProbeStatus {
+    /// The wire spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Healthy => "healthy",
+            Self::Degraded => "degraded",
+            Self::Error => "error",
+            Self::Timeout => "timeout",
+        }
+    }
+}
+
+/// One dependency's answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProbeSummary {
+    /// What was probed.
+    pub target: String,
+    /// How it answered.
+    pub status: ProbeStatus,
+}
+
+/// What N8 observed.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiagnosticInput {
+    /// How far it reaches.
+    pub blast_radius: BlastRadius,
+    /// Which component failed.
+    pub failed_component: String,
+    /// Which helix node it belongs to. Uncapped.
+    pub failed_node: u32,
+    /// What kind of failure.
+    pub error_type: ErrorType,
+    /// How many times.
+    pub error_count: u32,
+    /// How long since the first one, in milliseconds.
+    pub time_since_first_error_ms: f64,
+    /// What the dependencies said.
+    pub probe_results: Vec<ProbeSummary>,
+}
+
+/// Whether a person has to look at this before it runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Approval {
+    /// fundi may act.
+    NotRequired,
+    /// A person must clear it first.
+    ///
+    /// This is a STATE, not advice. The `.ts` makes it a boolean that
+    /// `autoHeal` — default true — overrides, so a plan declaring that it needs a
+    /// human executed anyway.
+    Required,
+    /// A person cleared it.
+    Granted,
+}
+
+/// The number of errors, within the window, that trips a circuit break.
+pub const REPEAT_ERROR_THRESHOLD: u32 = 3;
+/// The window that count is measured over, in milliseconds.
+pub const REPEAT_ERROR_WINDOW_MS: f64 = 60_000.0;
+
+/// What fundi decided to do.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HealingPlan {
+    /// Supplied by the host, not derived from a clock. See defect 6.
+    pub id: String,
+    /// When, milliseconds since the Unix epoch.
+    pub at_ms: f64,
+    /// What it was reacting to.
+    pub diagnostic: DiagnosticInput,
+    /// What to do, in order.
+    pub actions: Vec<RemediationAction>,
+    /// A number nothing acts on. See the module docs.
+    pub confidence: f64,
+    /// Why, in words.
+    pub reasoning: String,
+    /// Whether a person has to clear it.
+    pub approval: Approval,
+}
+
+impl HealingPlan {
+    /// The actions a host may run right now.
+    ///
+    /// A plan awaiting approval yields only its notifications — escalating is how
+    /// the human who must approve it finds out there is something to approve, so
+    /// withholding that would deadlock the gate it enforces. Everything that
+    /// changes the system waits.
+    #[must_use]
+    pub fn may_execute(&self) -> Vec<&RemediationAction> {
+        match self.approval {
+            Approval::NotRequired | Approval::Granted => self.actions.iter().collect(),
+            Approval::Required => self
+                .actions
+                .iter()
+                .filter(|a| a.is_notification_only())
+                .collect(),
+        }
+    }
+
+    /// Whether anything is being held back.
+    #[must_use]
+    pub fn is_held(&self) -> bool {
+        self.approval == Approval::Required
+            && self.actions.iter().any(|a| !a.is_notification_only())
+    }
+
+    /// Record that a person cleared it.
+    pub fn grant_approval(&mut self) {
+        if self.approval == Approval::Required {
+            self.approval = Approval::Granted;
+        }
+    }
+}
+
+/// Decide what to do about a failure.
+///
+/// The order is deliberate and differs from the `.ts`: the never-auto-fix rule is
+/// consulted BEFORE the blast radius, because in the `.ts` the auth branch lives
+/// inside the isolated-failure `else` and is therefore skipped for exactly the
+/// partial and systemic auth failures it most needs to catch.
+#[must_use]
+pub fn create_healing_plan(
+    id: impl Into<String>,
+    input: DiagnosticInput,
+    at_ms: f64,
+) -> HealingPlan {
+    let mut actions = Vec::new();
+    let mut reasoning = String::new();
+    let mut confidence = 0.8;
+    let mut approval = Approval::NotRequired;
+
+    // Rule 1: repeated failures trip the breaker, whatever else is true.
+    if input.error_count > REPEAT_ERROR_THRESHOLD
+        && input.time_since_first_error_ms < REPEAT_ERROR_WINDOW_MS
+    {
+        actions.push(RemediationAction::CircuitBreak {
+            service: input.failed_component.clone(),
+            duration_ms: 30_000,
+        });
+        reasoning.push_str("Repeated failures detected — circuit-breaking to prevent cascade. ");
+    }
+
+    // Rule 2: auth is never fixed automatically, at ANY blast radius.
+    if input.error_type.is_never_auto_fixed() {
+        actions.push(RemediationAction::Escalate {
+            severity: match input.blast_radius {
+                BlastRadius::Systemic => EscalationSeverity::Critical,
+                _ => EscalationSeverity::High,
+            },
+            message: format!(
+                "Auth failure in {} on N{} ({} blast radius)",
+                input.failed_component,
+                input.failed_node,
+                input.blast_radius.as_str()
+            ),
+        });
+        reasoning.push_str("Auth error — escalating (never auto-fix auth). ");
+        return HealingPlan {
+            id: id.into(),
+            at_ms,
+            diagnostic: input,
+            actions,
+            confidence,
+            reasoning: reasoning.trim().to_owned(),
+            approval: Approval::Required,
+        };
+    }
+
+    // Rule 3: chain and crypto fall back to the Web2 path, at any blast radius.
+    // The .ts reaches this only on an isolated failure.
+    if matches!(input.error_type, ErrorType::Chain | ErrorType::Crypto) {
+        actions.push(RemediationAction::FallbackSwitch {
+            from: "web3".to_owned(),
+            to: "web2".to_owned(),
+        });
+        actions.push(RemediationAction::DegradeFeature {
+            feature: input.failed_component.clone(),
+            level: DegradeLevel::Partial,
+        });
+        reasoning.push_str("Chain/crypto failure — falling back to Web2 path. ");
+        confidence = 0.7;
+    }
+
+    match input.blast_radius {
+        BlastRadius::Systemic => {
+            actions.push(RemediationAction::DegradeFeature {
+                feature: "non-critical".to_owned(),
+                level: DegradeLevel::Disabled,
+            });
+            actions.push(RemediationAction::Escalate {
+                severity: EscalationSeverity::Critical,
+                message: format!(
+                    "Systemic failure: {} on N{}. {} errors in {}s.",
+                    input.failed_component,
+                    input.failed_node,
+                    input.error_count,
+                    (input.time_since_first_error_ms / 1000.0).round()
+                ),
+            });
+            confidence = 0.6;
+            reasoning
+                .push_str("Systemic outage — disabling non-critical features, escalating to ops. ");
+            approval = Approval::Required;
+        }
+        BlastRadius::Partial => {
+            // Sorted, so two runs over the same probe set choose the same target.
+            // `healthyNodes[0]` in the .ts takes whichever probe came back first.
+            let mut healthy: Vec<&str> = input
+                .probe_results
+                .iter()
+                .filter(|p| p.status == ProbeStatus::Healthy)
+                .map(|p| p.target.as_str())
+                .collect();
+            healthy.sort_unstable();
+            if let Some(target) = healthy.first() {
+                actions.push(RemediationAction::Reroute {
+                    from_node: input.failed_component.clone(),
+                    to_node: (*target).to_owned(),
+                });
+                reasoning.push_str(&format!(
+                    "Partial failure — rerouting to healthy node: {target}. "
+                ));
+            }
+            actions.push(RemediationAction::DegradeFeature {
+                feature: input.failed_component.clone(),
+                level: DegradeLevel::Partial,
+            });
+            reasoning.push_str("Degrading affected feature to partial mode. ");
+        }
+        BlastRadius::Unknown => {
+            // Nothing was probed. The .ts has no representation for this, so its
+            // `else` treats it as isolated — the calmest response, chosen at the
+            // moment the least is known.
+            actions.push(RemediationAction::Escalate {
+                severity: EscalationSeverity::Medium,
+                message: format!(
+                    "Blast radius unknown for {} on N{} — no dependencies were probed.",
+                    input.failed_component, input.failed_node
+                ),
+            });
+            confidence = 0.3;
+            reasoning.push_str(
+                "Blast radius unknown — no dependency was probed, so no remediation is \
+                 chosen on the strength of it. ",
+            );
+            approval = Approval::Required;
+        }
+        BlastRadius::Isolated => match input.error_type {
+            ErrorType::Network | ErrorType::Timeout => {
+                actions.push(RemediationAction::RetryWithBackoff {
+                    service: input.failed_component.clone(),
+                    max_retries: 3,
+                });
+                actions.push(RemediationAction::FallbackSwitch {
+                    from: "cloud".to_owned(),
+                    to: "edge".to_owned(),
+                });
+                reasoning.push_str(
+                    "Isolated network issue — retrying with backoff, switching to edge. ",
+                );
+            }
+            ErrorType::Data | ErrorType::Render => {
+                actions.push(RemediationAction::CacheClear {
+                    scope: CacheScope::Local,
+                });
+                actions.push(RemediationAction::RetryWithBackoff {
+                    service: input.failed_component.clone(),
+                    max_retries: 2,
+                });
+                reasoning
+                    .push_str("Isolated data/render error — clearing local cache and retrying. ");
+            }
+            // Chain and crypto were handled above, at any radius; auth returned.
+            ErrorType::Chain | ErrorType::Crypto | ErrorType::Auth => {}
+        },
+    }
+
+    HealingPlan {
+        id: id.into(),
+        at_ms,
+        diagnostic: input,
+        actions,
+        confidence,
+        reasoning: reasoning.trim().to_owned(),
+        approval,
+    }
+}
+
+/// What happened when the host ran one action.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ActionOutcome {
+    /// Which action.
+    pub action: RemediationAction,
+    /// Whether it worked.
+    pub success: bool,
+    /// What went wrong, when something did.
+    pub error: Option<String>,
+}
+
+/// What happened to a whole plan.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HealingResult {
+    /// Which plan.
+    pub plan_id: String,
+    /// How many actions succeeded.
+    pub actions_executed: usize,
+    /// How many did not.
+    pub actions_failed: usize,
+    /// How many were never attempted, because approval was pending.
+    ///
+    /// The `.ts` has no such count: an unapproved plan either ran in full or
+    /// returned `null`, so "held" and "never happened" were indistinguishable
+    /// afterwards.
+    pub actions_held: usize,
+    /// One entry per action attempted.
+    pub outcomes: Vec<ActionOutcome>,
+    /// When, milliseconds since the Unix epoch.
+    pub at_ms: f64,
+}
+
+/// Fold what the host reported back into a result.
+///
+/// The core does not execute — clearing a cache, opening a circuit and paging
+/// somebody are all I/O — so the host runs [`HealingPlan::may_execute`] and hands
+/// the outcomes here.
+#[must_use]
+pub fn plan_outcome(plan: &HealingPlan, outcomes: Vec<ActionOutcome>, at_ms: f64) -> HealingResult {
+    let executed = outcomes.iter().filter(|o| o.success).count();
+    let failed = outcomes.len() - executed;
+    HealingResult {
+        plan_id: plan.id.clone(),
+        actions_executed: executed,
+        actions_failed: failed,
+        actions_held: plan.actions.len().saturating_sub(outcomes.len()),
+        outcomes,
+        at_ms,
+    }
+}
+
+/// How many of each action type a plan carries, for a summary line.
+#[must_use]
+pub fn action_tally(plan: &HealingPlan) -> BTreeMap<&'static str, usize> {
+    let mut tally = BTreeMap::new();
+    for action in &plan.actions {
+        *tally.entry(action.type_str()).or_insert(0) += 1;
+    }
+    tally
+}

--- a/docs/n8-telemetry.md
+++ b/docs/n8-telemetry.md
@@ -54,25 +54,31 @@ another agent, a dashboard — without this repo knowing any of them exist.
 `mzizi-otel`. It is a registry component rather than repo tooling because the
 apps that need to emit are consumer apps, not this one.
 
-> **This file is TypeScript, and N8 is a Rust node. Treat it as a stopgap.**
+> **The Rust core landed. The `.ts` is the JavaScript shim over it, not a stopgap.**
 >
-> The doctrine is that N4, N5, N8 and N9 — the core, the nodes holding logic
-> rather than UI — are built in Rust: N4/N5/N8 as a WASM shared core, N9 as a
-> `workers-rs` edge worker. Today **none of them are**; there are zero `.rs`
-> files under those four directories and the Rust workspace covers only N1
-> tokens and N2 primitives.
+> This note used to say N8 was a Rust node with zero `.rs` files under it. That
+> is no longer true. `mzizi-otel.rs` sits beside `mzizi-otel.ts`, **every N8 and
+> N9 component now has a Rust core**, and the `mzizi-assurance` / `mzizi-fundi`
+> crates compile them under `cargo check`, `clippy -D warnings` and a contract
+> suite in CI.
 >
-> So this exporter is not the destination. The split when the core lands:
-> **payload construction, id generation, endpoint resolution and the
-> never-throw contract are `shared-core` logic and belong in Rust**; what stays
-> per-target is the thin call that actually sends — `fetch` in a browser,
-> `env.BROWSER`/`fetch` in a Worker.
+> The split the old note promised is the split that shipped: **payload
+> construction, id handling, endpoint resolution, the nanosecond conversion and
+> the never-throw contract live in the `.rs`**; what stays per-target is the thin
+> call that actually sends — `fetch` in a browser, `fetch` or `env.BROWSER` in a
+> Worker.
 >
-> It exists in TypeScript now because a consumer app's browser has to be able to
-> emit at all, and because two live defects (`mzizi-rum` writing into a 404,
-> `nyuchi-fundi-reporter` filing against a renamed repo) were found through it
-> and should not wait on a WASM core that has not been started. **Do not copy
-> this file as the pattern for a new N4/N5/N8/N9 component.**
+> So the `.ts` is not deprecated and not a placeholder — it is the shim a
+> JavaScript-runtime consumer installs. What it must not do is drift, and it
+> cannot silently: the contract suite reads the `.ts` on disk and fails when a
+> threshold, an attribute key or a payload shape changes on one side only.
+>
+> **Still outstanding, stated plainly.** The core is pure logic with no I/O, so
+> there is no WASM build wired into any consumer and the `.ts` does not call one.
+> The two implementations agree by contract test, not by sharing a binary.
+> Compiling the core to WASM and having the shim call it is the next step, and
+> until it happens "the core landed" means the rules have one authoritative
+> home — not that one binary serves every target.
 
 ```ts
 import { exportProbeResult } from "./mzizi-otel"

--- a/mzizi-rs/Cargo.lock
+++ b/mzizi-rs/Cargo.lock
@@ -472,6 +472,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "mzizi-assurance"
+version = "0.1.0"
+
+[[package]]
 name = "mzizi-tokens"
 version = "0.1.0"
 

--- a/mzizi-rs/Cargo.lock
+++ b/mzizi-rs/Cargo.lock
@@ -476,6 +476,10 @@ name = "mzizi-assurance"
 version = "0.1.0"
 
 [[package]]
+name = "mzizi-fundi"
+version = "0.1.0"
+
+[[package]]
 name = "mzizi-tokens"
 version = "0.1.0"
 

--- a/mzizi-rs/Cargo.toml
+++ b/mzizi-rs/Cargo.toml
@@ -24,7 +24,7 @@
 
 [workspace]
 resolver = "3"
-members = ["crates/mzizi-tokens", "crates/mzizi-ui"]
+members = ["crates/mzizi-tokens", "crates/mzizi-ui", "crates/mzizi-assurance"]
 
 [workspace.package]
 version = "0.1.0"

--- a/mzizi-rs/Cargo.toml
+++ b/mzizi-rs/Cargo.toml
@@ -24,7 +24,7 @@
 
 [workspace]
 resolver = "3"
-members = ["crates/mzizi-tokens", "crates/mzizi-ui", "crates/mzizi-assurance"]
+members = ["crates/mzizi-tokens", "crates/mzizi-ui", "crates/mzizi-assurance", "crates/mzizi-fundi"]
 
 [workspace.package]
 version = "0.1.0"

--- a/mzizi-rs/crates/mzizi-assurance/Cargo.toml
+++ b/mzizi-rs/crates/mzizi-assurance/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "mzizi-assurance"
+description = "Mzizi N8 assurance — the shared core: probes, telemetry and the OTLP exporter."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[lints]
+workspace = true
+
+# NO DEPENDENCIES, AND THAT IS THE DESIGN.
+#
+# N8 is a shared core compiled to WASM and loaded by every target, so a dependency
+# here is paid for by every consumer of every app. Two would have been reflexive
+# and both are declined:
+#
+#   * `serde_json` — OTLP/HTTP JSON is a small, fully documented shape, and the
+#     `.ts` sibling hand-builds it for the same reason.
+#   * `reqwest`/`hyper` — this core does not send. It returns a request and the
+#     host performs it, so pulling a TLS stack into a module whose host already
+#     has one would be pure weight.
+#
+# `getrandom` is absent for a sharper reason: a shared core must not pick the
+# host's CSPRNG. Ids are supplied as bytes, so a browser uses
+# `crypto.getRandomValues`, a native shell uses the OS, and no target needs a
+# `getrandom` backend configured — a footgun that surfaces as a link error.
+[dependencies]

--- a/mzizi-rs/crates/mzizi-assurance/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-assurance/src/lib.rs
@@ -27,6 +27,9 @@
 //! in a way that changes its caller's verdict, so a probe can never report
 //! "failed" merely because a collector was unreachable.
 
+#[path = "../../../../components/registry/n8-assurance/mzizi-alert-engine.rs"]
+pub mod mzizi_alert_engine;
+
 #[path = "../../../../components/registry/n8-assurance/mzizi-synthetic-probe.rs"]
 pub mod mzizi_synthetic_probe;
 

--- a/mzizi-rs/crates/mzizi-assurance/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-assurance/src/lib.rs
@@ -48,5 +48,11 @@ pub mod mzizi_synthetic_probe;
 #[path = "../../../../components/registry/n8-assurance/mzizi-a11y-audit.rs"]
 pub mod mzizi_a11y_audit;
 
+#[path = "../../../../components/registry/n8-assurance/mzizi-perf-probe.rs"]
+pub mod mzizi_perf_probe;
+
+#[path = "../../../../components/registry/n8-assurance/mzizi-incident-manager.rs"]
+pub mod mzizi_incident_manager;
+
 #[path = "../../../../components/registry/n8-assurance/mzizi-otel.rs"]
 pub mod mzizi_otel;

--- a/mzizi-rs/crates/mzizi-assurance/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-assurance/src/lib.rs
@@ -48,6 +48,9 @@ pub mod mzizi_synthetic_probe;
 #[path = "../../../../components/registry/n8-assurance/mzizi-a11y-audit.rs"]
 pub mod mzizi_a11y_audit;
 
+#[path = "../../../../components/registry/n8-assurance/mzizi-chaos.rs"]
+pub mod mzizi_chaos;
+
 #[path = "../../../../components/registry/n8-assurance/mzizi-perf-probe.rs"]
 pub mod mzizi_perf_probe;
 

--- a/mzizi-rs/crates/mzizi-assurance/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-assurance/src/lib.rs
@@ -27,5 +27,8 @@
 //! in a way that changes its caller's verdict, so a probe can never report
 //! "failed" merely because a collector was unreachable.
 
+#[path = "../../../../components/registry/n8-assurance/mzizi-synthetic-probe.rs"]
+pub mod mzizi_synthetic_probe;
+
 #[path = "../../../../components/registry/n8-assurance/mzizi-otel.rs"]
 pub mod mzizi_otel;

--- a/mzizi-rs/crates/mzizi-assurance/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-assurance/src/lib.rs
@@ -45,5 +45,8 @@ pub mod mzizi_alert_engine;
 #[path = "../../../../components/registry/n8-assurance/mzizi-synthetic-probe.rs"]
 pub mod mzizi_synthetic_probe;
 
+#[path = "../../../../components/registry/n8-assurance/mzizi-a11y-audit.rs"]
+pub mod mzizi_a11y_audit;
+
 #[path = "../../../../components/registry/n8-assurance/mzizi-otel.rs"]
 pub mod mzizi_otel;

--- a/mzizi-rs/crates/mzizi-assurance/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-assurance/src/lib.rs
@@ -27,6 +27,9 @@
 //! in a way that changes its caller's verdict, so a probe can never report
 //! "failed" merely because a collector was unreachable.
 
+#[path = "../../../../components/registry/n8-assurance/mzizi-api-probe.rs"]
+pub mod mzizi_api_probe;
+
 #[path = "../../../../components/registry/n8-assurance/mzizi-error-tracker.rs"]
 pub mod mzizi_error_tracker;
 

--- a/mzizi-rs/crates/mzizi-assurance/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-assurance/src/lib.rs
@@ -1,0 +1,31 @@
+//! Mzizi N8 assurance for Rust — the shared core behind "what breaks is seen
+//! before users feel it."
+//!
+//! # Where the components are
+//!
+//! Not in this crate's `src/`. Each one is a file under
+//! `components/registry/n8-assurance/<name>.rs`, beside the `.ts` that implements
+//! the same contract for a JavaScript host, and this module `#[path]`-includes
+//! it. One component, one name, one place — the registry — with this crate as the
+//! thing that compiles it.
+//!
+//! # N8 is a Rust node, and what that means precisely
+//!
+//! N8 holds *logic*, not UI: probe execution, error aggregation, alert
+//! evaluation, telemetry encoding. Logic does not need a copy per framework, so
+//! unlike N2 there is no "Dioxus alternative" here — there is an implementation,
+//! and each target's shim is a thin call into it.
+//!
+//! The boundary is drawn at **I/O, not at language**. Everything that must
+//! compute identically on every target lives here and is pure; everything that
+//! must differ — how bytes actually leave the process, where the clock and the
+//! CSPRNG come from — is the host's. That is why [`mzizi_otel::build_trace_request`]
+//! returns a request rather than sending one.
+//!
+//! A useful consequence: the never-throw rule that the TypeScript exporter had to
+//! promise in a `try`/`catch` is structural here. A core with no I/O cannot fail
+//! in a way that changes its caller's verdict, so a probe can never report
+//! "failed" merely because a collector was unreachable.
+
+#[path = "../../../../components/registry/n8-assurance/mzizi-otel.rs"]
+pub mod mzizi_otel;

--- a/mzizi-rs/crates/mzizi-assurance/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-assurance/src/lib.rs
@@ -27,6 +27,9 @@
 //! in a way that changes its caller's verdict, so a probe can never report
 //! "failed" merely because a collector was unreachable.
 
+#[path = "../../../../components/registry/n8-assurance/mzizi-rum.rs"]
+pub mod mzizi_rum;
+
 #[path = "../../../../components/registry/n8-assurance/mzizi-api-probe.rs"]
 pub mod mzizi_api_probe;
 

--- a/mzizi-rs/crates/mzizi-assurance/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-assurance/src/lib.rs
@@ -27,6 +27,9 @@
 //! in a way that changes its caller's verdict, so a probe can never report
 //! "failed" merely because a collector was unreachable.
 
+#[path = "../../../../components/registry/n8-assurance/mzizi-error-tracker.rs"]
+pub mod mzizi_error_tracker;
+
 #[path = "../../../../components/registry/n8-assurance/mzizi-alert-engine.rs"]
 pub mod mzizi_alert_engine;
 

--- a/mzizi-rs/crates/mzizi-assurance/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-assurance/src/lib.rs
@@ -51,6 +51,9 @@ pub mod mzizi_a11y_audit;
 #[path = "../../../../components/registry/n8-assurance/mzizi-chaos.rs"]
 pub mod mzizi_chaos;
 
+#[path = "../../../../components/registry/n8-assurance/rtl-conformity-check.rs"]
+pub mod rtl_conformity_check;
+
 #[path = "../../../../components/registry/n8-assurance/mzizi-platform-health.rs"]
 pub mod mzizi_platform_health;
 

--- a/mzizi-rs/crates/mzizi-assurance/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-assurance/src/lib.rs
@@ -51,6 +51,9 @@ pub mod mzizi_a11y_audit;
 #[path = "../../../../components/registry/n8-assurance/mzizi-chaos.rs"]
 pub mod mzizi_chaos;
 
+#[path = "../../../../components/registry/n8-assurance/mzizi-platform-health.rs"]
+pub mod mzizi_platform_health;
+
 #[path = "../../../../components/registry/n8-assurance/mzizi-perf-probe.rs"]
 pub mod mzizi_perf_probe;
 

--- a/mzizi-rs/crates/mzizi-assurance/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-assurance/src/lib.rs
@@ -27,6 +27,9 @@
 //! in a way that changes its caller's verdict, so a probe can never report
 //! "failed" merely because a collector was unreachable.
 
+#[path = "../../../../components/registry/n8-assurance/mzizi-conformity-check.rs"]
+pub mod mzizi_conformity_check;
+
 #[path = "../../../../components/registry/n8-assurance/mzizi-rum.rs"]
 pub mod mzizi_rum;
 

--- a/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
+++ b/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
@@ -1152,3 +1152,179 @@ fn unknown_is_never_inferred_only_stated() {
         assert!(s.is_unhealthy());
     }
 }
+
+// ── rum ────────────────────────────────────────────────────────────────────
+
+use mzizi_assurance::mzizi_rum::{
+    Connection, Device, RumBuffer, RumEvent, RumEventType, device_for, path_only, should_sample,
+};
+
+fn rum_event(t: RumEventType) -> RumEvent {
+    RumEvent {
+        event_type: t,
+        timestamp_ms: 1000.0,
+        url: "/wallet".to_owned(),
+        mini_app: Some("wallet".to_owned()),
+        device: Device::Mobile,
+        connection: Connection::FourG,
+        metrics: vec![("ttfb".to_owned(), 120.0)],
+    }
+}
+
+#[test]
+fn an_unsampled_session_discards_rather_than_hoards() {
+    // THE BUG THIS PORT FIXES. The .ts returns early from the constructor when
+    // unsampled — BEFORE init() — so no flush timer exists, but record() stays
+    // public and keeps pushing. Events pile up with nothing to drain them, in
+    // nine sessions out of ten at the default 10% rate.
+    let mut buffer = RumBuffer::new(false, 100);
+    assert!(!buffer.is_sampled());
+    for _ in 0..1000 {
+        assert!(!buffer.record(rum_event(RumEventType::Interaction)));
+    }
+    assert!(buffer.is_empty(), "an unsampled buffer must hold nothing");
+}
+
+#[test]
+fn a_sampled_buffer_is_bounded() {
+    // A flush that fails is swallowed by design — RUM must never surface its own
+    // network error to the user it measures. Correct, and unbounded without a
+    // ceiling: an unreachable endpoint accumulates for the whole session.
+    let mut buffer = RumBuffer::new(true, 3);
+    for i in 0..10 {
+        let mut e = rum_event(RumEventType::Navigation);
+        e.timestamp_ms = f64::from(i);
+        buffer.record(e);
+    }
+    assert_eq!(buffer.len(), 3);
+    assert_eq!(buffer.drain()[2].timestamp_ms, 9.0, "the newest survives");
+}
+
+#[test]
+fn draining_empties_the_buffer() {
+    let mut buffer = RumBuffer::new(true, 100);
+    buffer.record(rum_event(RumEventType::Pageload));
+    assert_eq!(buffer.drain().len(), 1);
+    assert!(buffer.is_empty());
+    assert!(buffer.drain().is_empty(), "draining twice is not an error");
+}
+
+#[test]
+fn sampling_is_exact_at_both_ends() {
+    // A `>=` on the wrong side makes rate 0.0 sample one draw in a billion, or
+    // rate 1.0 miss one — and nobody notices either.
+    assert!(
+        !should_sample(0.0, 0.0),
+        "rate 0 samples nothing, including draw 0"
+    );
+    assert!(should_sample(0.0, 1.0));
+    assert!(should_sample(0.999_999, 1.0), "rate 1 samples everything");
+    assert!(should_sample(0.09, 0.1));
+    assert!(!should_sample(0.1, 0.1), "the boundary is exclusive");
+}
+
+#[test]
+fn viewport_breakpoints_match_the_typescript() {
+    let ts = fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../components/registry/n8-assurance/mzizi-rum.ts"),
+    )
+    .expect("the rum TypeScript sibling");
+    assert!(ts.contains("innerWidth < 640"), "mobile breakpoint drifted");
+    assert!(
+        ts.contains("innerWidth < 1024"),
+        "tablet breakpoint drifted"
+    );
+    assert_eq!(device_for(639), Device::Mobile);
+    assert_eq!(device_for(640), Device::Tablet);
+    assert_eq!(device_for(1023), Device::Tablet);
+    assert_eq!(device_for(1024), Device::Desktop);
+}
+
+#[test]
+fn a_query_string_can_never_reach_the_wire() {
+    // This component's premise is that it collects no PII, and a query string is
+    // where session tokens, reset links and search terms live.
+    assert_eq!(path_only("/wallet?token=secret"), "/wallet");
+    assert_eq!(
+        path_only("https://app.test/wallet?token=secret#frag"),
+        "/wallet"
+    );
+    assert_eq!(path_only("https://app.test"), "/");
+    assert_eq!(path_only("/wallet"), "/wallet");
+    assert_eq!(path_only("/reset#token=secret"), "/reset");
+}
+
+#[test]
+fn rum_unions_keep_their_typescript_spellings() {
+    let ts = fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../components/registry/n8-assurance/mzizi-rum.ts"),
+    )
+    .expect("the rum TypeScript sibling");
+    for t in [
+        RumEventType::Pageload,
+        RumEventType::Interaction,
+        RumEventType::Navigation,
+        RumEventType::Network,
+        RumEventType::Error,
+    ] {
+        assert!(
+            ts.contains(&format!("\"{}\"", t.as_str())),
+            "event type {}",
+            t.as_str()
+        );
+    }
+    for d in [Device::Mobile, Device::Tablet, Device::Desktop] {
+        assert!(
+            ts.contains(&format!("\"{}\"", d.as_str())),
+            "device {}",
+            d.as_str()
+        );
+    }
+    for c in [
+        Connection::FourG,
+        Connection::ThreeG,
+        Connection::TwoG,
+        Connection::SlowTwoG,
+        Connection::Wifi,
+        Connection::Unknown,
+    ] {
+        assert!(
+            ts.contains(&format!("\"{}\"", c.as_str())),
+            "connection {}",
+            c.as_str()
+        );
+    }
+    assert_eq!(
+        Connection::from_str_or_unknown("nonsense"),
+        Connection::Unknown
+    );
+}
+
+#[test]
+fn the_typescript_still_has_no_default_endpoint() {
+    // It defaulted to https://mzizi.dev/api/rum, a route that returns 404, inside
+    // a catch that correctly swallows delivery failures — silent data loss that
+    // looked exactly like working RUM. Asserted on behaviour, not on the string,
+    // because the file explains the defect in its own prose.
+    let ts = fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../components/registry/n8-assurance/mzizi-rum.ts"),
+    )
+    .expect("the rum TypeScript sibling");
+    let code_only: String = ts
+        .lines()
+        .filter(|l| {
+            let t = l.trim_start();
+            !(t.starts_with("//") || t.starts_with('*') || t.starts_with("/*"))
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    for forbidden in ["?? \"http", "?? `http", "|| \"http"] {
+        assert!(
+            !code_only.contains(forbidden),
+            "a default endpoint returned ({forbidden}…)"
+        );
+    }
+}

--- a/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
+++ b/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
@@ -1344,6 +1344,7 @@ fn el(slot: &str, tag: &str) -> ObservedElement {
         tag_name: tag.to_owned(),
         portal_url: Some("https://mzizi.dev/components/button".to_owned()),
         aria_label: Some("Save".to_owned()),
+        aria_labelledby: None,
         role: None,
         has_text: true,
     }
@@ -1416,6 +1417,12 @@ fn an_interactive_element_needs_a_name_from_somewhere() {
     with_text.has_text = true;
     assert!(with_text.has_accessible_name());
 
+    // aria-labelledby names it too. The .ts never looked at that attribute at
+    // all, while mzizi-a11y-audit always did.
+    let mut labelled_by = bare.clone();
+    labelled_by.aria_labelledby = Some("heading-1".to_owned());
+    assert!(labelled_by.has_accessible_name());
+
     // role=button makes a div interactive.
     let mut div = el("card", "DIV");
     div.role = Some("button".to_owned());
@@ -1423,6 +1430,66 @@ fn an_interactive_element_needs_a_name_from_somewhere() {
     let mut span = el("card", "SPAN");
     span.role = None;
     assert!(!span.is_interactive());
+}
+
+#[test]
+fn a_role_is_not_an_accessible_name() {
+    // THE .ts RULE COULD NEVER FIRE FOR THE ELEMENTS IT WAS WIDENED TO COVER.
+    // `const ariaLabel = getAttribute("aria-label") || getAttribute("role")`,
+    // then `if (isButton && !ariaLabel && !text)`. Any element carrying
+    // role="button" supplies its own "name" via the same attribute that put it
+    // in scope, so it is exempted by construction.
+    let mut div = el("card", "DIV");
+    div.aria_label = None;
+    div.aria_labelledby = None;
+    div.has_text = false;
+    div.role = Some("button".to_owned());
+
+    assert!(div.is_interactive(), "role=button is interactive");
+    assert!(
+        !div.has_accessible_name(),
+        "a role says what a thing IS, never what it is CALLED"
+    );
+
+    let found = check_element(&div, Some(&registry()), &BTreeSet::new());
+    let kinds: BTreeSet<ViolationType> = found.iter().map(|v| v.violation_type).collect();
+    assert!(
+        kinds.contains(&ViolationType::MissingAria),
+        "the unnamed role=button must be reported"
+    );
+}
+
+#[test]
+fn the_two_n8_components_agree_on_what_a_name_is() {
+    // Two definitions of "accessible name" across one node meant the same
+    // button was a violation on one surface and a pass on the other, and
+    // whichever a consumer saw first was the one they believed.
+    use mzizi_assurance::mzizi_a11y_audit::ObservedNode;
+
+    for (aria, labelledby, text, expected) in [
+        (None, None, false, false),
+        (Some("Save"), None, false, true),
+        (None, Some("h1"), false, true),
+        (None, None, true, true),
+    ] {
+        let mut conformity = el("button", "BUTTON");
+        conformity.aria_label = aria.map(str::to_owned);
+        conformity.aria_labelledby = labelledby.map(str::to_owned);
+        conformity.has_text = text;
+        conformity.role = Some("button".to_owned());
+
+        let audit = ObservedNode {
+            tag_name: "BUTTON".to_owned(),
+            aria_label: aria.map(str::to_owned),
+            aria_labelledby: labelledby.map(str::to_owned),
+            text: text.then(|| "Save".to_owned()),
+            role: Some("button".to_owned()),
+            ..ObservedNode::default()
+        };
+
+        assert_eq!(conformity.has_accessible_name(), expected);
+        assert_eq!(audit.accessible_name().is_some(), expected);
+    }
 }
 
 #[test]
@@ -1511,4 +1578,418 @@ fn conformity_unions_keep_their_typescript_spellings() {
     }
     assert!(ts.contains("data-slot"), "the slot attribute drifted");
     assert!(ts.contains("data-portal"), "the portal attribute drifted");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// mzizi-a11y-audit — the rules, the score, and the heading order
+// ═══════════════════════════════════════════════════════════════════════════
+
+use mzizi_assurance::mzizi_a11y_audit::{
+    A11yConfig, A11yLevel, HitBox, ObservedNode, Rule, audit, check_node, css_selector,
+    guess_node_from_slot, meets_threshold, resolve_node, worst_level,
+};
+
+fn a11y_ts() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../components/registry/n8-assurance/mzizi-a11y-audit.ts");
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read the TypeScript sibling at {path:?}: {e}"))
+}
+
+fn node(tag: &str) -> ObservedNode {
+    ObservedNode {
+        tag_name: tag.to_owned(),
+        visible: true,
+        ..ObservedNode::default()
+    }
+}
+
+fn button(name: Option<&str>, hit: Option<(f64, f64)>) -> ObservedNode {
+    ObservedNode {
+        aria_label: name.map(str::to_owned),
+        hit_box: hit.map(|(width, height)| HitBox { width, height }),
+        ..node("BUTTON")
+    }
+}
+
+fn no_registry() -> BTreeMap<String, u32> {
+    BTreeMap::new()
+}
+
+#[test]
+fn one_element_reports_every_rule_it_breaks() {
+    // THE PRIMARY BUG. The .ts chains its rules with `else if`, so the first
+    // finding hides the rest — and a button with no accessible name is exactly
+    // the button most likely to also be too small to hit.
+    let broken = button(None, Some((24.0, 24.0)));
+
+    let found = check_node(&broken, None, &A11yConfig::default(), &no_registry());
+    let rules: BTreeSet<Rule> = found.iter().map(|v| v.rule).collect();
+    assert!(rules.contains(&Rule::ButtonName), "the name rule ran");
+    assert!(rules.contains(&Rule::TouchTarget), "the size rule ran too");
+    assert_eq!(found.len(), 2);
+}
+
+#[test]
+fn an_image_with_no_alt_is_still_checked_for_everything_else() {
+    // Same else-if chain, seen from the img branch: in the .ts an <img> missing
+    // alt exits before any other rule is considered.
+    let img = ObservedNode {
+        role: Some("button".to_owned()),
+        hit_box: Some(HitBox {
+            width: 16.0,
+            height: 16.0,
+        }),
+        ..node("IMG")
+    };
+
+    let found = check_node(&img, None, &A11yConfig::default(), &no_registry());
+    let rules: BTreeSet<Rule> = found.iter().map(|v| v.rule).collect();
+    assert!(rules.contains(&Rule::ImgAlt));
+    assert!(rules.contains(&Rule::ButtonName));
+    assert!(rules.contains(&Rule::TouchTarget));
+}
+
+#[test]
+fn an_empty_alt_is_a_decorative_image_and_passes() {
+    // `alt=""` is the documented way to say "decorative". Absent is the defect.
+    let mut decorative = node("IMG");
+    decorative.alt = Some(String::new());
+    assert!(
+        check_node(&decorative, None, &A11yConfig::default(), &no_registry()).is_empty(),
+        "alt=\"\" is a deliberate answer, not a missing one"
+    );
+
+    let missing = node("IMG");
+    assert_eq!(
+        check_node(&missing, None, &A11yConfig::default(), &no_registry())[0].rule,
+        Rule::ImgAlt
+    );
+}
+
+#[test]
+fn a_conformant_button_counts_as_a_pass() {
+    // THE SCORE INVERSION. In the .ts `passes++` lives only in branches an
+    // interactive element cannot reach, so a page of correct buttons scored
+    // LOWER than a page of divs — the number moved the wrong way as
+    // accessibility improved.
+    let good = button(Some("Save"), Some((44.0, 44.0)));
+    let result = audit(
+        "/wallet",
+        &[good.clone(), good.clone(), good],
+        &A11yConfig::default(),
+        &no_registry(),
+    );
+
+    assert_eq!(result.total_elements, 3);
+    assert_eq!(result.passes, 3, "a correct button is a pass");
+    assert_eq!(result.score, 100);
+    assert!(result.violations.is_empty());
+}
+
+#[test]
+fn the_score_falls_only_as_violations_rise() {
+    let good = button(Some("Save"), Some((44.0, 44.0)));
+    let bad = button(None, Some((44.0, 44.0)));
+    let result = audit(
+        "/wallet",
+        &[good.clone(), good, bad],
+        &A11yConfig::default(),
+        &no_registry(),
+    );
+    assert_eq!(result.passes, 2);
+    assert_eq!(result.score, 67);
+    assert!(!meets_threshold(&result, 90));
+    assert!(meets_threshold(&result, 60));
+}
+
+#[test]
+fn an_empty_page_is_not_a_division_by_zero() {
+    let result = audit("/", &[], &A11yConfig::default(), &no_registry());
+    assert_eq!(result.score, 100);
+    assert_eq!(result.total_elements, 0, "the count says it was untested");
+}
+
+#[test]
+fn the_touch_target_floor_measures_the_hit_area_not_the_painted_box() {
+    // Mzizi's control scale is h-8 / h-9 / h-10 — 32-40px — by deliberate
+    // decision (CLAUDE.md §8.2), and §8.2 says a dense control earns its hit
+    // area through padding or spacing. The .ts measures getBoundingClientRect(),
+    // so every correctly-built Mzizi control failed this rule: a design system
+    // that fails its own audit universally teaches everyone to ignore the audit.
+    let dense_but_padded = ObservedNode {
+        hit_box: Some(HitBox {
+            width: 48.0,
+            height: 48.0,
+        }),
+        ..button(Some("Save"), None)
+    };
+    assert!(
+        check_node(
+            &dense_but_padded,
+            None,
+            &A11yConfig::default(),
+            &no_registry()
+        )
+        .is_empty(),
+        "an h-9 control with real padding around it is not a violation"
+    );
+
+    let genuinely_small = button(Some("Save"), Some((44.0, 30.0)));
+    let found = check_node(
+        &genuinely_small,
+        None,
+        &A11yConfig::default(),
+        &no_registry(),
+    );
+    assert_eq!(found[0].rule, Rule::TouchTarget);
+    assert_eq!(found[0].level, A11yLevel::Moderate);
+    assert!(
+        found[0].message.contains("44×30px"),
+        "the message names the measured size: {}",
+        found[0].message
+    );
+}
+
+#[test]
+fn an_unmeasured_or_hidden_control_is_not_accused_of_being_small() {
+    // No hit box means the host could not measure, which is not evidence of a
+    // small target. Reporting one would be inventing a finding.
+    let unmeasured = button(Some("Save"), None);
+    assert!(check_node(&unmeasured, None, &A11yConfig::default(), &no_registry()).is_empty());
+
+    let mut hidden = button(Some("Save"), Some((0.0, 0.0)));
+    hidden.visible = false;
+    assert!(check_node(&hidden, None, &A11yConfig::default(), &no_registry()).is_empty());
+}
+
+#[test]
+fn the_heading_order_rule_actually_evaluates_something() {
+    // The .ts carries `// Rule: Headings should be in order` above a branch that
+    // matches H1-H6 and then only counts a pass. A stated rule that evaluates
+    // nothing reads as coverage and is worse than an absent one.
+    let page = vec![node("H1"), node("H2"), node("H4"), node("P")];
+    let result = audit("/docs", &page, &A11yConfig::default(), &no_registry());
+
+    assert_eq!(result.violations.len(), 1);
+    assert_eq!(result.violations[0].rule, Rule::HeadingOrder);
+    assert_eq!(result.violations[0].element, "H4");
+    assert!(result.violations[0].message.contains("h2 → h4"));
+}
+
+#[test]
+fn a_heading_may_close_a_section_without_skipping() {
+    // h4 → h2 goes back UP the outline, which ends a section rather than
+    // leaving a gap. Only descending more than one level is a skip.
+    let page = vec![node("H1"), node("H2"), node("H3"), node("H2")];
+    let result = audit("/docs", &page, &A11yConfig::default(), &no_registry());
+    assert!(result.violations.is_empty(), "{:?}", result.violations);
+}
+
+#[test]
+fn the_first_heading_on_a_page_is_compared_against_nothing_above_it() {
+    let starts_deep = audit(
+        "/docs",
+        &[node("H3")],
+        &A11yConfig::default(),
+        &no_registry(),
+    );
+    assert_eq!(starts_deep.violations.len(), 1, "h3 with no h1 or h2 above");
+
+    let starts_right = audit(
+        "/docs",
+        &[node("H1")],
+        &A11yConfig::default(),
+        &no_registry(),
+    );
+    assert!(starts_right.violations.is_empty());
+}
+
+#[test]
+fn heading_order_reads_document_order() {
+    // Which is why `audit` takes a slice in the order the host saw them, and why
+    // that is stated in the signature's docs rather than assumed.
+    let forwards = audit(
+        "/docs",
+        &[node("H1"), node("H2"), node("H3")],
+        &A11yConfig::default(),
+        &no_registry(),
+    );
+    assert!(forwards.violations.is_empty());
+
+    let shuffled = audit(
+        "/docs",
+        &[node("H3"), node("H1"), node("H2")],
+        &A11yConfig::default(),
+        &no_registry(),
+    );
+    assert_eq!(shuffled.violations.len(), 1);
+}
+
+#[test]
+fn a_disabled_rule_produces_nothing_and_an_empty_set_is_not_absence() {
+    let broken = button(None, Some((10.0, 10.0)));
+
+    let names_only = A11yConfig {
+        rules: Some([Rule::ButtonName].into_iter().collect()),
+        ..A11yConfig::default()
+    };
+    let found = check_node(&broken, None, &names_only, &no_registry());
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].rule, Rule::ButtonName);
+
+    let nothing = A11yConfig {
+        rules: Some(BTreeSet::new()),
+        ..A11yConfig::default()
+    };
+    assert!(
+        check_node(&broken, None, &nothing, &no_registry()).is_empty(),
+        "an explicitly empty rule set runs no rules"
+    );
+    assert_eq!(
+        check_node(&broken, None, &A11yConfig::default(), &no_registry()).len(),
+        2,
+        "unconfigured runs every rule"
+    );
+}
+
+#[test]
+fn a_selector_survives_an_id_that_is_not_an_identifier() {
+    // The .ts emits `#${el.id}` raw, so an id with a space, a quote or a leading
+    // digit yields a selector that does not parse — and finding the element
+    // again is the selector's only job.
+    let mut plain = node("BUTTON");
+    plain.id = Some("save-button".to_owned());
+    assert_eq!(css_selector(&plain), "#save-button");
+
+    let mut awkward = node("BUTTON");
+    awkward.id = Some("2 items\"".to_owned());
+    assert_eq!(css_selector(&awkward), "[id=\"2 items\\\"\"]");
+
+    let mut slotted = node("BUTTON");
+    slotted.data_slot = Some("nyuchi-wallet-card".to_owned());
+    assert_eq!(css_selector(&slotted), "[data-slot=\"nyuchi-wallet-card\"]");
+
+    let mut classy = node("BUTTON");
+    classy.first_class = Some("inline-flex".to_owned());
+    assert_eq!(css_selector(&classy), "button.inline-flex");
+
+    // A Tailwind arbitrary-variant class is not a bare identifier.
+    let mut arbitrary = node("BUTTON");
+    arbitrary.first_class = Some("[&>svg]:size-4".to_owned());
+    assert_eq!(
+        css_selector(&arbitrary),
+        "button[class~=\"[&>svg]:size-4\"]"
+    );
+
+    assert_eq!(css_selector(&node("SPAN")), "span");
+}
+
+#[test]
+fn the_registry_outranks_the_slot_name_heuristic() {
+    // guessNodeFromSlot can only ever answer 2, 3 or 6, so an N7 shell component
+    // is labelled N6 and routed to the wrong owner — and N1, N4, N5 and N8-N12
+    // are answers it cannot reach at all.
+    assert_eq!(guess_node_from_slot("nyuchi-wallet-card"), Some(3));
+    assert_eq!(guess_node_from_slot("dashboard-page"), Some(6));
+    assert_eq!(guess_node_from_slot("button"), Some(2));
+
+    let registry: BTreeMap<String, u32> =
+        [("nyuchi-app-shell".to_owned(), 7)].into_iter().collect();
+    assert_eq!(
+        resolve_node(Some("nyuchi-app-shell"), &registry),
+        Some(7),
+        "the registry knows the real node"
+    );
+    assert_eq!(
+        resolve_node(Some("nyuchi-app-shell"), &no_registry()),
+        Some(3),
+        "the heuristic is the fallback, and it is wrong here"
+    );
+    assert_eq!(resolve_node(None, &registry), None);
+}
+
+#[test]
+fn a_violation_carries_the_component_identity_it_was_found_on() {
+    let mut broken = button(None, None);
+    broken.data_slot = Some("nyuchi-wallet-card".to_owned());
+    broken.data_portal = Some("https://mzizi.dev/components/nyuchi-wallet-card".to_owned());
+
+    let registry: BTreeMap<String, u32> =
+        [("nyuchi-wallet-card".to_owned(), 3)].into_iter().collect();
+    let found = check_node(&broken, None, &A11yConfig::default(), &registry);
+    assert_eq!(
+        found[0].component_name.as_deref(),
+        Some("nyuchi-wallet-card")
+    );
+    assert_eq!(found[0].node, Some(3));
+    assert!(found[0].portal_url.is_some());
+    assert!(
+        !found[0].fix.is_empty(),
+        "a finding says what to do about it"
+    );
+}
+
+#[test]
+fn a_lowercase_tag_is_the_same_element() {
+    // The DOM reports uppercase; server-rendered HTML handed to a CI run does not.
+    let mut lower = button(None, None);
+    lower.tag_name = "button".to_owned();
+    assert!(lower.is_button());
+    assert_eq!(
+        check_node(&lower, None, &A11yConfig::default(), &no_registry())[0].rule,
+        Rule::ButtonName
+    );
+}
+
+#[test]
+fn worst_level_gives_one_go_no_go_answer() {
+    let page = vec![
+        node("IMG"),
+        button(Some("Save"), Some((20.0, 20.0))),
+        button(Some("Save"), Some((44.0, 44.0))),
+    ];
+    let result = audit("/wallet", &page, &A11yConfig::default(), &no_registry());
+    assert_eq!(worst_level(&result.violations), Some(A11yLevel::Critical));
+    assert_eq!(worst_level(&[]), None);
+}
+
+#[test]
+fn the_wire_spellings_match_the_typescript() {
+    // A renamed rule or level silently reclassifies every historical finding.
+    let ts = a11y_ts();
+    for level in [
+        A11yLevel::Critical,
+        A11yLevel::Serious,
+        A11yLevel::Moderate,
+        A11yLevel::Minor,
+    ] {
+        assert!(
+            ts.contains(&format!("\"{}\"", level.as_str())),
+            "level {}",
+            level.as_str()
+        );
+    }
+    for rule in [Rule::ImgAlt, Rule::ButtonName, Rule::TouchTarget] {
+        assert!(
+            ts.contains(&format!("\"{}\"", rule.as_str())),
+            "rule {}",
+            rule.as_str()
+        );
+    }
+    // heading-order is deliberately absent from the .ts as a STRING: it is a
+    // comment there and a rule here. Asserting it would demand the defect.
+    assert!(
+        !ts.contains("\"heading-order\""),
+        "the .ts gained a heading-order rule — reconcile the two, do not just \
+         delete this assertion"
+    );
+    assert!(
+        ts.contains("Headings should be in order"),
+        "the .ts still states the rule it does not implement"
+    );
+    assert!(
+        ts.contains("44"),
+        "the touch-target floor drifted from the sibling"
+    );
 }

--- a/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
+++ b/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
@@ -1328,3 +1328,187 @@ fn the_typescript_still_has_no_default_endpoint() {
         );
     }
 }
+
+// ── conformity ─────────────────────────────────────────────────────────────
+
+use std::collections::BTreeSet;
+
+use mzizi_assurance::mzizi_conformity_check::{
+    ObservedElement, ViolationSeverity, ViolationType, check_conformity, check_element,
+    selector_for, worst_severity,
+};
+
+fn el(slot: &str, tag: &str) -> ObservedElement {
+    ObservedElement {
+        slot: slot.to_owned(),
+        tag_name: tag.to_owned(),
+        portal_url: Some("https://mzizi.dev/components/button".to_owned()),
+        aria_label: Some("Save".to_owned()),
+        role: None,
+        has_text: true,
+    }
+}
+
+fn registry() -> BTreeSet<String> {
+    ["button", "card"].iter().map(|s| (*s).to_owned()).collect()
+}
+
+#[test]
+fn one_bad_button_does_not_condemn_every_other_button() {
+    // THE BUG THIS PORT FIXES. The .ts counts conformance by SLOT NAME —
+    // "has any element with this slot had a violation" — so twenty conformant
+    // buttons and one broken one scored zero for all twenty-one.
+    let mut broken = el("button", "BUTTON");
+    broken.portal_url = None;
+    let elements = vec![el("button", "BUTTON"), el("button", "BUTTON"), broken];
+
+    let report = check_conformity("/wallet", &elements, Some(&registry()), &BTreeSet::new());
+    assert_eq!(report.total_components, 3);
+    assert_eq!(report.conformant, 2, "the two good buttons still count");
+    assert_eq!(report.score, 67);
+}
+
+#[test]
+fn an_unregistered_component_is_still_checked_for_everything_else() {
+    // The .ts returns early on `unregistered`, so a component that is also
+    // deprecated and also missing its accessible name reports one problem
+    // instead of three. Being absent from the registry does not make an
+    // accessibility defect untrue.
+    let mut element = el("mystery", "BUTTON");
+    element.portal_url = None;
+    element.aria_label = None;
+    element.has_text = false;
+
+    let deprecated: BTreeSet<String> = ["mystery".to_owned()].into_iter().collect();
+    let found = check_element(&element, Some(&registry()), &deprecated);
+    let kinds: BTreeSet<ViolationType> = found.iter().map(|v| v.violation_type).collect();
+    assert!(kinds.contains(&ViolationType::Unregistered));
+    assert!(kinds.contains(&ViolationType::MissingPortal));
+    assert!(kinds.contains(&ViolationType::Deprecated));
+    assert!(kinds.contains(&ViolationType::MissingAria));
+    assert_eq!(found.len(), 4);
+}
+
+#[test]
+fn every_violation_reaches_the_caller() {
+    // The .ts only passes `unregistered` to onViolation — every other branch
+    // just pushes — so a consumer wiring that callback to an alert saw one type
+    // out of four. Returning them all makes a second code path impossible.
+    let mut element = el("card", "DIV");
+    element.portal_url = None;
+    let found = check_element(&element, Some(&registry()), &BTreeSet::new());
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].violation_type, ViolationType::MissingPortal);
+    assert_eq!(found[0].severity, ViolationSeverity::Info);
+}
+
+#[test]
+fn an_interactive_element_needs_a_name_from_somewhere() {
+    let mut bare = el("button", "BUTTON");
+    bare.aria_label = None;
+    bare.role = None;
+    bare.has_text = false;
+    assert!(!bare.has_accessible_name());
+    assert!(bare.is_interactive());
+
+    // Any one of the three sources is enough.
+    let mut with_text = bare.clone();
+    with_text.has_text = true;
+    assert!(with_text.has_accessible_name());
+
+    // role=button makes a div interactive.
+    let mut div = el("card", "DIV");
+    div.role = Some("button".to_owned());
+    assert!(div.is_interactive());
+    let mut span = el("card", "SPAN");
+    span.role = None;
+    assert!(!span.is_interactive());
+}
+
+#[test]
+fn a_tag_name_is_matched_case_insensitively() {
+    // The DOM reports uppercase; server-rendered HTML and other hosts may not.
+    let mut lower = el("button", "button");
+    lower.aria_label = None;
+    lower.has_text = false;
+    assert!(
+        lower.is_interactive(),
+        "a lowercase tag is the same element"
+    );
+}
+
+#[test]
+fn a_selector_survives_a_quote_in_the_slot() {
+    // The selector's whole job is finding the element again, and an unescaped
+    // quote produces one that does not parse.
+    assert_eq!(selector_for("button"), "[data-slot=\"button\"]");
+    assert_eq!(selector_for("a\"b"), "[data-slot=\"a\\\"b\"]");
+}
+
+#[test]
+fn no_registry_means_no_unregistered_finding() {
+    // A host that does not know the registry cannot claim anything is missing
+    // from it — that is absence of evidence.
+    let found = check_element(&el("anything", "DIV"), None, &BTreeSet::new());
+    assert!(
+        found
+            .iter()
+            .all(|v| v.violation_type != ViolationType::Unregistered)
+    );
+}
+
+#[test]
+fn an_empty_page_scores_100_rather_than_dividing_by_zero() {
+    let report = check_conformity("/", &[], Some(&registry()), &BTreeSet::new());
+    assert_eq!(report.score, 100);
+    assert_eq!(
+        report.total_components, 0,
+        "which is how you tell it from a tested page"
+    );
+}
+
+#[test]
+fn worst_severity_is_the_go_no_go_answer() {
+    let mut deprecated_el = el("card", "DIV");
+    deprecated_el.portal_url = None;
+    let deprecated: BTreeSet<String> = ["card".to_owned()].into_iter().collect();
+    let found = check_element(&deprecated_el, Some(&registry()), &deprecated);
+    assert_eq!(worst_severity(&found), Some(ViolationSeverity::Error));
+    assert_eq!(worst_severity(&[]), None);
+}
+
+#[test]
+fn conformity_unions_keep_their_typescript_spellings() {
+    let ts = fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../components/registry/n8-assurance/mzizi-conformity-check.ts"),
+    )
+    .expect("the conformity-check TypeScript sibling");
+    for t in [
+        ViolationType::Unregistered,
+        ViolationType::MissingPortal,
+        ViolationType::Deprecated,
+        ViolationType::VersionMismatch,
+        ViolationType::MissingAria,
+        ViolationType::MissingSlot,
+    ] {
+        assert!(
+            ts.contains(&format!("\"{}\"", t.as_str())),
+            "violation type {}",
+            t.as_str()
+        );
+    }
+    for s in [
+        ViolationSeverity::Info,
+        ViolationSeverity::Warning,
+        ViolationSeverity::Error,
+    ] {
+        assert!(
+            ts.contains(&format!("\"{}\"", s.as_str())),
+            "severity {}",
+            s.as_str()
+        );
+    }
+    assert!(ts.contains("data-slot"), "the slot attribute drifted");
+    assert!(ts.contains("data-portal"), "the portal attribute drifted");
+}

--- a/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
+++ b/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
@@ -1,0 +1,474 @@
+//! Contract tests — the N8 Rust core against its TypeScript sibling.
+//!
+//! `cargo check` proves `mzizi-otel.rs` compiles. It cannot prove the thing that
+//! matters: that `mzizi-otel.rs` and `mzizi-otel.ts` produce the SAME OTLP.
+//!
+//! That failure mode is worse here than in N2. A Dioxus button that disagrees
+//! with its React sibling renders visibly wrong. A malformed or drifted OTLP body
+//! fails **silently** — the collector returns 200 and drops the span, or accepts
+//! it under a different attribute name, and the first anyone knows is a dashboard
+//! that is empty or a query that matches nothing. Nobody debugs a graph that is
+//! merely thinner than it should be.
+//!
+//! So two things are asserted:
+//!
+//! 1. **The wire shape**, against the OTLP spec — hex id lengths, integer
+//!    nanosecond strings, one type tag per attribute, the status enum.
+//! 2. **Agreement with the `.ts`**, by reading it on disk. Every attribute key
+//!    and every literal the two must share has to appear in both. The TypeScript
+//!    is the incumbent that consumers install today, so where they disagree the
+//!    Rust is wrong until somebody decides otherwise.
+//!
+//! What is deliberately NOT asserted: `telemetry.sdk.language`. It reads `rust`
+//! here and `webjs` there, correctly — that field names the emitter, and a test
+//! demanding they match would be demanding a lie.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+
+use mzizi_assurance::mzizi_otel::{
+    AttributeValue, NotExported, OtelConfig, ProbeResult, ProbeStatus, ProbeStep, SpanId, SpanKind,
+    StatusCode, StepStatus, TraceId, build_trace_body, build_trace_request, probe_result_to_spans,
+    resolve_traces_url,
+};
+
+/// Read the TypeScript sibling that this core has to agree with.
+fn ts_sibling() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../components/registry/n8-assurance/mzizi-otel.ts");
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read the TypeScript sibling at {path:?}: {e}"))
+}
+
+fn trace_id() -> TraceId {
+    TraceId::new([
+        0x0a, 0x1b, 0x2c, 0x3d, 0x4e, 0x5f, 0x60, 0x71, 0x82, 0x93, 0xa4, 0xb5, 0xc6, 0xd7, 0xe8,
+        0xf9,
+    ])
+}
+
+fn span_ids() -> Vec<SpanId> {
+    vec![
+        SpanId::new([1, 2, 3, 4, 5, 6, 7, 8]),
+        SpanId::new([9, 10, 11, 12, 13, 14, 15, 16]),
+        SpanId::new([17, 18, 19, 20, 21, 22, 23, 24]),
+    ]
+}
+
+fn config() -> OtelConfig {
+    OtelConfig {
+        endpoint: Some("https://collector.test".to_owned()),
+        service_name: "test-service".to_owned(),
+        ..OtelConfig::default()
+    }
+}
+
+/// Fixed timestamp — 2026-08-08T03:00:00.000Z, matching the vitest fixture.
+const STARTED_AT_MS: f64 = 1_786_158_000_000.0;
+
+fn passing() -> ProbeResult {
+    ProbeResult {
+        journey_id: "mzizi-browser-render".to_owned(),
+        started_at_ms: STARTED_AT_MS,
+        region: "cloudflare-edge".to_owned(),
+        status: ProbeStatus::Pass,
+        duration_ms: 1200.0,
+        steps: vec![
+            ProbeStep {
+                description: "/tokens".to_owned(),
+                status: StepStatus::Pass,
+                duration_ms: 500.0,
+                error: None,
+            },
+            ProbeStep {
+                description: "/architecture".to_owned(),
+                status: StepStatus::Pass,
+                duration_ms: 700.0,
+                error: None,
+            },
+        ],
+    }
+}
+
+fn failing() -> ProbeResult {
+    ProbeResult {
+        status: ProbeStatus::Fail,
+        steps: vec![
+            ProbeStep {
+                description: "/tokens".to_owned(),
+                status: StepStatus::Pass,
+                duration_ms: 500.0,
+                error: None,
+            },
+            ProbeStep {
+                description: "/changelog/button".to_owned(),
+                status: StepStatus::Fail,
+                duration_ms: 700.0,
+                error: Some("missing body".to_owned()),
+            },
+        ],
+        ..passing()
+    }
+}
+
+// ── ids ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn ids_render_at_the_lengths_a_collector_accepts() {
+    // Any other length is rejected by dropping the span, not by an error the
+    // caller sees — so the type enforces it rather than a check at the edge.
+    assert_eq!(trace_id().to_string().len(), 32);
+    assert_eq!(span_ids()[0].to_string().len(), 16);
+    assert!(
+        trace_id()
+            .to_string()
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+    );
+}
+
+// ── the wire shape ─────────────────────────────────────────────────────────
+
+#[test]
+fn timestamps_are_quoted_integer_nanoseconds() {
+    let body = build_trace_body(
+        &probe_result_to_spans(&passing(), &span_ids(), &BTreeMap::new()),
+        &config(),
+        trace_id(),
+    );
+    // Quoted, because JSON has no int64 and a float64 loses precision above
+    // 2^53 — exactly where a nanosecond timestamp sits.
+    let nanos = STARTED_AT_MS as u128 * 1_000_000;
+    assert!(
+        body.contains(&format!("\"startTimeUnixNano\":\"{nanos}\"")),
+        "expected a quoted nanosecond string; body was:\n{body}"
+    );
+    // Milliseconds where nanoseconds belong puts the span in 1970, where nobody
+    // looks for it.
+    assert!(nanos > 1_700_000_000_000_000_000);
+}
+
+#[test]
+fn every_attribute_carries_exactly_one_type_tag() {
+    let body = build_trace_body(
+        &probe_result_to_spans(&passing(), &span_ids(), &BTreeMap::new()),
+        &config(),
+        trace_id(),
+    );
+    for fragment in body.split("{\"key\":").skip(1) {
+        let tags = ["stringValue", "intValue", "doubleValue", "boolValue"]
+            .iter()
+            .filter(|t| fragment.split("}}").next().is_some_and(|f| f.contains(**t)))
+            .count();
+        assert_eq!(tags, 1, "attribute has {tags} type tags in:\n{fragment}");
+    }
+}
+
+#[test]
+fn integers_are_quoted_and_floats_are_not() {
+    let spans = probe_result_to_spans(&passing(), &span_ids(), &BTreeMap::new());
+    let body = build_trace_body(&spans, &config(), trace_id());
+    assert!(
+        body.contains("\"intValue\":\"8\""),
+        "mzizi.node should be a quoted int"
+    );
+
+    let mut attrs = BTreeMap::new();
+    attrs.insert("ratio".to_owned(), AttributeValue::Double(0.5));
+    attrs.insert("on".to_owned(), AttributeValue::Bool(true));
+    let body = build_trace_body(
+        &probe_result_to_spans(&passing(), &span_ids(), &attrs),
+        &config(),
+        trace_id(),
+    );
+    assert!(body.contains("\"doubleValue\":0.5"));
+    assert!(body.contains("\"boolValue\":true"));
+}
+
+#[test]
+fn strings_that_break_json_are_escaped() {
+    // A failure reason is prose written by whatever failed, so it can contain
+    // anything. An unescaped quote or newline produces a body the collector
+    // rejects wholesale — losing the span that mattered most.
+    let mut result = failing();
+    result.steps[1].error = Some("missing \"malachite\"\n\tand a \\ backslash".to_owned());
+    let body = build_trace_body(
+        &probe_result_to_spans(&result, &span_ids(), &BTreeMap::new()),
+        &config(),
+        trace_id(),
+    );
+    assert!(body.contains("missing \\\"malachite\\\"\\n\\tand a \\\\ backslash"));
+    assert!(
+        !body.contains("malachite\"\n"),
+        "a raw newline survived into the body"
+    );
+}
+
+#[test]
+fn one_run_puts_every_span_under_one_trace_id() {
+    let body = build_trace_body(
+        &probe_result_to_spans(&passing(), &span_ids(), &BTreeMap::new()),
+        &config(),
+        trace_id(),
+    );
+    assert_eq!(body.matches(&trace_id().to_string()).count(), 3);
+}
+
+// ── the probe mapping ──────────────────────────────────────────────────────
+
+#[test]
+fn a_run_span_parents_one_child_per_step() {
+    let spans = probe_result_to_spans(&passing(), &span_ids(), &BTreeMap::new());
+    assert_eq!(spans.len(), 3);
+    assert!(spans[0].parent_span_id.is_none());
+    for step in &spans[1..] {
+        assert_eq!(step.parent_span_id, Some(spans[0].span_id));
+    }
+}
+
+#[test]
+fn the_run_is_internal_and_each_step_is_client() {
+    // A step calls something external, the run calls nothing. Reversing these
+    // makes a collector draw service-dependency edges that do not exist.
+    let spans = probe_result_to_spans(&passing(), &span_ids(), &BTreeMap::new());
+    assert_eq!(spans[0].kind, SpanKind::Internal);
+    assert!(spans[1..].iter().all(|s| s.kind == SpanKind::Client));
+}
+
+#[test]
+fn a_failure_marks_the_run_and_the_failing_step_only() {
+    // This is the case fundi acts on, so it must not come through as UNSET.
+    let spans = probe_result_to_spans(&failing(), &span_ids(), &BTreeMap::new());
+    assert_eq!(spans[0].status, StatusCode::Error);
+    assert_eq!(spans[1].status, StatusCode::Ok);
+    assert_eq!(spans[2].status, StatusCode::Error);
+    assert_eq!(spans[2].status_message.as_deref(), Some("missing body"));
+}
+
+#[test]
+fn the_failure_reason_travels_as_error_message() {
+    // So a consumer does not have to parse prose to tell an auth wall from a
+    // page that rendered empty.
+    let spans = probe_result_to_spans(&failing(), &span_ids(), &BTreeMap::new());
+    assert_eq!(
+        spans[2].attributes.get("error.message"),
+        Some(&AttributeValue::Str("missing body".to_owned()))
+    );
+}
+
+#[test]
+fn a_passing_run_is_ok_throughout() {
+    for span in probe_result_to_spans(&passing(), &span_ids(), &BTreeMap::new()) {
+        assert_eq!(span.status, StatusCode::Ok);
+        assert!(span.status_message.is_none());
+    }
+}
+
+#[test]
+fn step_counts_land_on_the_run_span() {
+    let spans = probe_result_to_spans(&failing(), &span_ids(), &BTreeMap::new());
+    assert_eq!(
+        spans[0].attributes.get("mzizi.probe.steps"),
+        Some(&AttributeValue::Int(2))
+    );
+    assert_eq!(
+        spans[0].attributes.get("mzizi.probe.steps_failed"),
+        Some(&AttributeValue::Int(1))
+    );
+}
+
+#[test]
+fn too_few_ids_truncates_rather_than_reusing_one() {
+    // A duplicated span id corrupts the trace a collector assembles, which is
+    // worse than a short one.
+    let spans = probe_result_to_spans(&passing(), &span_ids()[..2], &BTreeMap::new());
+    assert_eq!(spans.len(), 2, "one run + one step, not a reused id");
+    assert!(probe_result_to_spans(&passing(), &[], &BTreeMap::new()).is_empty());
+}
+
+#[test]
+fn steps_are_laid_end_to_end_from_the_run_start() {
+    // The durations are measured; the offsets are reconstructed, because
+    // ProbeResult carries no per-step timestamp.
+    let spans = probe_result_to_spans(&passing(), &span_ids(), &BTreeMap::new());
+    assert_eq!(spans[1].start_time_ms, STARTED_AT_MS);
+    assert_eq!(spans[1].end_time_ms, STARTED_AT_MS + 500.0);
+    assert_eq!(spans[2].start_time_ms, STARTED_AT_MS + 500.0);
+    assert_eq!(spans[2].end_time_ms, STARTED_AT_MS + 1200.0);
+}
+
+// ── endpoint resolution ────────────────────────────────────────────────────
+
+#[test]
+fn a_base_endpoint_gains_the_signal_path() {
+    assert_eq!(
+        resolve_traces_url(&config()).as_deref(),
+        Some("https://collector.test/v1/traces")
+    );
+}
+
+#[test]
+fn a_trailing_slash_does_not_double_up() {
+    let cfg = OtelConfig {
+        endpoint: Some("https://collector.test/".to_owned()),
+        ..config()
+    };
+    assert_eq!(
+        resolve_traces_url(&cfg).as_deref(),
+        Some("https://collector.test/v1/traces")
+    );
+}
+
+#[test]
+fn a_traces_endpoint_is_used_verbatim() {
+    // The asymmetry is the OTLP spec's. Appending here yields
+    // /v1/traces/v1/traces — a 404 that reads like a broken collector.
+    let cfg = OtelConfig {
+        traces_endpoint: Some("https://collector.test/custom".to_owned()),
+        ..config()
+    };
+    assert_eq!(
+        resolve_traces_url(&cfg).as_deref(),
+        Some("https://collector.test/custom")
+    );
+}
+
+#[test]
+fn no_endpoint_is_inert_rather_than_an_error() {
+    // Most consumers run no collector. Inert must mean inert — never a request
+    // to a guessed address, which is the /api/rum defect this node already paid
+    // for once.
+    let cfg = OtelConfig {
+        service_name: "s".to_owned(),
+        ..OtelConfig::default()
+    };
+    assert!(resolve_traces_url(&cfg).is_none());
+    let spans = probe_result_to_spans(&passing(), &span_ids(), &BTreeMap::new());
+    assert_eq!(
+        build_trace_request(&spans, &cfg, trace_id()),
+        Err(NotExported::NoEndpoint)
+    );
+}
+
+#[test]
+fn nothing_to_send_says_so() {
+    assert_eq!(
+        build_trace_request(&[], &config(), trace_id()),
+        Err(NotExported::NoSpans)
+    );
+}
+
+#[test]
+fn a_request_carries_the_json_content_type() {
+    let spans = probe_result_to_spans(&passing(), &span_ids(), &BTreeMap::new());
+    let req = build_trace_request(&spans, &config(), trace_id()).expect("configured");
+    assert_eq!(
+        req.headers.get("Content-Type").map(String::as_str),
+        Some("application/json")
+    );
+    assert!(req.body.starts_with("{\"resourceSpans\":["));
+}
+
+// ── agreement with the TypeScript sibling ──────────────────────────────────
+
+#[test]
+fn every_shared_literal_appears_in_both_implementations() {
+    // The drift this catches is silent: an attribute renamed on one side lands
+    // in the collector under a key nobody queries, and the graph is merely
+    // thinner than it should be.
+    let ts = ts_sibling();
+    let shared = [
+        // attribute keys
+        "mzizi.node",
+        "mzizi.probe.journey",
+        "mzizi.probe.status",
+        "mzizi.probe.region",
+        "mzizi.probe.steps",
+        "mzizi.probe.steps_failed",
+        "error.message",
+        "service.name",
+        "service.version",
+        "deployment.environment.name",
+        "telemetry.sdk.name",
+        // payload structure
+        "resourceSpans",
+        "scopeSpans",
+        "mzizi.n8.assurance",
+        "startTimeUnixNano",
+        "endTimeUnixNano",
+        "parentSpanId",
+        "stringValue",
+        "intValue",
+        "doubleValue",
+        "boolValue",
+        // endpoint contract
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "/v1/traces",
+        // the emitter name, which IS shared even though the language is not
+        "mzizi-otel",
+    ];
+    for literal in shared {
+        assert!(
+            ts.contains(literal),
+            "the Rust core uses `{literal}`, which does not appear in mzizi-otel.ts. \
+             The two implementations have drifted — one of them is wrong, and a \
+             collector will not tell you which."
+        );
+    }
+}
+
+#[test]
+fn the_status_and_kind_enums_match_the_typescript() {
+    let ts = ts_sibling();
+    // Transposing OK and ERROR is the easiest possible mistake here and the
+    // hardest to notice: every span still arrives, just labelled backwards.
+    assert!(ts.contains("STATUS_UNSET = 0"));
+    assert!(ts.contains("STATUS_OK = 1"));
+    assert!(ts.contains("STATUS_ERROR = 2"));
+    assert!(ts.contains("SPAN_KIND_INTERNAL = 1"));
+    assert!(ts.contains("SPAN_KIND_CLIENT = 3"));
+    assert_eq!(StatusCode::Unset as u8, 0);
+    assert_eq!(StatusCode::Ok as u8, 1);
+    assert_eq!(StatusCode::Error as u8, 2);
+    assert_eq!(SpanKind::Internal as u8, 1);
+    assert_eq!(SpanKind::Client as u8, 3);
+}
+
+#[test]
+fn the_typescript_still_declares_no_default_endpoint() {
+    // If a default ever reappears there, the two implementations disagree about
+    // the single rule this component exists to enforce.
+    //
+    // This asserts on CODE, not on a mention. The first version banned the
+    // string "mzizi.dev/api/rum" and failed immediately — because that URL
+    // appears in the file's own prose, explaining the defect it exists not to
+    // repeat. A check that cannot tell a bug from its post-mortem forces you to
+    // delete the explanation to make the test pass, which is exactly backwards.
+    //
+    // The repo already solved this shape once: the llms.txt doctrine test
+    // asserts that any paragraph mentioning axes also marks them retired,
+    // instead of banning the word.
+    //
+    // What is actually forbidden is a fallback from an unset endpoint to a URL
+    // literal — `?? "http…"` — which is the behaviour, not the vocabulary.
+    let ts = ts_sibling();
+    let code_only: String = ts
+        .lines()
+        .filter(|l| {
+            let t = l.trim_start();
+            !(t.starts_with("//") || t.starts_with('*') || t.starts_with("/*"))
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    for forbidden in ["?? \"http", "?? `http", "|| \"http"] {
+        assert!(
+            !code_only.contains(forbidden),
+            "mzizi-otel.ts falls back to a URL literal ({forbidden}…). Unset must \
+             mean inert: sending a consumer's telemetry to an address they never \
+             chose is the /api/rum defect restated."
+        );
+    }
+}

--- a/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
+++ b/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
@@ -3406,3 +3406,38 @@ fn the_worst_level_is_the_go_no_go_answer() {
     assert_eq!(rtl_worst_level(&result.violations), Some(RtlLevel::Serious));
     assert_eq!(rtl_worst_level(&[]), None);
 }
+
+#[test]
+fn the_exporter_shim_does_not_claim_the_core_is_missing() {
+    // The .ts header is a doctrine surface: it is installed into consumer apps,
+    // so a stale claim there travels further than one on a page. It said "there
+    // are zero .rs files under those four directories" and called itself a
+    // stopgap for a core nobody had started — true when written, false the
+    // moment mzizi-otel.rs landed beside it.
+    //
+    // This asserts BEHAVIOUR rather than banning words: the file may name the
+    // old state in order to disown it, exactly as public/llms.txt is allowed to
+    // name the retired axis model. What it may not do is assert the absence.
+    // Checked PER PARAGRAPH, which is the point. A first attempt banned the
+    // substring outright and failed on the very sentence that retracts it —
+    // the same self-tripping the llms.txt doctrine test was built to avoid.
+    let ts = ts_sibling();
+    for paragraph in ts.split("\n *\n") {
+        for claim in ["zero `.rs` files", "Today none of them are"] {
+            if paragraph.contains(claim) {
+                assert!(
+                    paragraph.contains("no longer true") || paragraph.contains("used to say"),
+                    "a paragraph asserts `{claim}` without retracting it:\n{paragraph}"
+                );
+            }
+        }
+    }
+
+    // And it must keep saying the thing that IS still true, so "the core landed"
+    // is never read as "one binary serves every target".
+    assert!(
+        ts.contains("there is no WASM build"),
+        "the shim must keep stating that the two agree by contract test, not by \
+         sharing a binary — when a WASM build lands, update this assertion"
+    );
+}

--- a/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
+++ b/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
@@ -1993,3 +1993,642 @@ fn the_wire_spellings_match_the_typescript() {
         "the touch-target floor drifted from the sibling"
     );
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// mzizi-perf-probe — thresholds, the fold, and what "not measured" means
+// ═══════════════════════════════════════════════════════════════════════════
+
+use mzizi_assurance::mzizi_perf_probe::{
+    ComponentPerf, DEFAULT_SAMPLE_RATE, MarkPair, Rating, Vital, VitalsAccumulator, build_report,
+    rate, should_sample as perf_should_sample,
+};
+
+fn perf_ts() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../components/registry/n8-assurance/mzizi-perf-probe.ts");
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read the TypeScript sibling at {path:?}: {e}"))
+}
+
+#[test]
+fn the_thresholds_match_the_typescript_table_exactly() {
+    // A drifted threshold silently reclassifies every historical measurement,
+    // and nothing about the report looks wrong afterwards.
+    let ts = perf_ts();
+    for vital in Vital::all() {
+        let (good, poor) = vital.thresholds();
+        let line = format!(
+            "{}: {{ good: {}, poor: {} }}",
+            vital.as_str(),
+            trim_float(good),
+            trim_float(poor)
+        );
+        assert!(ts.contains(&line), "threshold row drifted: {line}");
+    }
+}
+
+/// Render a threshold the way the `.ts` literal writes it: `2500`, not `2500.0`.
+fn trim_float(value: f64) -> String {
+    let s = format!("{value}");
+    s.strip_suffix(".0").map_or(s.clone(), str::to_owned)
+}
+
+#[test]
+fn an_unknown_metric_is_not_rated_good() {
+    // THE FAIL-OPEN. `rateMetric` looks the name up in a Record<string, …> and
+    // returns "good" when the lookup misses, so a typo or a metric added ahead
+    // of its threshold reports as healthy. CLAUDE.md §14 forbids exactly this
+    // shape for entitlement; it is no better for performance.
+    assert_eq!(Vital::parse("LCP"), Some(Vital::Lcp));
+    assert_eq!(
+        Vital::parse("TBT"),
+        None,
+        "an unknown name has no rating, which the caller must handle"
+    );
+    assert_eq!(
+        rate(Vital::Lcp, f64::NAN),
+        Rating::Unrated,
+        "a NaN compares false against every bound and would land on \
+         needs-improvement — a rating invented from a non-measurement"
+    );
+}
+
+#[test]
+fn the_rating_boundaries_are_inclusive_on_both_ends() {
+    assert_eq!(rate(Vital::Lcp, 2500.0), Rating::Good, "<= good is good");
+    assert_eq!(rate(Vital::Lcp, 2500.1), Rating::NeedsImprovement);
+    assert_eq!(rate(Vital::Lcp, 3999.9), Rating::NeedsImprovement);
+    assert_eq!(rate(Vital::Lcp, 4000.0), Rating::Poor, ">= poor is poor");
+    assert_eq!(rate(Vital::Cls, 0.1), Rating::Good);
+    assert_eq!(rate(Vital::Cls, 0.25), Rating::Poor);
+}
+
+#[test]
+fn cls_is_folded_to_one_value_not_appended_per_batch() {
+    // The .ts calls recordMetric inside the layout-shift observer callback, so a
+    // page with twelve shift batches reports twelve CLS metrics, each carrying
+    // the running total. Anyone averaging that array gets a meaningless number.
+    let mut vitals = VitalsAccumulator::new();
+    vitals.record(Vital::Cls, 0.02, "/wallet", 1.0);
+    vitals.record(Vital::Cls, 0.09, "/wallet", 2.0);
+    vitals.record(Vital::Cls, 0.31, "/wallet", 3.0);
+
+    assert_eq!(vitals.metrics().len(), 1, "one CLS entry, not three");
+    let cls = vitals.get(Vital::Cls).expect("CLS was recorded");
+    assert!(
+        (cls.value - 0.31).abs() < f64::EPSILON,
+        "the latest total wins"
+    );
+    assert_eq!(cls.rating, Rating::Poor);
+    assert!(Vital::Cls.is_cumulative());
+    assert!(!Vital::Lcp.is_cumulative());
+}
+
+#[test]
+fn an_unrated_metric_never_outranks_a_poor_one() {
+    // Worst-rating is the number somebody acts on. Letting an absence of
+    // judgement win would hide a real failure behind an unknown metric.
+    let mut vitals = VitalsAccumulator::new();
+    vitals.record(Vital::Lcp, 5000.0, "/wallet", 1.0);
+    vitals.record(Vital::Cls, f64::NAN, "/wallet", 2.0);
+    assert_eq!(vitals.worst_rating(), Some(Rating::Poor));
+
+    let empty = VitalsAccumulator::new();
+    assert_eq!(empty.worst_rating(), None);
+}
+
+#[test]
+fn an_unmeasured_component_says_so_rather_than_reporting_zero() {
+    // THE ZEROS. The .ts fills renderTimeMs / rerenderCount / mountTimeMs with
+    // literal 0 for every component, and usePerfMark writes performance.mark
+    // entries that nothing ever reads. A table of components all rendering in
+    // 0ms is not an empty dashboard — it says everything is perfect.
+    let seen = ComponentPerf::observed("nyuchi-wallet-card");
+    assert_eq!(seen.render_time_ms, None);
+    assert_eq!(seen.mount_duration_ms, None);
+    assert_eq!(seen.rerender_count, None);
+    assert!(!seen.is_measured());
+
+    let measured = ComponentPerf::from_marks(
+        "nyuchi-wallet-card",
+        MarkPair {
+            mount_ms: 120.0,
+            unmount_ms: Some(980.0),
+        },
+    );
+    assert_eq!(measured.mount_duration_ms, Some(860.0));
+    assert!(measured.is_measured());
+}
+
+#[test]
+fn a_negative_lifetime_is_a_measurement_error_not_a_fast_component() {
+    let backwards = ComponentPerf::from_marks(
+        "nyuchi-wallet-card",
+        MarkPair {
+            mount_ms: 980.0,
+            unmount_ms: Some(120.0),
+        },
+    );
+    assert_eq!(backwards.mount_duration_ms, None);
+
+    let still_mounted = ComponentPerf::from_marks(
+        "nyuchi-wallet-card",
+        MarkPair {
+            mount_ms: 980.0,
+            unmount_ms: None,
+        },
+    );
+    assert_eq!(still_mounted.mount_duration_ms, None);
+}
+
+#[test]
+fn total_render_time_is_a_sum_of_measurements_not_the_age_of_the_page() {
+    // The .ts sets totalRenderTimeMs to performance.now() inside a
+    // setTimeout(…, 5000), so it was never below 5000 and had nothing to do
+    // with rendering.
+    let vitals = VitalsAccumulator::new();
+
+    let unmeasured = build_report(
+        "/wallet",
+        1_786_158_000_000.0,
+        &vitals,
+        vec![ComponentPerf::observed("a"), ComponentPerf::observed("b")],
+        None,
+    );
+    assert_eq!(
+        unmeasured.total_render_time_ms, None,
+        "nothing measured is not zero and is certainly not 5000"
+    );
+    assert_eq!(unmeasured.components.len(), 2, "both were still seen");
+
+    let mut one = ComponentPerf::observed("a");
+    one.render_time_ms = Some(12.5);
+    let mut two = ComponentPerf::observed("b");
+    two.render_time_ms = Some(3.5);
+    let measured = build_report(
+        "/wallet",
+        1_786_158_000_000.0,
+        &vitals,
+        vec![one, two],
+        None,
+    );
+    assert_eq!(measured.total_render_time_ms, Some(16.0));
+}
+
+#[test]
+fn memory_stays_absent_rather_than_becoming_nan() {
+    // performance.memory is Chromium-only. Dividing undefined by 1048576 gives
+    // NaN — a number-shaped value that poisons any average computed from it.
+    let vitals = VitalsAccumulator::new();
+    let report = build_report("/wallet", 1.0, &vitals, Vec::new(), None);
+    assert_eq!(report.memory_usage_mb, None);
+    assert!(
+        perf_ts().contains("memoryUsageMB` is optional; absent is the honest answer"),
+        "the .ts still states the rule this preserves"
+    );
+}
+
+#[test]
+fn sampling_is_exact_at_both_ends_here_too() {
+    // RUM and the perf probe each carry their own copy of this. Deliberate
+    // duplication, not an oversight: a registry component has to be
+    // independently installable (CLAUDE.md §15.6), so a shared sampling module
+    // would be a dependency a consumer installing one component alone does not
+    // have. The `as perf_should_sample` alias above exists so this spec cannot
+    // accidentally exercise RUM's copy and report it as the perf probe's.
+    assert!(!perf_should_sample(0.0, 0.0), "a rate of 0 samples nothing");
+    assert!(
+        perf_should_sample(0.999_999, 1.0),
+        "a rate of 1 samples everything"
+    );
+    assert!(perf_should_sample(0.05, DEFAULT_SAMPLE_RATE));
+    assert!(!perf_should_sample(0.1, DEFAULT_SAMPLE_RATE));
+    assert!(
+        perf_ts().contains("sampleRate = 0.1"),
+        "the default sample rate drifted from the sibling"
+    );
+}
+
+#[test]
+fn the_vital_and_rating_spellings_match_the_typescript() {
+    let ts = perf_ts();
+    for vital in Vital::all() {
+        assert!(
+            ts.contains(&format!("\"{}\"", vital.as_str())),
+            "vital {}",
+            vital.as_str()
+        );
+    }
+    for rating in [Rating::Good, Rating::NeedsImprovement, Rating::Poor] {
+        assert!(
+            ts.contains(&format!("\"{}\"", rating.as_str())),
+            "rating {}",
+            rating.as_str()
+        );
+    }
+    // `unrated` has no .ts counterpart because the .ts cannot express it — it
+    // answers "good" instead, which is defect 1.
+    assert!(!ts.contains("\"unrated\""));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// mzizi-incident-manager — ids, the no-op transition, and the postmortem
+// ═══════════════════════════════════════════════════════════════════════════
+
+use mzizi_assurance::mzizi_incident_manager::{
+    ActionItem, AffectedComponent, IncidentError, IncidentLog, IncidentSeverity, IncidentState,
+    NewIncident, Transitioned, component_link, escape_markdown, postmortem,
+};
+
+fn incident_ts() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../components/registry/n8-assurance/mzizi-incident-manager.ts");
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read the TypeScript sibling at {path:?}: {e}"))
+}
+
+const T0: f64 = 1_786_158_000_000.0;
+
+fn opened() -> IncidentLog {
+    let mut log = IncidentLog::new();
+    log.open(
+        "inc-1",
+        IncidentSeverity::Sev2,
+        NewIncident {
+            title: "Wallet balance not loading".to_owned(),
+            ..NewIncident::default()
+        },
+        T0,
+    )
+    .expect("a fresh id");
+    log
+}
+
+#[test]
+fn two_incidents_in_the_same_millisecond_do_not_erase_each_other() {
+    // THE CLOCK-AS-IDENTITY BUG, again. `inc-${Date.now().toString(36)}` plus
+    // `incidents.set(id, …)` means the second incident in a millisecond
+    // OVERWRITES the first — timeline and all — with nobody told. Detection is
+    // precisely when a burst arrives: one outage trips several alerts at once.
+    let mut log = opened();
+    let clash = log.open("inc-1", IncidentSeverity::Sev1, NewIncident::default(), T0);
+    assert_eq!(clash.unwrap_err(), IncidentError::DuplicateId);
+
+    assert_eq!(
+        log.get("inc-1").map(|i| i.severity),
+        Some(IncidentSeverity::Sev2),
+        "the original survived rather than being replaced"
+    );
+    assert!(
+        !incident_ts().contains("randomUUID"),
+        "if the .ts gained a real id source, drop the host-supplied id here too"
+    );
+    assert!(
+        incident_ts().contains("Date.now().toString(36)"),
+        "the .ts still derives its id from the clock"
+    );
+}
+
+#[test]
+fn resolving_an_already_resolved_incident_changes_nothing() {
+    // The .ts has no guard on the current state, so resolved → resolved rewrites
+    // resolvedAt, recomputes TTR from the new timestamp, and fires onResolved a
+    // second time: a duplicate page, and a TTR that grows on every click.
+    let mut log = opened();
+    let first = log
+        .transition(
+            "inc-1",
+            IncidentState::Resolved,
+            "ops",
+            None,
+            T0 + 600_000.0,
+        )
+        .expect("the incident exists");
+    assert!(first.resolved_now());
+    assert_eq!(log.get("inc-1").unwrap().ttr_minutes(), Some(10.0));
+
+    let again = log
+        .transition(
+            "inc-1",
+            IncidentState::Resolved,
+            "ops",
+            None,
+            T0 + 9_000_000.0,
+        )
+        .expect("the incident exists");
+    assert_eq!(again, Transitioned::NoChange(IncidentState::Resolved));
+    assert!(!again.resolved_now(), "no second page");
+    assert_eq!(
+        log.get("inc-1").unwrap().ttr_minutes(),
+        Some(10.0),
+        "TTR did not grow"
+    );
+    assert_eq!(
+        log.get("inc-1").unwrap().timeline.len(),
+        2,
+        "the no-op recorded nothing"
+    );
+}
+
+#[test]
+fn a_regression_may_reopen_and_re_resolve() {
+    // What is NOT constrained: monitoring → mitigating is a regression and
+    // resolved → triaging is a reopen. An incident tool that refuses either is
+    // one people work around.
+    let mut log = opened();
+    log.transition("inc-1", IncidentState::Resolved, "ops", None, T0 + 60_000.0)
+        .unwrap();
+    let reopened = log
+        .transition(
+            "inc-1",
+            IncidentState::Triaging,
+            "ops",
+            None,
+            T0 + 120_000.0,
+        )
+        .unwrap();
+    assert_eq!(
+        reopened,
+        Transitioned::Moved {
+            from: IncidentState::Resolved,
+            to: IncidentState::Triaging
+        }
+    );
+    assert!(log.get("inc-1").unwrap().state.is_active());
+
+    let re_resolved = log
+        .transition(
+            "inc-1",
+            IncidentState::Resolved,
+            "ops",
+            None,
+            T0 + 300_000.0,
+        )
+        .unwrap();
+    assert!(re_resolved.resolved_now(), "a genuine second resolution");
+    assert_eq!(log.get("inc-1").unwrap().ttr_minutes(), Some(5.0));
+}
+
+#[test]
+fn every_mutation_on_an_unknown_id_is_refused_rather_than_ignored() {
+    // `if (!inc) return` — so transitioning, annotating or root-causing a typo'd
+    // id succeeded from the caller's point of view and changed nothing.
+    let mut log = opened();
+    assert_eq!(
+        log.transition("inc-typo", IncidentState::Triaging, "ops", None, T0)
+            .unwrap_err(),
+        IncidentError::NotFound
+    );
+    assert_eq!(
+        log.note("inc-typo", "ops", "looked", None, T0).unwrap_err(),
+        IncidentError::NotFound
+    );
+    assert_eq!(
+        log.set_root_cause("inc-typo", "cache").unwrap_err(),
+        IncidentError::NotFound
+    );
+    assert_eq!(
+        log.add_action_item(
+            "inc-typo",
+            ActionItem {
+                description: "add a probe".to_owned(),
+                owner: "ops".to_owned(),
+                due_date: None,
+                done: false,
+            }
+        )
+        .unwrap_err(),
+        IncidentError::NotFound
+    );
+}
+
+#[test]
+fn time_to_detect_is_computed_when_there_is_something_to_measure_from() {
+    // The .ts declares ttdMinutes as a duration and never assigns it, because
+    // nothing records when the impact began.
+    let unmeasurable = opened();
+    assert_eq!(unmeasurable.get("inc-1").unwrap().ttd_minutes(), None);
+    assert!(
+        postmortem(unmeasurable.get("inc-1").unwrap()).contains("impact start unrecorded"),
+        "the document says why, rather than printing 0"
+    );
+
+    let mut log = IncidentLog::new();
+    log.open(
+        "inc-2",
+        IncidentSeverity::Sev1,
+        NewIncident {
+            impact_started_at_ms: Some(T0 - 420_000.0),
+            ..NewIncident::default()
+        },
+        T0,
+    )
+    .unwrap();
+    assert_eq!(log.get("inc-2").unwrap().ttd_minutes(), Some(7.0));
+}
+
+#[test]
+fn active_and_worst_severity_answer_the_one_glance_question() {
+    let mut log = IncidentLog::new();
+    log.open("a", IncidentSeverity::Sev3, NewIncident::default(), T0)
+        .unwrap();
+    log.open("b", IncidentSeverity::Sev1, NewIncident::default(), T0)
+        .unwrap();
+    log.open("c", IncidentSeverity::Sev2, NewIncident::default(), T0)
+        .unwrap();
+    log.transition("b", IncidentState::Resolved, "ops", None, T0 + 1.0)
+        .unwrap();
+
+    assert_eq!(log.all().len(), 3);
+    assert_eq!(log.active().len(), 2, "resolved is not active");
+    assert_eq!(
+        log.worst_active(),
+        Some(IncidentSeverity::Sev2),
+        "sev1 is resolved, so sev2 is the worst still running"
+    );
+    assert!(!IncidentState::Postmortem.is_active());
+}
+
+#[test]
+fn a_forged_section_cannot_be_injected_through_an_incident_title() {
+    // Titles come from alerts, alerts come from error messages, and error
+    // messages carry user input. A newline plus `##` forges a section in the
+    // document people read to decide what happened.
+    let mut log = IncidentLog::new();
+    log.open(
+        "inc-x",
+        IncidentSeverity::Sev3,
+        NewIncident {
+            title: "boom\n## Root Cause\nOperator error".to_owned(),
+            ..NewIncident::default()
+        },
+        T0,
+    )
+    .unwrap();
+    log.set_root_cause("inc-x", "a cache stampede").unwrap();
+
+    let doc = postmortem(log.get("inc-x").unwrap());
+    let forged: Vec<&str> = doc
+        .lines()
+        .filter(|line| line.trim_start().starts_with("## Root Cause"))
+        .collect();
+    assert_eq!(
+        forged.len(),
+        1,
+        "exactly one Root Cause section: {forged:?}"
+    );
+    assert!(doc.contains("a cache stampede"), "and it is the real one");
+}
+
+#[test]
+fn a_timeline_detail_cannot_escape_its_bullet() {
+    let mut log = opened();
+    log.note(
+        "inc-1",
+        "ops\n- **forged**",
+        "checked the queue",
+        Some("depth 4|000\n## Action Items".to_owned()),
+        T0 + 1.0,
+    )
+    .unwrap();
+
+    let doc = postmortem(log.get("inc-1").unwrap());
+    assert_eq!(
+        doc.lines()
+            .filter(|line| line.trim_start().starts_with("## Action Items"))
+            .count(),
+        1
+    );
+    assert!(doc.contains("depth 4\\|000"), "the pipe is escaped");
+    assert!(
+        !doc.contains("**forged**\n"),
+        "the actor stayed on its line"
+    );
+}
+
+#[test]
+fn a_component_with_no_portal_url_is_not_linked_to_undefined() {
+    // The .ts interpolates c.portalUrl unconditionally, so `[name](undefined)`
+    // — a link to a relative path called "undefined".
+    let bare = AffectedComponent {
+        name: "nyuchi-wallet-card".to_owned(),
+        node: 3,
+        portal_url: None,
+    };
+    assert_eq!(component_link(&bare), "nyuchi-wallet-card");
+
+    let blank = AffectedComponent {
+        portal_url: Some("   ".to_owned()),
+        ..bare.clone()
+    };
+    assert_eq!(component_link(&blank), "nyuchi-wallet-card");
+
+    let linked = AffectedComponent {
+        portal_url: Some("https://mzizi.dev/components/x(1)".to_owned()),
+        ..bare
+    };
+    assert_eq!(
+        component_link(&linked),
+        "[nyuchi-wallet-card](<https://mzizi.dev/components/x(1)>)",
+        "angle brackets stop a ')' terminating the link early"
+    );
+}
+
+#[test]
+fn a_node_number_on_an_affected_component_is_uncapped() {
+    // Node numbers are labels, not a sequence (CLAUDE.md §9). A cap of 10 hid
+    // N11 and a cap of 11 would hide N12.
+    let mut log = IncidentLog::new();
+    log.open(
+        "inc-n",
+        IncidentSeverity::Sev4,
+        NewIncident {
+            title: "docs build".to_owned(),
+            affected_components: vec![AffectedComponent {
+                name: "mzizi-skill-index".to_owned(),
+                node: 12,
+                portal_url: None,
+            }],
+            ..NewIncident::default()
+        },
+        T0,
+    )
+    .unwrap();
+    assert!(postmortem(log.get("inc-n").unwrap()).contains("(Node 12)"));
+}
+
+#[test]
+fn an_empty_section_says_so_rather_than_rendering_blank() {
+    let doc = postmortem(opened().get("inc-1").unwrap());
+    assert!(doc.contains("## Affected Components\n_None recorded_"));
+    assert!(doc.contains("## Affected Mini-Apps\n_None recorded_"));
+    assert!(doc.contains("## Root Cause\n_To be determined_"));
+    assert!(doc.contains("## Action Items\n_None yet_"));
+}
+
+#[test]
+fn an_action_item_shows_whether_it_is_done() {
+    let mut log = opened();
+    log.add_action_item(
+        "inc-1",
+        ActionItem {
+            description: "add a synthetic probe".to_owned(),
+            owner: "ops".to_owned(),
+            due_date: Some("2026-09-01".to_owned()),
+            done: false,
+        },
+    )
+    .unwrap();
+    log.add_action_item(
+        "inc-1",
+        ActionItem {
+            description: "raise the timeout".to_owned(),
+            owner: "ops".to_owned(),
+            due_date: None,
+            done: true,
+        },
+    )
+    .unwrap();
+
+    let doc = postmortem(log.get("inc-1").unwrap());
+    assert!(doc.contains("- [ ] add a synthetic probe (Owner: ops, Due: 2026-09-01)"));
+    assert!(doc.contains("- [x] raise the timeout (Owner: ops)"));
+}
+
+#[test]
+fn escape_markdown_takes_the_backslash_first() {
+    // Otherwise the escapes it adds are themselves escapable.
+    assert_eq!(escape_markdown("a\\|b"), "a\\\\\\|b");
+    assert_eq!(escape_markdown("one\ntwo"), "one two");
+}
+
+#[test]
+fn the_incident_spellings_match_the_typescript() {
+    let ts = incident_ts();
+    for severity in [
+        IncidentSeverity::Sev1,
+        IncidentSeverity::Sev2,
+        IncidentSeverity::Sev3,
+        IncidentSeverity::Sev4,
+    ] {
+        assert!(
+            ts.contains(&format!("\"{}\"", severity.as_str())),
+            "severity {}",
+            severity.as_str()
+        );
+    }
+    for state in [
+        IncidentState::Detected,
+        IncidentState::Triaging,
+        IncidentState::Mitigating,
+        IncidentState::Monitoring,
+        IncidentState::Resolved,
+        IncidentState::Postmortem,
+    ] {
+        assert!(
+            ts.contains(&format!("\"{}\"", state.as_str())),
+            "state {}",
+            state.as_str()
+        );
+    }
+}

--- a/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
+++ b/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
@@ -28,9 +28,12 @@ use std::fs;
 use std::path::PathBuf;
 
 use mzizi_assurance::mzizi_otel::{
-    AttributeValue, NotExported, OtelConfig, ProbeResult, ProbeStatus, ProbeStep, SpanId, SpanKind,
-    StatusCode, StepStatus, TraceId, build_trace_body, build_trace_request, probe_result_to_spans,
-    resolve_traces_url,
+    AttributeValue, NotExported, OtelConfig, SpanId, SpanKind, StatusCode, TraceId,
+    build_trace_body, build_trace_request, probe_result_to_spans, resolve_traces_url,
+};
+// The probe contract has ONE home, and it is not the exporter.
+use mzizi_assurance::mzizi_synthetic_probe::{
+    ProbeResult, ProbeStatus, StepResult, StepStatus, auth_flow, should_alert, wallet_flow,
 };
 
 /// Read the TypeScript sibling that this core has to agree with.
@@ -75,13 +78,13 @@ fn passing() -> ProbeResult {
         status: ProbeStatus::Pass,
         duration_ms: 1200.0,
         steps: vec![
-            ProbeStep {
+            StepResult {
                 description: "/tokens".to_owned(),
                 status: StepStatus::Pass,
                 duration_ms: 500.0,
                 error: None,
             },
-            ProbeStep {
+            StepResult {
                 description: "/architecture".to_owned(),
                 status: StepStatus::Pass,
                 duration_ms: 700.0,
@@ -95,13 +98,13 @@ fn failing() -> ProbeResult {
     ProbeResult {
         status: ProbeStatus::Fail,
         steps: vec![
-            ProbeStep {
+            StepResult {
                 description: "/tokens".to_owned(),
                 status: StepStatus::Pass,
                 duration_ms: 500.0,
                 error: None,
             },
-            ProbeStep {
+            StepResult {
                 description: "/changelog/button".to_owned(),
                 status: StepStatus::Fail,
                 duration_ms: 700.0,
@@ -471,4 +474,128 @@ fn the_typescript_still_declares_no_default_endpoint() {
              chose is the /api/rum defect restated."
         );
     }
+}
+
+// ── the probe contract ─────────────────────────────────────────────────────
+
+#[test]
+fn a_run_status_is_derived_from_its_steps_not_asserted_by_the_runner() {
+    // A runner reporting a passing run that contains a failed step would be
+    // believed, and this constructor is the one place that can prevent it. The
+    // invariant lives in the type rather than in a rule somebody remembers.
+    let steps = vec![
+        StepResult {
+            description: "/ok".to_owned(),
+            status: StepStatus::Pass,
+            duration_ms: 10.0,
+            error: None,
+        },
+        StepResult {
+            description: "/bad".to_owned(),
+            status: StepStatus::Fail,
+            duration_ms: 20.0,
+            error: Some("boom".to_owned()),
+        },
+    ];
+    let result = ProbeResult::from_steps("j", "local", STARTED_AT_MS, 30.0, steps);
+    assert_eq!(result.status, ProbeStatus::Fail);
+    assert_eq!(result.failed_step_count(), 1);
+    assert_eq!(
+        result.first_failure().and_then(|s| s.error.as_deref()),
+        Some("boom")
+    );
+}
+
+#[test]
+fn an_all_passing_run_derives_pass() {
+    let result = ProbeResult::from_steps(
+        "j",
+        "local",
+        STARTED_AT_MS,
+        10.0,
+        vec![StepResult {
+            description: "/ok".to_owned(),
+            status: StepStatus::Pass,
+            duration_ms: 10.0,
+            error: None,
+        }],
+    );
+    assert_eq!(result.status, ProbeStatus::Pass);
+    assert!(!result.status.is_failure());
+    assert!(result.first_failure().is_none());
+}
+
+#[test]
+fn timeout_and_error_are_failures_but_not_the_same_failure() {
+    // A journey that failed and a runner that could not complete warrant
+    // different responses, so they stay distinct on the wire.
+    assert!(ProbeStatus::Timeout.is_failure());
+    assert!(ProbeStatus::Error.is_failure());
+    assert_ne!(ProbeStatus::Timeout.as_str(), ProbeStatus::Error.as_str());
+}
+
+#[test]
+fn alerting_is_a_separate_decision_from_failing() {
+    // "Did it fail" and "should somebody be woken" are different questions.
+    let mut journey = wallet_flow();
+    assert!(should_alert(&journey, &failing()));
+    assert!(!should_alert(&journey, &passing()));
+    journey.alert_on_failure = false;
+    assert!(!should_alert(&journey, &failing()));
+}
+
+#[test]
+fn journey_templates_match_the_typescript() {
+    let ts = fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../components/registry/n8-assurance/mzizi-synthetic-probe.ts"),
+    )
+    .expect("the synthetic-probe TypeScript sibling");
+
+    let auth = auth_flow("wallet");
+    assert_eq!(auth.id, "auth-wallet");
+    assert_eq!(auth.nodes, vec![6, 4, 7]);
+    let wallet = wallet_flow();
+    assert_eq!(wallet.id, "wallet-balance");
+    assert_eq!(wallet.nodes, vec![6, 4, 3, 2]);
+
+    // Every selector the Rust templates drive must exist in the TypeScript, or
+    // the two implementations probe different pages while reporting the same
+    // journey id — which a collector would happily graph as one series.
+    for journey in [&auth, &wallet] {
+        for step in &journey.steps {
+            if let Some(target) = &step.target {
+                assert!(
+                    ts.contains(target.as_str()),
+                    "journey `{}` drives `{target}`, absent from the TypeScript sibling",
+                    journey.id
+                );
+            }
+            assert!(ts.contains(step.description.as_str()));
+        }
+    }
+}
+
+#[test]
+fn every_step_type_keeps_its_typescript_spelling() {
+    let ts = fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../components/registry/n8-assurance/mzizi-synthetic-probe.ts"),
+    )
+    .expect("the synthetic-probe TypeScript sibling");
+    for spelling in ["navigate", "click", "input", "assert", "wait", "screenshot"] {
+        assert!(
+            ts.contains(&format!("\"{spelling}\"")),
+            "step type `{spelling}` is not in the TypeScript union"
+        );
+    }
+}
+
+#[test]
+fn the_node_list_on_a_journey_is_uncapped() {
+    // Node numbers are labels, not a sequence. Any upper bound here would be the
+    // defect rather than its current value — a cap of 10 hid N11 once already.
+    let mut journey = wallet_flow();
+    journey.nodes.push(97);
+    assert!(journey.nodes.contains(&97));
 }

--- a/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
+++ b/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
@@ -2925,3 +2925,154 @@ fn the_chaos_spellings_match_the_typescript() {
     // which is `isolated`.
     assert!(!ts.contains("\"unknown\""));
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// mzizi-platform-health — the rollup, and the empty list that rendered green
+// ═══════════════════════════════════════════════════════════════════════════
+
+use mzizi_assurance::mzizi_platform_health::{
+    Overall, ServiceHealth, ServiceStatus, overall, tally,
+};
+
+fn health_ts() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../components/registry/n8-assurance/mzizi-platform-health.tsx");
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read the TypeScript sibling at {path:?}: {e}"))
+}
+
+fn service(name: &str, status: ServiceStatus) -> ServiceHealth {
+    ServiceHealth {
+        name: name.to_owned(),
+        status,
+        latency_ms: Some(42.0),
+        message: None,
+    }
+}
+
+#[test]
+fn an_empty_service_list_does_not_report_all_systems_operational() {
+    // THE WORST ONE IN THE NODE. `services.every(…)` is true for an empty array,
+    // so a panel whose fetch failed, or whose list has not loaded, or whose
+    // config is wrong, renders green and says "All Systems Operational".
+    // A status page is the one surface whose entire job is to be trusted at a
+    // glance, and knowing nothing rendered as knowing everything was fine.
+    assert_eq!(overall(&[]), Overall::Unknown);
+    assert_eq!(overall(&[]).headline(), "Status Unavailable");
+    assert!(!overall(&[]).needs_attention(), "unknown is not an alarm");
+
+    assert!(
+        health_ts().contains("services.every((s) => s.status === \"operational\")"),
+        "the .tsx still rolls up with .every, which is vacuously true"
+    );
+}
+
+#[test]
+fn planned_maintenance_is_not_an_issue_detected() {
+    // `allOk` is false for any non-operational status and the fallback branch is
+    // `degraded`, so a service someone deliberately took down on a schedule
+    // turned the header amber and announced a problem. A status page that cries
+    // about planned work is one people stop reading.
+    let scheduled = vec![
+        service("API", ServiceStatus::Operational),
+        service("Search", ServiceStatus::Maintenance),
+    ];
+    assert_eq!(overall(&scheduled), Overall::UnderMaintenance);
+    assert_eq!(overall(&scheduled).headline(), "Planned Maintenance");
+    assert!(!overall(&scheduled).needs_attention());
+    assert!(!ServiceStatus::Maintenance.is_problem());
+}
+
+#[test]
+fn an_unmeasured_service_is_not_a_degraded_one() {
+    // Same fallback branch. "We could not determine this service's state" and
+    // "this service is impaired" are different claims, and a status page that
+    // cannot tell them apart cannot be used to decide anything.
+    let unmeasured = vec![
+        service("API", ServiceStatus::Operational),
+        service("Search", ServiceStatus::Unknown),
+    ];
+    assert_eq!(overall(&unmeasured), Overall::Unknown);
+    assert!(!ServiceStatus::Unknown.is_problem());
+
+    // And unknown outranks maintenance: an unmeasured service MIGHT be down, a
+    // scheduled one is known not to be.
+    let both = vec![
+        service("API", ServiceStatus::Maintenance),
+        service("Search", ServiceStatus::Unknown),
+    ];
+    assert_eq!(overall(&both), Overall::Unknown);
+}
+
+#[test]
+fn the_worst_status_wins_the_headline() {
+    let all_good = vec![
+        service("API", ServiceStatus::Operational),
+        service("Search", ServiceStatus::Operational),
+    ];
+    assert_eq!(overall(&all_good), Overall::Operational);
+    assert_eq!(overall(&all_good).headline(), "All Systems Operational");
+
+    let one_slow = vec![
+        service("API", ServiceStatus::Operational),
+        service("Search", ServiceStatus::Degraded),
+    ];
+    assert_eq!(overall(&one_slow), Overall::Degraded);
+
+    // An outage outranks everything, including a degraded service beside it.
+    let one_down = vec![
+        service("API", ServiceStatus::Degraded),
+        service("Search", ServiceStatus::Outage),
+        service("Auth", ServiceStatus::Maintenance),
+    ];
+    assert_eq!(overall(&one_down), Overall::Outage);
+    assert_eq!(overall(&one_down).headline(), "Issues Detected");
+    assert!(overall(&one_down).needs_attention());
+}
+
+#[test]
+fn a_tally_counts_one_state_at_a_time() {
+    let mixed = vec![
+        service("API", ServiceStatus::Operational),
+        service("Search", ServiceStatus::Operational),
+        service("Auth", ServiceStatus::Outage),
+    ];
+    assert_eq!(tally(&mixed, ServiceStatus::Operational), 2);
+    assert_eq!(tally(&mixed, ServiceStatus::Outage), 1);
+    assert_eq!(tally(&mixed, ServiceStatus::Unknown), 0);
+}
+
+#[test]
+fn the_status_labels_and_colour_variables_match_the_tsx() {
+    // The label is what a reader sees beside the service name, and the variable
+    // is what every target resolves for the dot. A drift in either makes two
+    // panels showing the same services look like different systems.
+    let ts = health_ts();
+    for status in [
+        ServiceStatus::Operational,
+        ServiceStatus::Degraded,
+        ServiceStatus::Outage,
+        ServiceStatus::Maintenance,
+        ServiceStatus::Unknown,
+    ] {
+        assert!(
+            ts.contains(&format!("label: \"{}\"", status.label())),
+            "label for {}",
+            status.as_str()
+        );
+        assert!(
+            ts.contains(status.color_var()),
+            "colour variable for {}",
+            status.as_str()
+        );
+    }
+    // The VALUE is not asserted, and must not be: the .tsx pairs each variable
+    // with a raw hex fallback (#22C55E and friends), which is a design value
+    // defined outside N1 — §7.4 forbids it, and copying it here would put the
+    // same wrong value in a second place. The fix is a token.
+    assert!(
+        ts.contains("#22C55E"),
+        "when the hex fallbacks become tokens, this assertion is the reminder \
+         that this comment needs deleting too"
+    );
+}

--- a/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
+++ b/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
@@ -990,3 +990,165 @@ fn severity_keeps_its_typescript_spelling() {
     assert!(ts.contains("node === 7"), "shell rule drifted");
     assert!(ts.contains("> 10"), "blast-radius threshold drifted");
 }
+
+// ── the api probe ──────────────────────────────────────────────────────────
+
+use mzizi_assurance::mzizi_api_probe::{
+    EndpointStatus, Outcome, check, classify, default_endpoints, degraded_threshold_for,
+    worst_status,
+};
+
+#[test]
+fn a_timeout_is_a_reported_fact_not_a_guess_at_prose() {
+    // THE BUG THIS PORT FIXES. The .ts writes String(err).includes("abort"), and
+    // an abort reads differently per runtime — "The operation was aborted",
+    // "This operation was aborted", "signal is aborted without reason". The same
+    // timeout therefore classified as `timeout` in one host and `down` in
+    // another, and `down` pages people where `timeout` often does not.
+    assert_eq!(
+        classify(&Outcome::TimedOut, 5000.0, 2000.0),
+        EndpointStatus::Timeout
+    );
+    // Even an error whose text happens to contain "abort" is not a timeout.
+    let failed = Outcome::Failed {
+        error: "connection aborted by peer".to_owned(),
+    };
+    assert_eq!(classify(&failed, 10.0, 2000.0), EndpointStatus::Down);
+}
+
+#[test]
+fn the_degraded_threshold_cannot_contradict_the_timeout() {
+    // The .ts hardcodes 2000ms while the timeout is configurable at 5000. Set
+    // the timeout below 2000 and Degraded becomes unreachable — the request
+    // aborts before it can ever be classified slow.
+    assert!(degraded_threshold_for(5000.0) < 5000.0);
+    assert!(degraded_threshold_for(1000.0) < 1000.0);
+    assert_eq!(degraded_threshold_for(100.0), 250.0, "floored, never zero");
+}
+
+#[test]
+fn a_slow_success_is_degraded_and_a_slow_failure_is_down() {
+    // A slow 500 is an outage, not a slowdown. Calling it degraded would
+    // understate it.
+    let ok = Outcome::Responded { status_code: 200 };
+    assert_eq!(classify(&ok, 100.0, 2000.0), EndpointStatus::Healthy);
+    assert_eq!(classify(&ok, 3000.0, 2000.0), EndpointStatus::Degraded);
+    let err = Outcome::Responded { status_code: 500 };
+    assert_eq!(classify(&err, 3000.0, 2000.0), EndpointStatus::Down);
+    assert_eq!(classify(&err, 10.0, 2000.0), EndpointStatus::Down);
+}
+
+#[test]
+fn redirects_count_as_alive() {
+    let redirect = Outcome::Responded { status_code: 308 };
+    assert_eq!(classify(&redirect, 10.0, 2000.0), EndpointStatus::Healthy);
+    let gone = Outcome::Responded { status_code: 410 };
+    assert_eq!(classify(&gone, 10.0, 2000.0), EndpointStatus::Down);
+}
+
+#[test]
+fn a_check_carries_the_status_code_only_when_there_was_one() {
+    let ep = &default_endpoints("https://mzizi.dev")[0];
+    let responded = check(
+        ep,
+        &Outcome::Responded { status_code: 204 },
+        10.0,
+        1000.0,
+        2000.0,
+    );
+    assert_eq!(responded.status_code, Some(204));
+    assert!(responded.error.is_none());
+
+    let timed_out = check(ep, &Outcome::TimedOut, 5000.0, 1000.0, 2000.0);
+    assert_eq!(timed_out.status_code, None);
+    assert!(
+        timed_out
+            .error
+            .as_deref()
+            .is_some_and(|e| e.contains("timed out"))
+    );
+}
+
+#[test]
+fn one_endpoint_down_makes_the_whole_set_down() {
+    // Worst, not most common: nine healthy endpoints do not cancel out an
+    // outage, and an average would hide the only case worth seeing.
+    let ep = default_endpoints("https://mzizi.dev");
+    let checks = vec![
+        check(
+            &ep[0],
+            &Outcome::Responded { status_code: 200 },
+            10.0,
+            0.0,
+            2000.0,
+        ),
+        check(
+            &ep[1],
+            &Outcome::Responded { status_code: 200 },
+            10.0,
+            0.0,
+            2000.0,
+        ),
+        check(
+            &ep[2],
+            &Outcome::Failed {
+                error: "refused".to_owned(),
+            },
+            1.0,
+            0.0,
+            2000.0,
+        ),
+    ];
+    assert_eq!(worst_status(&checks), EndpointStatus::Down);
+    assert_eq!(worst_status(&checks[..2]), EndpointStatus::Healthy);
+    assert_eq!(
+        worst_status(&[]),
+        EndpointStatus::Unknown,
+        "nothing probed is not healthy"
+    );
+}
+
+#[test]
+fn default_endpoints_match_the_typescript_and_tolerate_a_trailing_slash() {
+    let ts = fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../components/registry/n8-assurance/mzizi-api-probe.ts"),
+    )
+    .expect("the api-probe TypeScript sibling");
+    for ep in default_endpoints("https://mzizi.dev") {
+        assert!(
+            ts.contains(ep.component_name.as_str()),
+            "{} missing",
+            ep.component_name
+        );
+        assert!(ts.contains(&format!("node: {}", ep.node)) || ts.contains(&ep.node.to_string()));
+    }
+    for status in [
+        EndpointStatus::Healthy,
+        EndpointStatus::Degraded,
+        EndpointStatus::Down,
+        EndpointStatus::Timeout,
+        EndpointStatus::Unknown,
+    ] {
+        assert!(ts.contains(&format!("\"{}\"", status.as_str())));
+    }
+    assert_eq!(
+        default_endpoints("https://mzizi.dev/")[0].url,
+        default_endpoints("https://mzizi.dev")[0].url
+    );
+}
+
+#[test]
+fn unknown_is_never_inferred_only_stated() {
+    // A host that has not probed yet needs to say so. A dashboard rendering
+    // "unknown" is honest where defaulting to "healthy" is not.
+    assert!(!EndpointStatus::Unknown.is_unhealthy());
+    assert!(!EndpointStatus::Healthy.is_unhealthy());
+    for s in [
+        EndpointStatus::Degraded,
+        EndpointStatus::Down,
+        EndpointStatus::Timeout,
+    ] {
+        assert!(s.is_unhealthy());
+    }
+}

--- a/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
+++ b/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
@@ -809,3 +809,184 @@ fn an_alert_is_constructible_without_a_dom() {
     };
     assert_eq!(alert.affected_components, vec!["button".to_owned()]);
 }
+
+// ── the error tracker ──────────────────────────────────────────────────────
+
+use mzizi_assurance::mzizi_error_tracker::{
+    ErrorContext, ErrorLog, ErrorLogConfig, Severity, Tracked, classify_severity,
+};
+
+fn ctx(node: Option<u32>, blast: usize) -> ErrorContext {
+    ErrorContext {
+        component_name: Some("button".to_owned()),
+        node,
+        mini_app: Some("wallet".to_owned()),
+        url: Some("/wallet".to_owned()),
+        blast_radius: (0..blast).map(|i| format!("sib-{i}")).collect(),
+    }
+}
+
+#[test]
+fn a_token_or_safety_failure_is_always_critical() {
+    // N1 and N4 are core guarantees. If design values or safety gates fail,
+    // everything downstream is already wrong, so nothing else can lower this.
+    assert_eq!(
+        classify_severity("anything", Some(1), 0),
+        Severity::Critical
+    );
+    assert_eq!(
+        classify_severity("anything", Some(4), 0),
+        Severity::Critical
+    );
+    assert_eq!(
+        classify_severity("Cannot read x", Some(1), 50),
+        Severity::Critical
+    );
+}
+
+#[test]
+fn shell_failures_and_wide_blast_radii_are_high() {
+    assert_eq!(classify_severity("x", Some(7), 0), Severity::High);
+    assert_eq!(classify_severity("x", Some(2), 11), Severity::High);
+    assert_eq!(
+        classify_severity("x", Some(2), 10),
+        Severity::Low,
+        "boundary is >10"
+    );
+}
+
+#[test]
+fn the_typeerror_heuristic_is_preserved_including_its_flaw() {
+    // "TypeError" is normally the error's NAME, not part of its message, so that
+    // branch rarely fires and the neighbouring "Cannot read" test is what
+    // actually catches those. Preserved rather than fixed: changing it would
+    // silently reclassify live errors, which is a product decision.
+    assert_eq!(
+        classify_severity("Cannot read properties of undefined", None, 0),
+        Severity::Medium
+    );
+    assert_eq!(
+        classify_severity("TypeError: nope", None, 0),
+        Severity::Medium
+    );
+    assert_eq!(classify_severity("something else", None, 0), Severity::Low);
+}
+
+#[test]
+fn recurrences_group_and_count_rather_than_multiply() {
+    let mut log = ErrorLog::new(ErrorLogConfig::default());
+    let (first, _) = log.track("boom", None, &ctx(Some(2), 0), "id-1", 1_000.0);
+    assert_eq!(first, Tracked::New);
+    let (again, error) = log.track("boom", None, &ctx(Some(2), 0), "id-2", 2_000.0);
+    assert_eq!(again, Tracked::Recurrence);
+    assert_eq!(error.count, 2);
+    assert_eq!(error.first_seen_ms, 1_000.0);
+    assert_eq!(error.last_seen_ms, 2_000.0);
+    assert_eq!(log.len(), 1);
+}
+
+#[test]
+fn a_recurrence_unresolves_because_it_was_not_settled() {
+    let mut log = ErrorLog::new(ErrorLogConfig::default());
+    log.track("boom", None, &ctx(None, 0), "id-1", 1_000.0);
+    let key = ErrorLog::dedup_key("boom", Some("button"));
+    assert!(log.resolve(&key));
+    assert!(log.unresolved().is_empty());
+    log.track("boom", None, &ctx(None, 0), "id-2", 2_000.0);
+    assert_eq!(log.unresolved().len(), 1);
+}
+
+#[test]
+fn auto_resolve_actually_exists() {
+    // THE DEFECT THIS PORT FIXES. The .ts declares autoResolveMinutes, defaults
+    // it to 60 via Required<>, and never reads it — so every error stayed
+    // unresolved forever while a dashboard counted them. A config option that
+    // does nothing is worse than an absent one, because it is believed.
+    let mut log = ErrorLog::new(ErrorLogConfig {
+        auto_resolve_minutes: 60.0,
+        ..ErrorLogConfig::default()
+    });
+    log.track("boom", None, &ctx(None, 0), "id-1", 0.0);
+    assert_eq!(
+        log.auto_resolve(59.0 * 60_000.0),
+        0,
+        "still inside the window"
+    );
+    assert_eq!(log.auto_resolve(60.0 * 60_000.0), 1, "the window elapsed");
+    assert!(log.unresolved().is_empty());
+    assert_eq!(
+        log.auto_resolve(120.0 * 60_000.0),
+        0,
+        "already resolved, not recounted"
+    );
+}
+
+#[test]
+fn eviction_drops_the_least_recently_seen_and_never_the_new_one() {
+    // Evicting what you were just asked to record is not eviction, it is a
+    // silent drop — and with max_errors of 1 that is exactly what a naive
+    // implementation does.
+    let mut log = ErrorLog::new(ErrorLogConfig {
+        max_errors: 2,
+        dedup: true,
+        auto_resolve_minutes: 60.0,
+    });
+    let mut c = ctx(None, 0);
+    for (i, t) in [("a", 1_000.0), ("b", 2_000.0), ("c", 3_000.0)] {
+        c.component_name = Some(i.to_owned());
+        log.track("boom", None, &c, i, t);
+    }
+    assert_eq!(log.len(), 2);
+    let held: Vec<_> = log
+        .all()
+        .iter()
+        .map(|e| e.component_name.clone().unwrap())
+        .collect();
+    assert!(
+        !held.contains(&"a".to_owned()),
+        "the oldest should have gone"
+    );
+    assert!(held.contains(&"c".to_owned()), "the newest must survive");
+}
+
+#[test]
+fn dedup_off_uses_the_supplied_id_rather_than_a_clock() {
+    // The .ts uses Date.now().toString() here, which collides for two errors in
+    // the same millisecond — which an error storm produces by construction, and
+    // an error storm is exactly when dedup gets turned off.
+    let mut log = ErrorLog::new(ErrorLogConfig {
+        dedup: false,
+        ..ErrorLogConfig::default()
+    });
+    log.track("boom", None, &ctx(None, 0), "id-1", 1_000.0);
+    log.track("boom", None, &ctx(None, 0), "id-2", 1_000.0);
+    assert_eq!(log.len(), 2, "same millisecond, distinct ids, both kept");
+}
+
+#[test]
+fn severity_keeps_its_typescript_spelling() {
+    let ts = fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../components/registry/n8-assurance/mzizi-error-tracker.ts"),
+    )
+    .expect("the error-tracker TypeScript sibling");
+    for s in [
+        Severity::Low,
+        Severity::Medium,
+        Severity::High,
+        Severity::Critical,
+    ] {
+        assert!(
+            ts.contains(&format!("\"{}\"", s.as_str())),
+            "severity {} missing",
+            s.as_str()
+        );
+    }
+    // The classification thresholds are the contract, not implementation detail.
+    assert!(
+        ts.contains("node === 1 || ctx?.node === 4"),
+        "critical-node rule drifted"
+    );
+    assert!(ts.contains("node === 7"), "shell rule drifted");
+    assert!(ts.contains("> 10"), "blast-radius threshold drifted");
+}

--- a/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
+++ b/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
@@ -2632,3 +2632,296 @@ fn the_incident_spellings_match_the_typescript() {
         );
     }
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// mzizi-chaos — the config options that did nothing, and a classifier that
+// could only say "systemic"
+// ═══════════════════════════════════════════════════════════════════════════
+
+// `ProbeResult` and `ProbeStatus` are aliased because mzizi-synthetic-probe
+// declares the same two names for different shapes — a journey step versus a
+// dependency check. The .ts has the same collision and never feels it, since
+// nothing imports both; a consumer who did would. Recorded here rather than
+// renamed, because renaming either changes a published type name.
+use mzizi_assurance::mzizi_chaos::{
+    BlastRadius, ChaosConfig, ProbeResult as ChaosProbe, ProbeStatus as ChaosStatus,
+    SYSTEMIC_FRACTION, classify_blast_radius, diagnose, injected_error_message,
+    injected_latency_ms, should_inject_error, should_inject_latency,
+};
+
+fn chaos_ts() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../components/registry/n8-assurance/mzizi-chaos.tsx");
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read the TypeScript sibling at {path:?}: {e}"))
+}
+
+fn probe(target: &str, status: ChaosStatus) -> ChaosProbe {
+    ChaosProbe {
+        target: target.to_owned(),
+        status,
+        latency_ms: 42.0,
+        error: None,
+    }
+}
+
+#[test]
+fn target_nodes_actually_narrows_the_blast_zone() {
+    // THE DEAD OPTION. `targetNodes` is documented "Nodes to target (empty =
+    // all)" and nothing in the .ts reads it — so a consumer who took the
+    // deliberate step of scoping chaos to one node got chaos everywhere, and
+    // the option bought them confidence rather than safety.
+    let scoped = ChaosConfig {
+        enabled: true,
+        error_probability: 1.0,
+        target_nodes: [5].into_iter().collect(),
+        ..ChaosConfig::default()
+    };
+    assert!(should_inject_error(&scoped, 5, 0.0), "N5 is in scope");
+    assert!(!should_inject_error(&scoped, 2, 0.0), "N2 is not");
+    assert!(scoped.targets(5));
+    assert!(!scoped.targets(2));
+
+    let everything = ChaosConfig {
+        enabled: true,
+        error_probability: 1.0,
+        ..ChaosConfig::default()
+    };
+    assert!(everything.targets(2), "an empty set means all");
+    assert!(everything.targets(12), "including nodes not yet invented");
+    assert!(should_inject_error(&everything, 12, 0.0));
+
+    assert!(
+        chaos_ts().contains("targetNodes"),
+        "the .ts still declares the field"
+    );
+}
+
+#[test]
+fn nothing_is_injected_while_chaos_is_disabled() {
+    let off = ChaosConfig {
+        error_probability: 1.0,
+        latency_probability: 1.0,
+        ..ChaosConfig::default()
+    };
+    assert!(!off.enabled, "off is the default, as in the .ts");
+    assert!(!should_inject_error(&off, 2, 0.0));
+    assert!(!should_inject_latency(&off, 2, 0.0));
+    assert_eq!(
+        injected_latency_ms(&off, 0.9),
+        0,
+        "the .ts computes a delay regardless, so a caller reaching for it \
+         directly slowed a system with chaos switched off"
+    );
+}
+
+#[test]
+fn the_probability_boundary_is_exact() {
+    let on = ChaosConfig {
+        enabled: true,
+        error_probability: 0.001,
+        latency_probability: 0.005,
+        ..ChaosConfig::default()
+    };
+    assert!(should_inject_error(&on, 2, 0.000_9));
+    assert!(!should_inject_error(&on, 2, 0.001), "strictly less than");
+    assert!(should_inject_latency(&on, 2, 0.004_9));
+    assert!(!should_inject_latency(&on, 2, 0.005));
+
+    let defaults = ChaosConfig::default();
+    assert!((defaults.error_probability - 0.001).abs() < f64::EPSILON);
+    assert!((defaults.latency_probability - 0.005).abs() < f64::EPSILON);
+    assert_eq!(defaults.max_latency_ms, 3000);
+    let ts = chaos_ts();
+    assert!(ts.contains("errorProbability: 0.001"), "error rate drifted");
+    assert!(
+        ts.contains("latencyProbability: 0.005"),
+        "latency rate drifted"
+    );
+    assert!(ts.contains("maxLatencyMs: 3000"), "latency ceiling drifted");
+}
+
+#[test]
+fn injected_latency_stays_inside_its_ceiling() {
+    let on = ChaosConfig {
+        enabled: true,
+        max_latency_ms: 3000,
+        ..ChaosConfig::default()
+    };
+    assert_eq!(injected_latency_ms(&on, 0.0), 0);
+    assert_eq!(injected_latency_ms(&on, 0.5), 1500);
+    assert_eq!(injected_latency_ms(&on, 0.999_999), 2999);
+    assert_eq!(injected_latency_ms(&on, 1.0), 3000, "clamped, not wrapped");
+    assert_eq!(injected_latency_ms(&on, 7.0), 3000);
+}
+
+#[test]
+fn an_injected_error_is_labelled_as_injected() {
+    // An injected failure that reads like a real one wastes an on-call hour.
+    let message = injected_error_message(5, "nyuchi-wallet-card");
+    assert!(message.starts_with("[nyuchi:chaos]"));
+    assert!(message.contains("Node 5"));
+    assert!(message.contains("nyuchi-wallet-card"));
+    assert!(
+        chaos_ts().contains("[nyuchi:chaos] Injected error in Node"),
+        "the marker drifted from the sibling"
+    );
+}
+
+#[test]
+fn one_failure_out_of_two_is_partial_not_systemic() {
+    // THE DEAD BAND. `errorCount < probes.length / 2` gives, for the .ts's own
+    // default of two probes: 0 → isolated, 1 → systemic, 2 → systemic. `partial`
+    // is unreachable, so a single failing dependency recommended "Activate
+    // incident response". A classifier whose error is toward paging is one
+    // people learn to disregard.
+    let one_of_two = vec![
+        probe("API", ChaosStatus::Healthy),
+        probe("Search", ChaosStatus::Error),
+    ];
+    assert_eq!(classify_blast_radius(&one_of_two), BlastRadius::Partial);
+
+    let one_of_four = vec![
+        probe("API", ChaosStatus::Healthy),
+        probe("Search", ChaosStatus::Healthy),
+        probe("Auth", ChaosStatus::Healthy),
+        probe("Queue", ChaosStatus::Timeout),
+    ];
+    assert_eq!(classify_blast_radius(&one_of_four), BlastRadius::Partial);
+
+    let two_of_four = vec![
+        probe("API", ChaosStatus::Error),
+        probe("Search", ChaosStatus::Healthy),
+        probe("Auth", ChaosStatus::Healthy),
+        probe("Queue", ChaosStatus::Timeout),
+    ];
+    assert_eq!(
+        classify_blast_radius(&two_of_four),
+        BlastRadius::Partial,
+        "exactly half is still partial — half your dependencies answering is \
+         not an outage"
+    );
+
+    let three_of_four = vec![
+        probe("API", ChaosStatus::Error),
+        probe("Search", ChaosStatus::Error),
+        probe("Auth", ChaosStatus::Healthy),
+        probe("Queue", ChaosStatus::Timeout),
+    ];
+    assert_eq!(classify_blast_radius(&three_of_four), BlastRadius::Systemic);
+
+    let both_of_two = vec![
+        probe("API", ChaosStatus::Error),
+        probe("Search", ChaosStatus::Timeout),
+    ];
+    assert_eq!(
+        classify_blast_radius(&both_of_two),
+        BlastRadius::Systemic,
+        "all three bands are reachable with two probes, which is the point"
+    );
+
+    // The threshold is EXCLUSIVE, and this spec exists because the first fix
+    // used `>=` — which leaves `partial` exactly as unreachable with two probes
+    // as the .ts did. Reproducing the bug you are fixing is easy; the assertion
+    // above is what caught it.
+    assert!((SYSTEMIC_FRACTION - 0.5).abs() < f64::EPSILON);
+}
+
+#[test]
+fn a_slow_dependency_is_not_a_down_one() {
+    // `degraded` does not count toward the blast radius, matching the .ts.
+    // Folding the two together would make every busy afternoon an outage.
+    let slow = vec![
+        probe("API", ChaosStatus::Degraded),
+        probe("Search", ChaosStatus::Degraded),
+    ];
+    assert_eq!(classify_blast_radius(&slow), BlastRadius::Isolated);
+    assert!(!ChaosStatus::Degraded.is_down());
+    assert!(ChaosStatus::Timeout.is_down());
+    assert!(ChaosStatus::Error.is_down());
+    assert!(!ChaosStatus::Healthy.is_down());
+}
+
+#[test]
+fn probing_nothing_answers_unknown_rather_than_isolated() {
+    // THE DEFAULT ENDPOINT LIST, and how it compounded the dead band. The .ts
+    // ships /api/weather?lat=-17.83&lon=31.05 as a default in a component
+    // anyone can install, so in any app that is not the weather app that probe
+    // fails every time — one out of two — which its classifier then calls a
+    // systemic outage. Installed anywhere else, it reported a systemic outage
+    // on every single diagnosis.
+    assert_eq!(classify_blast_radius(&[]), BlastRadius::Unknown);
+
+    let report = diagnose("nyuchi-wallet-card", "fetch failed", Vec::new(), 1.0);
+    assert_eq!(report.blast_radius, BlastRadius::Unknown);
+    assert!(
+        report.recommendation.contains("unknown"),
+        "not 'retry should resolve', which the .ts asserts on zero evidence"
+    );
+    assert!(
+        chaos_ts().contains("/api/weather?lat=-17.83&lon=31.05"),
+        "the .ts still hardcodes one app's endpoint as a registry default"
+    );
+}
+
+#[test]
+fn the_report_is_returned_rather_than_written_to_a_console() {
+    // The .ts console.warns JSON.stringify(report, null, 2) on every diagnosis,
+    // in a component whose own header says it runs in production, carrying an
+    // error message that is attacker-influenced whenever user input reaches an
+    // exception.
+    let report = diagnose(
+        "nyuchi-wallet-card",
+        "TypeError: fetch failed",
+        vec![
+            probe("API", ChaosStatus::Healthy),
+            probe("Search", ChaosStatus::Error),
+        ],
+        1_786_158_000_000.0,
+    );
+    assert_eq!(report.trigger_component, "nyuchi-wallet-card");
+    assert_eq!(report.trigger_error, "TypeError: fetch failed");
+    assert_eq!(report.probes.len(), 2);
+    assert_eq!(report.blast_radius, BlastRadius::Partial);
+    assert_eq!(
+        report.recommendation,
+        BlastRadius::Partial.recommendation(),
+        "the recommendation follows the classification, never set separately"
+    );
+}
+
+#[test]
+fn the_chaos_spellings_match_the_typescript() {
+    let ts = chaos_ts();
+    for status in [
+        ChaosStatus::Healthy,
+        ChaosStatus::Degraded,
+        ChaosStatus::Timeout,
+        ChaosStatus::Error,
+    ] {
+        assert!(
+            ts.contains(&format!("\"{}\"", status.as_str())),
+            "probe status {}",
+            status.as_str()
+        );
+    }
+    for radius in [
+        BlastRadius::Isolated,
+        BlastRadius::Partial,
+        BlastRadius::Systemic,
+    ] {
+        assert!(
+            ts.contains(&format!("\"{}\"", radius.as_str())),
+            "blast radius {}",
+            radius.as_str()
+        );
+        assert!(
+            ts.contains(radius.recommendation()),
+            "recommendation for {}",
+            radius.as_str()
+        );
+    }
+    // `unknown` has no .ts counterpart: zero probes there gives errorCount === 0,
+    // which is `isolated`.
+    assert!(!ts.contains("\"unknown\""));
+}

--- a/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
+++ b/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
@@ -599,3 +599,213 @@ fn the_node_list_on_a_journey_is_uncapped() {
     journey.nodes.push(97);
     assert!(journey.nodes.contains(&97));
 }
+
+// ── the alert engine ───────────────────────────────────────────────────────
+
+use mzizi_assurance::mzizi_alert_engine::{
+    Alert, AlertLog, AlertSeverity, AlertState, Escalation, SloDefinition, SloMetric, burn_rate,
+    escalate_to, evaluate_slo,
+};
+
+fn ladder() -> Vec<Escalation> {
+    vec![
+        Escalation {
+            burn_rate: 1.0,
+            severity: AlertSeverity::Warning,
+        },
+        Escalation {
+            burn_rate: 2.0,
+            severity: AlertSeverity::Critical,
+        },
+        Escalation {
+            burn_rate: 5.0,
+            severity: AlertSeverity::Page,
+        },
+    ]
+}
+
+fn slo() -> SloDefinition {
+    SloDefinition {
+        id: "api-availability".to_owned(),
+        name: "API availability".to_owned(),
+        target: 99.9,
+        window_hours: 720,
+        metric: SloMetric::Availability,
+        mini_apps: vec!["wallet".to_owned()],
+        escalation: ladder(),
+    }
+}
+
+#[test]
+fn meeting_the_objective_burns_nothing() {
+    assert_eq!(burn_rate(99.95, 99.9), 0.0);
+    assert_eq!(burn_rate(99.9, 99.9), 0.0);
+}
+
+#[test]
+fn burn_rate_counts_error_budget_consumed() {
+    // Target 99.9 leaves a 0.1 budget; observing 99.8 consumes exactly one.
+    assert!((burn_rate(99.8, 99.9) - 1.0).abs() < 1e-9);
+    assert!((burn_rate(99.7, 99.9) - 2.0).abs() < 1e-9);
+}
+
+#[test]
+fn an_unmeetable_objective_says_so_rather_than_dividing_by_zero() {
+    // A 100% target leaves no budget. The .ts divides straight through and gets
+    // Infinity by accident; here it is deliberate, so a caller can notice the
+    // objective was probably a mistake.
+    assert_eq!(burn_rate(99.9, 100.0), f64::INFINITY);
+    assert_eq!(burn_rate(100.0, 100.0), 0.0);
+}
+
+#[test]
+fn one_breach_reaches_exactly_one_rung() {
+    // THE BUG THIS PORT FIXES. The .ts fires once per matching tier, so a burn
+    // rate of 6 against this ladder produced three alerts — and one of them
+    // pages a human, three times, for a single breach.
+    assert_eq!(
+        escalate_to(&ladder(), 6.0).map(|e| e.severity),
+        Some(AlertSeverity::Page)
+    );
+    assert_eq!(
+        escalate_to(&ladder(), 2.5).map(|e| e.severity),
+        Some(AlertSeverity::Critical)
+    );
+    assert_eq!(
+        escalate_to(&ladder(), 1.0).map(|e| e.severity),
+        Some(AlertSeverity::Warning)
+    );
+    assert_eq!(escalate_to(&ladder(), 0.5), None);
+}
+
+#[test]
+fn rung_order_in_the_ladder_does_not_change_the_answer() {
+    // A caller should not have to sort their config for it to behave.
+    let mut reversed = ladder();
+    reversed.reverse();
+    assert_eq!(
+        escalate_to(&reversed, 6.0).map(|e| e.severity),
+        escalate_to(&ladder(), 6.0).map(|e| e.severity)
+    );
+}
+
+#[test]
+fn a_tie_breaks_toward_the_louder_severity() {
+    // Under-alerting a breach is the worse error.
+    let tied = vec![
+        Escalation {
+            burn_rate: 2.0,
+            severity: AlertSeverity::Warning,
+        },
+        Escalation {
+            burn_rate: 2.0,
+            severity: AlertSeverity::Page,
+        },
+    ];
+    assert_eq!(
+        escalate_to(&tied, 3.0).map(|e| e.severity),
+        Some(AlertSeverity::Page)
+    );
+}
+
+#[test]
+fn evaluating_an_slo_yields_at_most_one_alert() {
+    assert!(evaluate_slo(&slo(), 99.95, "a1", 1000.0).is_none());
+    let alert = evaluate_slo(&slo(), 99.4, "a1", 1000.0).expect("breached");
+    assert_eq!(alert.severity, AlertSeverity::Page);
+    assert_eq!(alert.state, AlertState::Firing);
+    assert_eq!(alert.slo_id.as_deref(), Some("api-availability"));
+    assert_eq!(alert.affected_mini_apps, vec!["wallet".to_owned()]);
+    assert!(
+        alert
+            .runbook_url
+            .as_deref()
+            .is_some_and(|u| u.ends_with("api-availability"))
+    );
+}
+
+#[test]
+fn a_displaced_alert_is_returned_rather_than_silently_destroyed() {
+    // With the .ts's colliding `alert-${Date.now()}` ids this quietly dropped
+    // alerts. A caller that ignores the return value at least had the chance not
+    // to.
+    let mut log = AlertLog::new();
+    let first = evaluate_slo(&slo(), 99.4, "same-id", 1000.0).expect("breached");
+    let second = evaluate_slo(&slo(), 99.0, "same-id", 2000.0).expect("breached");
+    assert!(log.fire(first.clone()).is_none());
+    assert_eq!(
+        log.fire(second).as_ref().map(|a| a.fired_at_ms),
+        Some(1000.0)
+    );
+    assert_eq!(log.len(), 1);
+}
+
+#[test]
+fn resolving_moves_an_alert_out_of_active() {
+    let mut log = AlertLog::new();
+    log.fire(evaluate_slo(&slo(), 99.4, "a1", 1000.0).expect("breached"));
+    assert_eq!(log.active().len(), 1);
+    assert!(log.resolve("a1", 5000.0));
+    assert!(log.active().is_empty());
+    assert_eq!(log.all().len(), 1, "resolved alerts stay in the record");
+    assert!(!log.resolve("nope", 1.0), "an unknown id reports failure");
+}
+
+#[test]
+fn severity_and_state_keep_their_typescript_spellings() {
+    let ts = fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../components/registry/n8-assurance/mzizi-alert-engine.ts"),
+    )
+    .expect("the alert-engine TypeScript sibling");
+    for s in [
+        AlertSeverity::Info,
+        AlertSeverity::Warning,
+        AlertSeverity::Critical,
+        AlertSeverity::Page,
+    ] {
+        assert!(
+            ts.contains(&format!("\"{}\"", s.as_str())),
+            "severity {} missing",
+            s.as_str()
+        );
+    }
+    for s in [
+        AlertState::Firing,
+        AlertState::Pending,
+        AlertState::Resolved,
+    ] {
+        assert!(
+            ts.contains(&format!("\"{}\"", s.as_str())),
+            "state {} missing",
+            s.as_str()
+        );
+    }
+    for m in [
+        SloMetric::Availability,
+        SloMetric::LatencyP99,
+        SloMetric::ErrorRate,
+        SloMetric::SuccessRate,
+    ] {
+        assert!(
+            ts.contains(&format!("\"{}\"", m.as_str())),
+            "metric {} missing",
+            m.as_str()
+        );
+    }
+    assert!(
+        ts.contains("mzizi.dev/runbooks/"),
+        "runbook URL shape drifted"
+    );
+}
+
+#[test]
+fn an_alert_is_constructible_without_a_dom() {
+    // affectedComponents falls back to document.querySelectorAll in the .ts.
+    // A Worker and a native shell have no document, so the core takes the list.
+    let alert = Alert {
+        affected_components: vec!["button".to_owned()],
+        ..evaluate_slo(&slo(), 99.4, "a1", 1000.0).expect("breached")
+    };
+    assert_eq!(alert.affected_components, vec!["button".to_owned()]);
+}

--- a/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
+++ b/mzizi-rs/crates/mzizi-assurance/tests/contract.rs
@@ -3076,3 +3076,333 @@ fn the_status_labels_and_colour_variables_match_the_tsx() {
          that this comment needs deleting too"
     );
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// rtl-conformity-check — the rule that did not count, and the one that never ran
+// ═══════════════════════════════════════════════════════════════════════════
+
+use mzizi_assurance::rtl_conformity_check::{
+    Direction, NON_MIRRORING_ICONS, ObservedNode as RtlNode, PHYSICAL_PROPERTIES, RtlConfig,
+    RtlLevel, RtlRule, audit as rtl_audit, check_node as rtl_check_node, has_bidi_chars,
+    is_directional, is_non_mirroring, worst_level as rtl_worst_level,
+};
+
+fn rtl_ts() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../components/registry/n8-assurance/rtl-conformity-check.tsx");
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read the TypeScript sibling at {path:?}: {e}"))
+}
+
+fn rtl_node(tag: &str) -> RtlNode {
+    RtlNode {
+        tag_name: tag.to_owned(),
+        ..RtlNode::default()
+    }
+}
+
+fn styled(tag: &str, property: &str, value: &str) -> RtlNode {
+    let mut node = rtl_node(tag);
+    node.inline_styles
+        .insert(property.to_owned(), value.to_owned());
+    node
+}
+
+fn rtl_registry() -> BTreeMap<String, u32> {
+    BTreeMap::new()
+}
+
+#[test]
+fn a_missing_dir_attribute_actually_lowers_the_score() {
+    // THE RULE THAT DID NOT COUNT. `direction-attribute` is pushed after the
+    // element loop and `passes` only ever moves inside it, so a page whose sole
+    // defect is that RTL does not work at all scored 100 — and it is the most
+    // serious finding the check can produce.
+    let clean = vec![rtl_node("P"), rtl_node("DIV")];
+
+    let no_dir = rtl_audit("/", None, &clean, &RtlConfig::default(), &rtl_registry());
+    assert_eq!(no_dir.violations.len(), 1);
+    assert_eq!(no_dir.violations[0].rule, RtlRule::DirectionAttribute);
+    assert_eq!(no_dir.violations[0].level, RtlLevel::Serious);
+    assert!(no_dir.score < 100, "score was {}", no_dir.score);
+    assert_eq!(
+        no_dir.score, 67,
+        "two elements pass, the document check does not"
+    );
+
+    let with_dir = rtl_audit(
+        "/",
+        Some(Direction::Ltr),
+        &clean,
+        &RtlConfig::default(),
+        &rtl_registry(),
+    );
+    assert!(with_dir.violations.is_empty());
+    assert_eq!(with_dir.score, 100);
+    assert_eq!(with_dir.direction, Some(Direction::Ltr));
+}
+
+#[test]
+fn dir_ltr_is_a_deliberate_answer_and_an_absent_dir_is_not() {
+    // The .ts collapses both to "ltr" with `?? "ltr"`, so a page that declares
+    // its direction and a page that says nothing report identically.
+    assert_eq!(Direction::parse("rtl"), Some(Direction::Rtl));
+    assert_eq!(Direction::parse("LTR"), Some(Direction::Ltr));
+    assert_eq!(Direction::parse("auto"), Some(Direction::Auto));
+    assert_eq!(Direction::parse("sideways"), None);
+}
+
+#[test]
+fn the_icon_rule_runs_on_the_ltr_build_too() {
+    // The .ts gates it on `docDir === "rtl"`, so the check that finds icons
+    // needing mirroring never fires on the build almost everyone audits. And
+    // whether a chevron carries a mirroring hint is a property of the ICON, not
+    // of the render you happen to be looking at.
+    let mut chevron = rtl_node("SVG");
+    chevron.data_slot = Some("chevron-right-icon".to_owned());
+
+    for direction in [Direction::Ltr, Direction::Rtl, Direction::Auto] {
+        let result = rtl_audit(
+            "/",
+            Some(direction),
+            std::slice::from_ref(&chevron),
+            &RtlConfig::default(),
+            &rtl_registry(),
+        );
+        assert_eq!(
+            result.violations.len(),
+            1,
+            "the icon rule must not depend on {}",
+            direction.as_str()
+        );
+        assert_eq!(result.violations[0].rule, RtlRule::IconMirroring);
+    }
+
+    assert!(
+        rtl_ts().contains("docDir === \"rtl\""),
+        "the .tsx still gates the icon rule on the current direction"
+    );
+}
+
+#[test]
+fn a_mirroring_hint_settles_the_question() {
+    let mut hinted = rtl_node("SVG");
+    hinted.data_slot = Some("arrow-left-icon".to_owned());
+    hinted.rtl_mirror_hint = Some("true".to_owned());
+    assert!(rtl_check_node(&hinted, &RtlConfig::default(), &rtl_registry()).is_empty());
+
+    let mut transformed = rtl_node("SVG");
+    transformed.data_slot = Some("arrow-left-icon".to_owned());
+    transformed
+        .inline_styles
+        .insert("transform".to_owned(), "scaleX(-1)".to_owned());
+    assert!(rtl_check_node(&transformed, &RtlConfig::default(), &rtl_registry()).is_empty());
+}
+
+#[test]
+fn icon_names_are_matched_by_segment_not_by_substring() {
+    // "research-icon".includes("search-icon") is TRUE, so the .ts exempts a
+    // research icon from mirroring using the magnifying glass's entry. And
+    // isDirectionalIcon matches "back", so background-icon is reported as a
+    // directional icon needing mirroring.
+    let non_mirroring: BTreeSet<String> = NON_MIRRORING_ICONS
+        .iter()
+        .map(|s| (*s).to_owned())
+        .collect();
+
+    assert!(is_non_mirroring("search-icon", &non_mirroring));
+    assert!(
+        is_non_mirroring("icon-search", &non_mirroring),
+        "order-free"
+    );
+    assert!(
+        !is_non_mirroring("research-icon", &non_mirroring),
+        "research is not search"
+    );
+
+    assert!(is_directional("arrow-left-icon"));
+    assert!(is_directional("chevron-right"));
+    assert!(!is_directional("background-icon"), "background is not back");
+    assert!(!is_directional("legend-icon"));
+
+    // And the two compose the way the rule needs: a background icon produces
+    // nothing at all.
+    let mut background = rtl_node("SVG");
+    background.data_slot = Some("background-icon".to_owned());
+    assert!(rtl_check_node(&background, &RtlConfig::default(), &rtl_registry()).is_empty());
+}
+
+#[test]
+fn bidi_detection_covers_the_blocks_real_arabic_arrives_in() {
+    // The .ts range list stops after the base blocks, so Arabic Supplement,
+    // Arabic Extended-A and — the big one — the Presentation Forms all read as
+    // non-bidi. Presentation forms are where a great deal of real-world Arabic
+    // arrives, particularly out of PDFs and older systems, so the rule passed
+    // exactly the content most likely to need it.
+    assert!(has_bidi_chars("مرحبا"), "base Arabic");
+    assert!(has_bidi_chars("שלום"), "Hebrew");
+    assert!(has_bidi_chars("\u{FEF0}"), "Arabic Presentation Forms-B");
+    assert!(has_bidi_chars("\u{FB50}"), "Arabic Presentation Forms-A");
+    assert!(has_bidi_chars("\u{FB2A}"), "Hebrew Presentation Forms");
+    assert!(has_bidi_chars("\u{0750}"), "Arabic Supplement");
+    assert!(has_bidi_chars("\u{08A0}"), "Arabic Extended-A");
+    assert!(!has_bidi_chars("hello world"));
+    assert!(!has_bidi_chars("你好"), "CJK is not bidi");
+
+    assert!(
+        !rtl_ts().contains("FB50"),
+        "the .tsx still omits the presentation forms"
+    );
+}
+
+#[test]
+fn bidi_prose_without_lang_or_dir_is_reported_once() {
+    let mut bare = rtl_node("P");
+    bare.text = Some("مرحبا بالعالم".to_owned());
+    let found = rtl_check_node(&bare, &RtlConfig::default(), &rtl_registry());
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].rule, RtlRule::BidiText);
+    assert_eq!(found[0].level, RtlLevel::Moderate);
+
+    // Either attribute settles it.
+    let mut with_lang = bare.clone();
+    with_lang.lang = Some("ar".to_owned());
+    assert!(rtl_check_node(&with_lang, &RtlConfig::default(), &rtl_registry()).is_empty());
+
+    let mut with_dir = bare.clone();
+    with_dir.dir = Some("auto".to_owned());
+    assert!(rtl_check_node(&with_dir, &RtlConfig::default(), &rtl_registry()).is_empty());
+
+    // A tag that does not carry prose is not asked.
+    let mut heading = bare.clone();
+    heading.tag_name = "H1".to_owned();
+    assert!(rtl_check_node(&heading, &RtlConfig::default(), &rtl_registry()).is_empty());
+}
+
+#[test]
+fn every_physical_property_on_one_element_is_reported() {
+    // Not just the first: twelve wrong properties on one element are twelve
+    // edits, and the .ts gets this one right.
+    let mut node = rtl_node("DIV");
+    node.inline_styles
+        .insert("margin-left".to_owned(), "8px".to_owned());
+    node.inline_styles
+        .insert("padding-right".to_owned(), "4px".to_owned());
+    node.inline_styles
+        .insert("border-top-left-radius".to_owned(), "7px".to_owned());
+    // A logical property is fine and must not be flagged.
+    node.inline_styles
+        .insert("margin-inline-start".to_owned(), "8px".to_owned());
+
+    let found = rtl_check_node(&node, &RtlConfig::default(), &rtl_registry());
+    assert_eq!(found.len(), 3);
+    assert!(found.iter().all(|v| v.rule == RtlRule::LogicalProperties));
+    assert!(found.iter().all(|v| v.level == RtlLevel::Serious));
+    assert!(found[0].fix.contains("logical counterpart"));
+
+    // An empty value is not a declaration.
+    let blank = styled("DIV", "margin-left", "  ");
+    assert!(rtl_check_node(&blank, &RtlConfig::default(), &rtl_registry()).is_empty());
+}
+
+#[test]
+fn physical_text_alignment_is_reported_with_its_logical_replacement() {
+    let left = styled("P", "text-align", "left");
+    let found = rtl_check_node(&left, &RtlConfig::default(), &rtl_registry());
+    assert_eq!(found[0].rule, RtlRule::TextAlignment);
+    assert!(found[0].fix.contains("text-align: start"));
+
+    let right = styled("P", "text-align", "right");
+    assert!(
+        rtl_check_node(&right, &RtlConfig::default(), &rtl_registry())[0]
+            .fix
+            .contains("text-align: end")
+    );
+
+    // Logical values are already correct.
+    for value in ["start", "end", "center"] {
+        let ok = styled("P", "text-align", value);
+        assert!(
+            rtl_check_node(&ok, &RtlConfig::default(), &rtl_registry()).is_empty(),
+            "text-align: {value} is not physical"
+        );
+    }
+}
+
+#[test]
+fn the_rule_set_has_one_home() {
+    // The .ts writes the rule names twice — once in the type union and once in
+    // the runtime default array — so adding a rule to one and not the other is a
+    // silently disabled rule.
+    let all = RtlRule::all();
+    assert_eq!(all.len(), 5);
+    let ts = rtl_ts();
+    for rule in &all {
+        assert!(
+            ts.contains(&format!("\"{}\"", rule.as_str())),
+            "rule {}",
+            rule.as_str()
+        );
+    }
+
+    let only_alignment = RtlConfig {
+        rules: Some([RtlRule::TextAlignment].into_iter().collect()),
+        ..RtlConfig::default()
+    };
+    let left = styled("P", "text-align", "left");
+    assert_eq!(
+        rtl_check_node(&left, &only_alignment, &rtl_registry()).len(),
+        1
+    );
+
+    // And with direction-attribute disabled, a missing dir is not a finding and
+    // the denominator does not include it.
+    let result = rtl_audit(
+        "/",
+        None,
+        &[rtl_node("P")],
+        &only_alignment,
+        &rtl_registry(),
+    );
+    assert!(result.violations.is_empty());
+    assert_eq!(result.score, 100);
+}
+
+#[test]
+fn the_physical_property_list_matches_the_tsx() {
+    let ts = rtl_ts();
+    for property in PHYSICAL_PROPERTIES {
+        assert!(
+            ts.contains(&format!("\"{property}\"")),
+            "property {property}"
+        );
+    }
+    for icon in NON_MIRRORING_ICONS {
+        assert!(ts.contains(&format!("\"{icon}\"")), "non-mirroring {icon}");
+    }
+    for level in [
+        RtlLevel::Critical,
+        RtlLevel::Serious,
+        RtlLevel::Moderate,
+        RtlLevel::Minor,
+    ] {
+        assert!(
+            ts.contains(&format!("\"{}\"", level.as_str())),
+            "level {}",
+            level.as_str()
+        );
+    }
+}
+
+#[test]
+fn the_worst_level_is_the_go_no_go_answer() {
+    let result = rtl_audit(
+        "/",
+        None,
+        &[styled("P", "text-align", "left")],
+        &RtlConfig::default(),
+        &rtl_registry(),
+    );
+    assert_eq!(rtl_worst_level(&result.violations), Some(RtlLevel::Serious));
+    assert_eq!(rtl_worst_level(&[]), None);
+}

--- a/mzizi-rs/crates/mzizi-fundi/Cargo.toml
+++ b/mzizi-rs/crates/mzizi-fundi/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "mzizi-fundi"
+description = "Mzizi N9 fundi — the self-healing rung: turning assurance signals into filed defects."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[lints]
+workspace = true
+
+# No dependencies, and no HTTP client in particular. N9's Rust position is
+# `edge-worker` (workers-rs), and a Worker already has `fetch` — so this crate
+# builds the issue and the host files it, exactly as N8 builds the OTLP request
+# and the host sends it.
+[dependencies]

--- a/mzizi-rs/crates/mzizi-fundi/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-fundi/src/lib.rs
@@ -1,0 +1,26 @@
+//! Mzizi N9 fundi for Rust — "failure is a learning event, not a user-facing
+//! incident."
+//!
+//! # Where the components are
+//!
+//! Not in this crate's `src/`. Each is a file under
+//! `components/registry/n9-fundi/<name>.rs`, beside the `.ts` implementing the
+//! same contract for a JavaScript host, and this module `#[path]`-includes it.
+//!
+//! # What is here, and what is emphatically not
+//!
+//! This crate holds the **client-side** rung: deciding whether a failure is worth
+//! filing, shaping the issue, and learning which fixes have worked before. It is
+//! what a consumer app installs so its own failures reach a tracker.
+//!
+//! The **healing loop itself** — the cron pass, the webhook ingest, the GitHub
+//! automation — is the `fundi-tester` Worker in `nyuchi/mzizi-tools`, and it is
+//! still TypeScript. Converting these registry components does not move it, and
+//! saying so matters because `CLAUDE.md` §17 diagrams a loop ending in a draft
+//! pull request while `heal.ts` files issues and `github.ts` has no
+//! pull-request code at all.
+//!
+//! So: N9's registry surface is Rust as of this crate. N9's worker is not.
+
+#[path = "../../../../components/registry/n9-fundi/nyuchi-fundi-reporter.rs"]
+pub mod nyuchi_fundi_reporter;

--- a/mzizi-rs/crates/mzizi-fundi/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-fundi/src/lib.rs
@@ -22,6 +22,9 @@
 //!
 //! So: N9's registry surface is Rust as of this crate. N9's worker is not.
 
+#[path = "../../../../components/registry/n9-fundi/nyuchi-fundi.rs"]
+pub mod nyuchi_fundi;
+
 #[path = "../../../../components/registry/n9-fundi/nyuchi-fundi-learning.rs"]
 pub mod nyuchi_fundi_learning;
 

--- a/mzizi-rs/crates/mzizi-fundi/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-fundi/src/lib.rs
@@ -22,5 +22,8 @@
 //!
 //! So: N9's registry surface is Rust as of this crate. N9's worker is not.
 
+#[path = "../../../../components/registry/n9-fundi/nyuchi-fundi-learning.rs"]
+pub mod nyuchi_fundi_learning;
+
 #[path = "../../../../components/registry/n9-fundi/nyuchi-fundi-reporter.rs"]
 pub mod nyuchi_fundi_reporter;

--- a/mzizi-rs/crates/mzizi-fundi/tests/contract.rs
+++ b/mzizi-rs/crates/mzizi-fundi/tests/contract.rs
@@ -469,3 +469,496 @@ fn learning_keeps_its_typescript_spellings_and_limits() {
     assert_eq!(stats.top_failing_components.len(), 10);
     assert_eq!(stats.top_error_types.len(), 5);
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// nyuchi-fundi — the approval that did not hold, and the auth rule that only
+// applied to the narrowest case
+// ═══════════════════════════════════════════════════════════════════════════
+
+// `ErrorType` is aliased: nyuchi-fundi-reporter declares one too, with FOUR
+// members the healing engine does not have (a11y, perf, conformity, slo). So
+// the reporter can file a defect the engine has no branch for — recorded in
+// `the_two_halves_of_the_rung_do_not_share_an_error_vocabulary` below rather
+// than papered over by renaming a published type.
+use mzizi_fundi::nyuchi_fundi::{
+    ActionOutcome, Approval, BlastRadius, DiagnosticInput, ErrorType as HealErrorType,
+    EscalationSeverity, ProbeStatus, ProbeSummary, REPEAT_ERROR_THRESHOLD, REPEAT_ERROR_WINDOW_MS,
+    RemediationAction, action_tally, create_healing_plan, plan_outcome,
+};
+
+fn fundi_ts() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../components/registry/n9-fundi/nyuchi-fundi.tsx");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read the TypeScript sibling at {path:?}: {e}"))
+}
+
+const NOW: f64 = 1_786_158_000_000.0;
+
+fn diagnostic(blast_radius: BlastRadius, error_type: HealErrorType) -> DiagnosticInput {
+    DiagnosticInput {
+        blast_radius,
+        failed_component: "nyuchi-wallet-card".to_owned(),
+        failed_node: 3,
+        error_type,
+        error_count: 1,
+        time_since_first_error_ms: 1_000.0,
+        probe_results: Vec::new(),
+    }
+}
+
+#[test]
+fn auth_is_never_auto_fixed_at_any_blast_radius() {
+    // THE RULE THAT ONLY APPLIED TO THE NARROWEST CASE. The .ts puts the auth
+    // branch inside the `else` that handles ISOLATED failures, so a partial or
+    // systemic auth failure never reaches "never auto-fix auth" — it gets
+    // degrade-feature and reroute instead. The rule the file states as
+    // inviolable applied exactly when the failure was smallest.
+    for radius in [
+        BlastRadius::Isolated,
+        BlastRadius::Partial,
+        BlastRadius::Systemic,
+        BlastRadius::Unknown,
+    ] {
+        let plan = create_healing_plan("plan-1", diagnostic(radius, HealErrorType::Auth), NOW);
+        assert_eq!(
+            plan.approval,
+            Approval::Required,
+            "auth at {} radius must wait for a person",
+            radius.as_str()
+        );
+        assert!(
+            plan.actions
+                .iter()
+                .all(RemediationAction::is_notification_only),
+            "auth at {} radius must change nothing by itself: {:?}",
+            radius.as_str(),
+            plan.actions
+        );
+    }
+
+    assert!(
+        fundi_ts().contains("never auto-fix auth"),
+        "the .tsx still states the rule it applies only when isolated"
+    );
+    assert!(HealErrorType::Auth.is_never_auto_fixed());
+    assert!(!HealErrorType::Network.is_never_auto_fixed());
+}
+
+#[test]
+fn a_systemic_auth_failure_escalates_more_loudly() {
+    let plan = create_healing_plan(
+        "plan-1",
+        diagnostic(BlastRadius::Systemic, HealErrorType::Auth),
+        NOW,
+    );
+    let severity = plan.actions.iter().find_map(|a| match a {
+        RemediationAction::Escalate { severity, .. } => Some(*severity),
+        _ => None,
+    });
+    assert_eq!(severity, Some(EscalationSeverity::Critical));
+
+    let isolated = create_healing_plan(
+        "plan-2",
+        diagnostic(BlastRadius::Isolated, HealErrorType::Auth),
+        NOW,
+    );
+    let severity = isolated.actions.iter().find_map(|a| match a {
+        RemediationAction::Escalate { severity, .. } => Some(*severity),
+        _ => None,
+    });
+    assert_eq!(severity, Some(EscalationSeverity::High));
+}
+
+#[test]
+fn requiring_approval_actually_withholds_the_actions() {
+    // THE GATE THAT DID NOT HOLD. FundiProvider defaults autoHeal = true and the
+    // check reads `if (plan.requiresHumanApproval && !autoHeal)`, so the flag
+    // meaning "a person must look at this" is overridden by a convenience flag
+    // that is on unless somebody turns it off. A systemic plan disabled
+    // non-critical features automatically while declaring that it should not.
+    let mut plan = create_healing_plan(
+        "plan-1",
+        diagnostic(BlastRadius::Systemic, HealErrorType::Render),
+        NOW,
+    );
+    assert_eq!(plan.approval, Approval::Required);
+    assert!(plan.is_held());
+
+    let runnable = plan.may_execute();
+    assert!(
+        runnable.iter().all(|a| a.is_notification_only()),
+        "only the page goes out: {runnable:?}"
+    );
+    assert!(
+        plan.actions
+            .iter()
+            .any(|a| matches!(a, RemediationAction::DegradeFeature { .. })),
+        "the degrade action is still IN the plan — held, not dropped"
+    );
+
+    plan.grant_approval();
+    assert_eq!(plan.approval, Approval::Granted);
+    assert_eq!(plan.may_execute().len(), plan.actions.len());
+    assert!(!plan.is_held());
+
+    assert!(
+        fundi_ts().contains("autoHeal = true"),
+        "the .tsx still defaults the override on"
+    );
+}
+
+#[test]
+fn a_held_plan_still_pages_the_person_who_must_approve_it() {
+    // Withholding the escalation would deadlock the gate it enforces: the page is
+    // how the human who must approve learns there is something to approve.
+    let plan = create_healing_plan(
+        "plan-1",
+        diagnostic(BlastRadius::Systemic, HealErrorType::Render),
+        NOW,
+    );
+    assert!(
+        plan.may_execute()
+            .iter()
+            .any(|a| matches!(a, RemediationAction::Escalate { .. })),
+        "the escalation is not held"
+    );
+}
+
+#[test]
+fn a_plan_that_needs_no_approval_runs_in_full() {
+    let plan = create_healing_plan(
+        "plan-1",
+        diagnostic(BlastRadius::Isolated, HealErrorType::Network),
+        NOW,
+    );
+    assert_eq!(plan.approval, Approval::NotRequired);
+    assert!(!plan.is_held());
+    assert_eq!(plan.may_execute().len(), plan.actions.len());
+    assert_eq!(plan.actions.len(), 2, "retry and fallback");
+}
+
+#[test]
+fn chain_and_crypto_fall_back_at_any_blast_radius() {
+    // Same `else` as auth, same hole: a systemic chain failure was rerouted
+    // rather than falling back to the Web2 path.
+    for error_type in [HealErrorType::Chain, HealErrorType::Crypto] {
+        for radius in [
+            BlastRadius::Isolated,
+            BlastRadius::Partial,
+            BlastRadius::Systemic,
+        ] {
+            let plan = create_healing_plan("plan-1", diagnostic(radius, error_type), NOW);
+            assert!(
+                plan.actions.iter().any(|a| matches!(
+                    a,
+                    RemediationAction::FallbackSwitch { from, to }
+                        if from == "web3" && to == "web2"
+                )),
+                "{} at {} radius must fall back to web2",
+                error_type.as_str(),
+                radius.as_str()
+            );
+        }
+    }
+}
+
+#[test]
+fn an_unknown_blast_radius_is_not_treated_as_isolated() {
+    // mzizi-chaos answers `unknown` when nothing was probed, and the two halves
+    // of one loop have to share a vocabulary. The .ts union has no such member,
+    // so its `else` would treat it as isolated — the calmest response, chosen at
+    // the moment the least is known.
+    let plan = create_healing_plan(
+        "plan-1",
+        diagnostic(BlastRadius::Unknown, HealErrorType::Render),
+        NOW,
+    );
+    assert_eq!(plan.approval, Approval::Required);
+    assert!(
+        plan.actions
+            .iter()
+            .all(RemediationAction::is_notification_only),
+        "no remediation is chosen on the strength of an unprobed diagnosis"
+    );
+    assert!(plan.reasoning.contains("Blast radius unknown"));
+    assert!(plan.confidence < 0.5, "and it says so in the number too");
+
+    assert!(
+        !fundi_ts().contains("\"unknown\""),
+        "the .tsx union still has no representation for it"
+    );
+}
+
+#[test]
+fn the_reroute_target_does_not_depend_on_probe_ordering() {
+    // healthyNodes[0] takes whichever healthy probe came back first, so two runs
+    // over the same set can reroute to different targets and neither is
+    // reproducible.
+    let mut one = diagnostic(BlastRadius::Partial, HealErrorType::Network);
+    one.probe_results = vec![
+        ProbeSummary {
+            target: "search".to_owned(),
+            status: ProbeStatus::Healthy,
+        },
+        ProbeSummary {
+            target: "auth".to_owned(),
+            status: ProbeStatus::Healthy,
+        },
+    ];
+    let mut reversed = one.clone();
+    reversed.probe_results.reverse();
+
+    let target = |input: DiagnosticInput| {
+        create_healing_plan("plan-1", input, NOW)
+            .actions
+            .iter()
+            .find_map(|a| match a {
+                RemediationAction::Reroute { to_node, .. } => Some(to_node.clone()),
+                _ => None,
+            })
+    };
+    assert_eq!(target(one), Some("auth".to_owned()));
+    assert_eq!(
+        target(reversed),
+        Some("auth".to_owned()),
+        "the same probe set must choose the same target"
+    );
+}
+
+#[test]
+fn a_partial_failure_with_no_healthy_node_does_not_reroute_into_the_void() {
+    let mut input = diagnostic(BlastRadius::Partial, HealErrorType::Network);
+    input.probe_results = vec![ProbeSummary {
+        target: "search".to_owned(),
+        status: ProbeStatus::Error,
+    }];
+    let plan = create_healing_plan("plan-1", input, NOW);
+    assert!(
+        !plan
+            .actions
+            .iter()
+            .any(|a| matches!(a, RemediationAction::Reroute { .. }))
+    );
+    assert!(
+        plan.actions
+            .iter()
+            .any(|a| matches!(a, RemediationAction::DegradeFeature { .. }))
+    );
+}
+
+#[test]
+fn repeated_failures_trip_the_breaker_whatever_else_is_true() {
+    let mut input = diagnostic(BlastRadius::Isolated, HealErrorType::Render);
+    input.error_count = REPEAT_ERROR_THRESHOLD + 1;
+    input.time_since_first_error_ms = REPEAT_ERROR_WINDOW_MS - 1.0;
+    let plan = create_healing_plan("plan-1", input.clone(), NOW);
+    assert!(
+        plan.actions
+            .iter()
+            .any(|a| matches!(a, RemediationAction::CircuitBreak { .. }))
+    );
+
+    // At the threshold, not over it.
+    let mut at_threshold = input.clone();
+    at_threshold.error_count = REPEAT_ERROR_THRESHOLD;
+    assert!(
+        !create_healing_plan("plan-2", at_threshold, NOW)
+            .actions
+            .iter()
+            .any(|a| matches!(a, RemediationAction::CircuitBreak { .. })),
+        "the .ts uses > 3, not >= 3"
+    );
+
+    // Outside the window.
+    let mut stale = input;
+    stale.time_since_first_error_ms = REPEAT_ERROR_WINDOW_MS;
+    assert!(
+        !create_healing_plan("plan-3", stale, NOW)
+            .actions
+            .iter()
+            .any(|a| matches!(a, RemediationAction::CircuitBreak { .. }))
+    );
+
+    assert!(
+        fundi_ts().contains("input.errorCount > 3 && input.timeSinceFirstError < 60000"),
+        "the repeat-failure threshold drifted from the sibling"
+    );
+}
+
+#[test]
+fn a_held_action_is_counted_as_held_not_as_never_happened() {
+    // The .ts either ran a plan in full or returned null, so afterwards "held for
+    // approval" and "nothing happened" were indistinguishable.
+    let plan = create_healing_plan(
+        "plan-1",
+        diagnostic(BlastRadius::Systemic, HealErrorType::Render),
+        NOW,
+    );
+    let ran: Vec<ActionOutcome> = plan
+        .may_execute()
+        .into_iter()
+        .map(|action| ActionOutcome {
+            action: action.clone(),
+            success: true,
+            error: None,
+        })
+        .collect();
+
+    let result = plan_outcome(&plan, ran, NOW + 5.0);
+    assert_eq!(result.plan_id, "plan-1");
+    assert_eq!(result.actions_executed, 1, "the escalation");
+    assert_eq!(result.actions_failed, 0);
+    assert_eq!(result.actions_held, 1, "the degrade waited");
+}
+
+#[test]
+fn a_failed_action_does_not_block_the_count_of_the_rest() {
+    let plan = create_healing_plan(
+        "plan-1",
+        diagnostic(BlastRadius::Isolated, HealErrorType::Network),
+        NOW,
+    );
+    let outcomes = vec![
+        ActionOutcome {
+            action: plan.actions[0].clone(),
+            success: false,
+            error: Some("no executor registered".to_owned()),
+        },
+        ActionOutcome {
+            action: plan.actions[1].clone(),
+            success: true,
+            error: None,
+        },
+    ];
+    let result = plan_outcome(&plan, outcomes, NOW + 5.0);
+    assert_eq!(result.actions_executed, 1);
+    assert_eq!(result.actions_failed, 1);
+    assert_eq!(result.actions_held, 0);
+}
+
+#[test]
+fn a_node_number_in_a_plan_is_uncapped() {
+    let mut input = diagnostic(BlastRadius::Systemic, HealErrorType::Render);
+    input.failed_node = 12;
+    let plan = create_healing_plan("plan-1", input, NOW);
+    assert!(plan.actions.iter().any(|a| matches!(
+        a,
+        RemediationAction::Escalate { message, .. } if message.contains("N12")
+    )));
+}
+
+#[test]
+fn the_action_types_and_enums_match_the_typescript() {
+    // A renamed action type is an executor a host silently never matches.
+    let ts = fundi_ts();
+    for action in [
+        RemediationAction::CircuitBreak {
+            service: String::new(),
+            duration_ms: 0,
+        },
+        RemediationAction::FallbackSwitch {
+            from: String::new(),
+            to: String::new(),
+        },
+        RemediationAction::CacheClear {
+            scope: mzizi_fundi::nyuchi_fundi::CacheScope::Local,
+        },
+        RemediationAction::Reroute {
+            from_node: String::new(),
+            to_node: String::new(),
+        },
+        RemediationAction::RetryWithBackoff {
+            service: String::new(),
+            max_retries: 0,
+        },
+        RemediationAction::DegradeFeature {
+            feature: String::new(),
+            level: mzizi_fundi::nyuchi_fundi::DegradeLevel::Partial,
+        },
+        RemediationAction::ScaleRequest {
+            up: true,
+            resource: String::new(),
+        },
+        RemediationAction::Escalate {
+            severity: EscalationSeverity::Low,
+            message: String::new(),
+        },
+    ] {
+        assert!(
+            ts.contains(&format!("type: \"{}\"", action.type_str())),
+            "action type {}",
+            action.type_str()
+        );
+    }
+    for error_type in [
+        HealErrorType::Render,
+        HealErrorType::Network,
+        HealErrorType::Data,
+        HealErrorType::Auth,
+        HealErrorType::Chain,
+        HealErrorType::Crypto,
+        HealErrorType::Timeout,
+    ] {
+        assert!(
+            ts.contains(&format!("\"{}\"", error_type.as_str())),
+            "error type {}",
+            error_type.as_str()
+        );
+    }
+}
+
+#[test]
+fn a_tally_summarises_a_plan_without_reading_its_prose() {
+    let plan = create_healing_plan(
+        "plan-1",
+        diagnostic(BlastRadius::Isolated, HealErrorType::Data),
+        NOW,
+    );
+    let tally = action_tally(&plan);
+    assert_eq!(tally.get("cache-clear"), Some(&1));
+    assert_eq!(tally.get("retry-with-backoff"), Some(&1));
+    assert_eq!(tally.get("escalate"), None);
+}
+
+#[test]
+fn the_two_halves_of_the_rung_do_not_share_an_error_vocabulary() {
+    // nyuchi-fundi-reporter declares eleven error types and the healing engine
+    // declares seven. The four the reporter has and the engine does not — a11y,
+    // perf, conformity, slo — are precisely the ones N8 assurance produces:
+    // mzizi-a11y-audit, mzizi-perf-probe, mzizi-conformity-check and the SLO
+    // half of mzizi-alert-engine. So the rung can FILE every one of them and can
+    // PLAN for none of them.
+    //
+    // Not fixed here, deliberately. Widening the engine's union means inventing
+    // a remediation for each — what does fundi automatically do about a failing
+    // contrast ratio? — and inventing one badly is worse than having none. What
+    // is not acceptable is the mismatch being invisible, so this spec is the
+    // record, and it fails the moment either side changes.
+    let reporter_only = ["a11y", "perf", "conformity", "slo"];
+    let engine: Vec<&str> = [
+        HealErrorType::Render,
+        HealErrorType::Network,
+        HealErrorType::Data,
+        HealErrorType::Auth,
+        HealErrorType::Chain,
+        HealErrorType::Crypto,
+        HealErrorType::Timeout,
+    ]
+    .iter()
+    .map(|e| e.as_str())
+    .collect();
+
+    for kind in reporter_only {
+        assert!(
+            !engine.contains(&kind),
+            "the healing engine gained a `{kind}` branch — good, but then this \
+             spec needs updating rather than deleting"
+        );
+        assert!(
+            ErrorType::A11y.as_str() == "a11y" || kind != "a11y",
+            "the reporter still declares it"
+        );
+    }
+    assert_eq!(engine.len(), 7);
+}

--- a/mzizi-rs/crates/mzizi-fundi/tests/contract.rs
+++ b/mzizi-rs/crates/mzizi-fundi/tests/contract.rs
@@ -1,0 +1,298 @@
+//! Contract tests — the N9 Rust core against its TypeScript sibling.
+//!
+//! The escaping tests here are the load-bearing ones. Every field in a fundi
+//! report ultimately derives from a runtime error message, and an error message
+//! is attacker-influenced whenever any user input reaches an exception — a
+//! rejected filename, a malformed address, a pasted value. That text is then
+//! interpolated into a Markdown document filed automatically into an issue
+//! tracker that humans triage.
+//!
+//! GitHub sanitises rendered HTML, so the risk is content forgery rather than
+//! script execution. That is not a small risk for this component: the body ends
+//! with a provenance line saying which tool filed it, and a report that can forge
+//! that line can claim to be from a source it is not.
+
+use std::fs;
+use std::path::PathBuf;
+
+use mzizi_fundi::nyuchi_fundi_reporter::{
+    CooldownLog, ErrorType, FundiReport, NotFiled, ReportSeverity, escape_code_span,
+    escape_markdown_cell, issue_body, issue_title, labels_for,
+};
+
+fn ts_sibling() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../components/registry/n9-fundi/nyuchi-fundi-reporter.ts");
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read the TypeScript sibling at {path:?}: {e}"))
+}
+
+fn report() -> FundiReport {
+    FundiReport {
+        component: "button".to_owned(),
+        node: 2,
+        severity: ReportSeverity::High,
+        error_type: ErrorType::Render,
+        source: "error-tracker".to_owned(),
+        title: "render failed".to_owned(),
+        description: "the button threw".to_owned(),
+        portal_url: Some("https://mzizi.dev/components/button".to_owned()),
+        diagnostic: None,
+        affected_mini_apps: vec!["wallet".to_owned()],
+        blast_radius: vec!["card".to_owned()],
+    }
+}
+
+// ── cooldown ───────────────────────────────────────────────────────────────
+
+#[test]
+fn a_failed_filing_does_not_start_the_cooldown() {
+    // THE BUG THIS PORT FIXES. The .ts records the cooldown BEFORE the fetch, so
+    // a GitHub outage, a 401 or a rate limit suppressed every retry for five
+    // minutes — consuming the signal without ever producing an issue.
+    let mut log = CooldownLog::new(300.0);
+    assert!(log.may_file(&report(), 0.0).is_ok());
+    // The host tried and failed, so it does NOT call record_filed.
+    assert!(
+        log.may_file(&report(), 1.0).is_ok(),
+        "a failed attempt must not suppress the retry"
+    );
+    log.record_filed(&report(), 1.0);
+    assert_eq!(log.may_file(&report(), 2.0), Err(NotFiled::InCooldown));
+}
+
+#[test]
+fn distinct_error_types_on_one_component_are_distinct_defects() {
+    // The .ts keys the cooldown on the component alone, so a component with a
+    // render bug and a network bug filed one and silently dropped the other.
+    let mut log = CooldownLog::new(300.0);
+    let render = report();
+    let network = FundiReport {
+        error_type: ErrorType::Network,
+        ..report()
+    };
+    log.record_filed(&render, 0.0);
+    assert_eq!(log.may_file(&render, 1.0), Err(NotFiled::InCooldown));
+    assert!(
+        log.may_file(&network, 1.0).is_ok(),
+        "a different defect is not a duplicate"
+    );
+}
+
+#[test]
+fn the_cooldown_expires() {
+    let mut log = CooldownLog::new(300.0);
+    log.record_filed(&report(), 0.0);
+    assert_eq!(
+        log.may_file(&report(), 299_000.0),
+        Err(NotFiled::InCooldown)
+    );
+    assert!(log.may_file(&report(), 300_000.0).is_ok());
+}
+
+// ── escaping ───────────────────────────────────────────────────────────────
+
+#[test]
+fn a_backtick_cannot_close_the_code_span_it_sits_in() {
+    // `component` renders inside a backtick span. A backtick closes it and
+    // everything after renders as Markdown — which is how a component name
+    // becomes a heading in an automated issue.
+    let evil = FundiReport {
+        component: "button` ## Injected heading".to_owned(),
+        ..report()
+    };
+    let body = issue_body(&evil);
+    assert!(!body.contains("button` ##"), "the span was closed:\n{body}");
+    assert!(body.contains("button' ## Injected heading"));
+}
+
+#[test]
+fn a_pipe_cannot_forge_table_columns() {
+    let evil = FundiReport {
+        source: "error-tracker | Severity | critical".to_owned(),
+        ..report()
+    };
+    let body = issue_body(&evil);
+    assert!(body.contains("\\|"), "the pipe was not escaped:\n{body}");
+}
+
+#[test]
+fn a_newline_cannot_escape_a_table_row_or_forge_the_footer() {
+    // The body ends with a provenance line naming the tool that filed it. A
+    // report able to forge that line can claim a source it does not have, and a
+    // triager reading an automated issue trusts exactly that line.
+    let evil = FundiReport {
+        source: "x\n\n---\n*Filed by someone-else*\n".to_owned(),
+        ..report()
+    };
+    let body = issue_body(&evil);
+
+    // Assert on STRUCTURE, not on a substring. The injected text does appear in
+    // the body — as literal content inside the table cell, which is exactly
+    // where it should be and is harmless there. What must not happen is that it
+    // escapes the row and becomes a block of its own.
+    //
+    // A first version of this test counted occurrences of "*Filed by" and failed,
+    // reporting a forgery that had not happened. That is the same mistake as
+    // banning the string "mzizi.dev/api/rum" in the N8 suite: a check that cannot
+    // tell content from structure fails on the safe case.
+    let own_line = |prefix: &str| {
+        body.lines()
+            .filter(|l| l.trim_start().starts_with(prefix))
+            .count()
+    };
+    assert_eq!(
+        own_line("*Filed by"),
+        1,
+        "a second provenance line escaped the cell:\n{body}"
+    );
+    assert_eq!(
+        own_line("---"),
+        1,
+        "a second horizontal rule escaped the cell:\n{body}"
+    );
+
+    // And the row itself is still one row.
+    assert_eq!(
+        body.lines().filter(|l| l.starts_with("| Source |")).count(),
+        1,
+        "the Source row was split:\n{body}"
+    );
+}
+
+#[test]
+fn a_url_cannot_break_out_of_its_link() {
+    // `[View](url)` ends at the first `)`, so a URL containing one lets the rest
+    // render as prose. Angle brackets are Markdown's literal-URL form.
+    let evil = FundiReport {
+        portal_url: Some("https://evil/a)  [Click me](https://evil/b".to_owned()),
+        ..report()
+    };
+    let body = issue_body(&evil);
+    assert!(
+        body.contains("[View](<"),
+        "the URL is not in angle-bracket form:\n{body}"
+    );
+    assert_eq!(
+        body.matches("[Click me]").count(),
+        1,
+        "content, not a second real link"
+    );
+}
+
+#[test]
+fn a_fence_inside_a_diagnostic_cannot_end_the_block() {
+    // The diagnostic is host-serialised JSON that can contain anything. A
+    // three-backtick fence inside a three-backtick block closes it and spills
+    // the remainder into prose, so the block is four.
+    let evil = FundiReport {
+        diagnostic: Some("{\"x\":\"```\\n## escaped\"}".to_owned()),
+        ..report()
+    };
+    let body = issue_body(&evil);
+    assert!(
+        body.contains("````json"),
+        "the fence is not widened:\n{body}"
+    );
+}
+
+#[test]
+fn escaping_backslashes_first_stops_the_escapes_being_escaped() {
+    // Escaping `|` before `\` lets `\|` in the input become `\\|` — a literal
+    // backslash followed by an unescaped pipe.
+    assert_eq!(escape_markdown_cell("a\\|b"), "a\\\\\\|b");
+    assert_eq!(escape_code_span("a`b\nc"), "a'b c");
+}
+
+#[test]
+fn a_title_stays_one_line() {
+    let evil = FundiReport {
+        title: "boom\n\n## Injected".to_owned(),
+        ..report()
+    };
+    assert!(!issue_title(&evil).contains('\n'));
+}
+
+// ── agreement with the TypeScript ──────────────────────────────────────────
+
+#[test]
+fn labels_match_the_typescript_shape() {
+    let labels = labels_for(&report());
+    assert_eq!(labels[0], "fundi:severity/high");
+    assert_eq!(labels[1], "fundi:node/2");
+    assert_eq!(labels[2], "fundi:type/render");
+    assert_eq!(labels[3], "fundi:source/error-tracker");
+    let ts = ts_sibling();
+    for prefix in [
+        "fundi:severity/",
+        "fundi:node/",
+        "fundi:type/",
+        "fundi:source/",
+    ] {
+        assert!(ts.contains(prefix), "label prefix {prefix} drifted");
+    }
+}
+
+#[test]
+fn every_severity_and_error_type_keeps_its_typescript_spelling() {
+    let ts = ts_sibling();
+    for s in [
+        ReportSeverity::Low,
+        ReportSeverity::Medium,
+        ReportSeverity::High,
+        ReportSeverity::Critical,
+    ] {
+        assert!(
+            ts.contains(&format!("\"{}\"", s.as_str())),
+            "severity {}",
+            s.as_str()
+        );
+    }
+    for t in [
+        ErrorType::Render,
+        ErrorType::Network,
+        ErrorType::Data,
+        ErrorType::Auth,
+        ErrorType::Chain,
+        ErrorType::Crypto,
+        ErrorType::Timeout,
+        ErrorType::A11y,
+        ErrorType::Perf,
+        ErrorType::Conformity,
+        ErrorType::Slo,
+    ] {
+        assert!(
+            ts.contains(&format!("\"{}\"", t.as_str())),
+            "error type {}",
+            t.as_str()
+        );
+    }
+}
+
+#[test]
+fn the_body_keeps_the_typescript_section_headings() {
+    let ts = ts_sibling();
+    let body = issue_body(&report());
+    for heading in [
+        "## Component Failure Report",
+        "### Description",
+        "### Affected Mini-Apps",
+        "### Blast Radius",
+    ] {
+        assert!(body.contains(heading), "body lost {heading}");
+        assert!(ts.contains(heading), "the TypeScript lost {heading}");
+    }
+    assert!(body.contains("*Filed by nyuchi-fundi-reporter"));
+}
+
+#[test]
+fn the_typescript_still_files_against_the_renamed_repo() {
+    // It said nyuchi/design-portal and worked only because GitHub redirects a
+    // renamed repo — which will break every consumer at once when that retires.
+    let ts = ts_sibling();
+    assert!(ts.contains("nyuchi/mzizi"), "the repo constant regressed");
+    assert!(
+        !ts.contains("\"nyuchi/design-portal\""),
+        "the stale repo name returned"
+    );
+}

--- a/mzizi-rs/crates/mzizi-fundi/tests/contract.rs
+++ b/mzizi-rs/crates/mzizi-fundi/tests/contract.rs
@@ -296,3 +296,176 @@ fn the_typescript_still_files_against_the_renamed_repo() {
         "the stale repo name returned"
     );
 }
+
+// ── learning ───────────────────────────────────────────────────────────────
+
+use mzizi_fundi::nyuchi_fundi_learning::{
+    HealingOutcome, LearningLog, ResolvedBy, Severity as LearnSeverity,
+};
+
+fn outcome(
+    component: &str,
+    error_type: &str,
+    sev: LearnSeverity,
+    recurred: bool,
+) -> HealingOutcome {
+    HealingOutcome {
+        issue_id: 1,
+        component: component.to_owned(),
+        node: 2,
+        error_type: error_type.to_owned(),
+        severity: sev,
+        plan_actions: vec!["patch".to_owned()],
+        actual_fix: "patched".to_owned(),
+        fundi_was_correct: true,
+        time_to_resolve_minutes: 10.0,
+        recurred,
+        resolved_by: ResolvedBy::Fundi,
+        recorded_at_ms: 0.0,
+    }
+}
+
+#[test]
+fn recurrence_escalates_severity_and_never_lowers_it() {
+    // THE BUG THIS PORT FIXES. The .ts returns "high" outright once something
+    // has recurred more than twice — LOWERING a critical defect that keeps
+    // coming back. Recurrence is evidence the first assessment was too generous,
+    // never too harsh.
+    let mut log = LearningLog::default();
+    for _ in 0..3 {
+        log.record(outcome("button", "render", LearnSeverity::Critical, true));
+    }
+    assert_eq!(
+        log.suggest_severity("button", "render"),
+        LearnSeverity::Critical,
+        "a repeatedly recurring critical defect must not be downgraded"
+    );
+
+    let mut low = LearningLog::default();
+    for _ in 0..3 {
+        low.record(outcome("card", "render", LearnSeverity::Low, true));
+    }
+    assert_eq!(
+        low.suggest_severity("card", "render"),
+        LearnSeverity::High,
+        "and it does escalate"
+    );
+}
+
+#[test]
+fn few_recurrences_keep_the_last_severity() {
+    let mut log = LearningLog::default();
+    log.record(outcome("button", "render", LearnSeverity::Low, true));
+    log.record(outcome("button", "render", LearnSeverity::Low, true));
+    assert_eq!(log.suggest_severity("button", "render"), LearnSeverity::Low);
+}
+
+#[test]
+fn no_history_suggests_medium() {
+    let log = LearningLog::default();
+    assert_eq!(
+        log.suggest_severity("unseen", "render"),
+        LearnSeverity::Medium
+    );
+    // And an unrecognised wire value is Medium too — an unknown risk treated as
+    // harmless is how things get missed.
+    assert_eq!(
+        LearnSeverity::from_str_or_medium("nonsense"),
+        LearnSeverity::Medium
+    );
+}
+
+#[test]
+fn history_is_bounded() {
+    // The .ts pushes forever, in a component whose whole purpose is to
+    // accumulate — so a long-lived Worker or session leaks until it dies.
+    let mut log = LearningLog::new(3);
+    for i in 0..10 {
+        log.record(outcome(
+            &format!("c{i}"),
+            "render",
+            LearnSeverity::Low,
+            false,
+        ));
+    }
+    assert_eq!(log.outcomes().len(), 3);
+    assert_eq!(log.outcomes()[2].component, "c9", "the newest is kept");
+}
+
+#[test]
+fn both_readings_of_accuracy_are_available() {
+    // accuracy counts correct diagnoses over ALL outcomes, including ones fundi
+    // never attempted. That is the .ts's definition and it is preserved rather
+    // than quietly redefined in the flattering direction.
+    let mut log = LearningLog::default();
+    log.record(outcome("a", "render", LearnSeverity::Low, false));
+    log.record(HealingOutcome {
+        fundi_was_correct: false,
+        resolved_by: ResolvedBy::Human,
+        ..outcome("b", "render", LearnSeverity::Low, false)
+    });
+    let stats = log.stats();
+    assert_eq!(stats.total_issues, 2);
+    assert_eq!(stats.auto_fixed, 1);
+    assert_eq!(stats.human_fixed, 1);
+    assert!((stats.accuracy - 0.5).abs() < 1e-9, "over all outcomes");
+    assert!(
+        (stats.accuracy_over_attempts - 1.0).abs() < 1e-9,
+        "over attempts only"
+    );
+}
+
+#[test]
+fn rankings_are_deterministic_when_counts_tie() {
+    // The .ts sorts a Map whose iteration order is insertion order, so equal
+    // counts swap places depending on which failed first — and a "top failing
+    // components" list that reshuffles between refreshes is one nobody trusts.
+    let mut log = LearningLog::default();
+    log.record(outcome("zebra", "render", LearnSeverity::Low, false));
+    log.record(outcome("alpha", "render", LearnSeverity::Low, false));
+    let top = log.stats().top_failing_components;
+    assert_eq!(top[0].name, "alpha", "ties break by name, not by arrival");
+    assert_eq!(top[1].name, "zebra");
+}
+
+#[test]
+fn empty_stats_are_zero_not_nan() {
+    // total is a denominator in three places; dividing by it unguarded yields
+    // NaN, which serialises to null and renders as a blank tile.
+    let stats = LearningLog::default().stats();
+    assert_eq!(stats.total_issues, 0);
+    assert_eq!(stats.accuracy, 0.0);
+    assert_eq!(stats.recurrence_rate, 0.0);
+    assert!(stats.top_failing_components.is_empty());
+}
+
+#[test]
+fn learning_keeps_its_typescript_spellings_and_limits() {
+    let ts = fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../components/registry/n9-fundi/nyuchi-fundi-learning.ts"),
+    )
+    .expect("the fundi-learning TypeScript sibling");
+    for r in [ResolvedBy::Fundi, ResolvedBy::Human, ResolvedBy::Both] {
+        assert!(
+            ts.contains(&format!("\"{}\"", r.as_str())),
+            "resolvedBy {}",
+            r.as_str()
+        );
+    }
+    assert!(ts.contains("slice(0, 10)"), "top-components limit drifted");
+    assert!(ts.contains("slice(0, 5)"), "top-error-types limit drifted");
+
+    let mut log = LearningLog::default();
+    for i in 0..20 {
+        log.record(outcome(
+            &format!("c{i}"),
+            &format!("t{i}"),
+            LearnSeverity::Low,
+            false,
+        ));
+    }
+    let stats = log.stats();
+    assert_eq!(stats.top_failing_components.len(), 10);
+    assert_eq!(stats.top_error_types.len(), 5);
+}


### PR DESCRIPTION
Every component in N8 assurance and N9 fundi now has a Rust core. Two crates — `mzizi-assurance` and `mzizi-fundi` — compiled in CI under `cargo check`, `clippy -D warnings`, `fmt --check` and **196 contract specs**.

> This PR started as one file (`mzizi-otel.rs`) and grew to the whole of both nodes. The description below replaces the original, which listed the remaining components as "queued".

## The boundary is I/O, not language

Every core is pure. `build_trace_request` returns a URL, headers and a body; the host performs the request. `create_healing_plan` returns a plan; the host executes it. `audit` takes what the host observed; the host walks the DOM.

That is what makes a shared core work — every target *sends* differently and must *compute* identically — and it converts a promise into a property. The TypeScript exporter had to wrap `fetch` in `try/catch` and return `{ exported: false, reason }`, because a probe reporting "failed" merely because its collector was unreachable manufactures an incident out of an exporter outage. **A core with no I/O cannot make that mistake.**

Clocks, ids and randomness are supplied, never chosen. A shared core must not pick the host's CSPRNG, and — as it turned out — deriving an identifier from `Date.now()` is a defect in its own right (below).

## Zero dependencies

Every dependency in a shared core is paid for by every consumer of every app. `serde_json` declined (OTLP/HTTP JSON is a small documented shape). `reqwest` declined (this core does not send). `getrandom` declined (a WASM build reaching for it needs a per-target backend — a footgun that surfaces as a link error).

## What the contract suites are for

`cargo check` proves a file compiles. It cannot prove the `.rs` and its `.ts` sibling agree. Each suite reads the sibling **on disk** and asserts every shared literal, threshold and enum table appears in both — so a renamed action type or a drifted threshold fails the build rather than silently reclassifying every historical finding.

**~20 defects were found this way, none of which `cargo check` would have caught.** The five worst:

| Component | Defect |
|---|---|
| `nyuchi-fundi` | "Requires human approval" stopped nothing — `FundiProvider` defaults `autoHeal = true` and the gate reads `requiresHumanApproval && !autoHeal`, so a systemic-outage plan disabled features automatically while declaring it should not |
| `nyuchi-fundi` | "Never auto-fix auth" sat inside the `else` handling *isolated* failures, so a partial or systemic auth failure never reached the one rule stated as inviolable |
| `mzizi-platform-health` | `[].every(…)` is `true`, so a status panel whose fetch failed rendered green: "All Systems Operational" |
| `mzizi-chaos` | `/api/weather?lat=-17.83&lon=31.05` ships as a registry default, so in any other app one probe fails every time — which the classifier's dead middle band then calls a systemic outage, on every diagnosis |
| `mzizi-a11y-audit` | A conformant button counted as neither pass nor violation, so the page score *fell as accessibility improved* |

Recurring shapes worth naming: clock-as-identity collisions (4 places, each silently overwriting a record), unbounded accumulators (3), config options declared and never read (2), and decisions inverted against their own stated intent (4).

**Two corrections made to my own work, recorded rather than quietly fixed.** The first blast-radius fix used `>= 0.5`, which leaves `partial` exactly as unreachable with two probes as the original did — reproducing the bug being fixed; the spec caught it and both the constant and the test now say so. The exporter drift-guard first banned a substring and failed on the very sentence retracting it, so it now checks per paragraph, matching the `llms.txt` doctrine test.

## The exporter is the shim now

`mzizi-otel.ts` opened with "N8 IS A RUST NODE AND THIS FILE IS TYPESCRIPT … there are zero `.rs` files under those four directories" — true when written, false once `mzizi-otel.rs` landed beside it, and it is installed into consumer apps. Corrected there, in `docs/n8-telemetry.md` and in CLAUDE.md §8.9, and guarded by a spec.

## Scope — stated precisely

**Shipped:** a Rust core for all 12 N8 components and both N9 components, with contract suites.

**Not shipped, deliberately:** a WASM build. The cores are pure logic; nothing compiles them to WASM, no consumer loads one, and no `.ts` calls into one. **The two implementations agree by contract test, not by sharing a binary** — "N8 is a Rust node" means its rules have one authoritative home, not that one binary serves every target.

**Not attempted:** Dioxus surfaces. Four files are genuinely UI (`mzizi-platform-health`, `nyuchi-fundi`, and the React wrappers on `mzizi-chaos` / `rtl-conformity-check`); their *logic* moved to the core and their rendering did not. Those get Dioxus alternatives, not implementations (CLAUDE.md §6.2) — and N11 makes a WASM web target a prerender constraint, so that is its own decision.

**Open question for the reviewer:** the defects above are fixed in Rust and still live in the `.ts` siblings that consumers install today. Back-porting them is a separate change and has not been done here.

## Verification

`cargo fmt --check`, `cargo check`, `clippy -D warnings`, `cargo test` (196 specs) green. `pnpm test` 185/185. `registry:validate` clean. `__tests__/api/v1/rust-route.test.ts` confirms every `.rs` in the registry is compiled by a crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_