### PR TITLE
fix(api): the registry index was unfilterable and installs were incomplete

### DIFF
--- a/__tests__/api/registry-route.test.ts
+++ b/__tests__/api/registry-route.test.ts
@@ -1,3 +1,17 @@
+/**
+ * GET /api/v1/ui — the registry index.
+ *
+ * READ THIS BEFORE EDITING THE FIXTURES. The previous version of this file is why the
+ * index shipped broken for so long: it fed `registry_type` and `registry_dependencies` —
+ * column names from the retired Supabase row shape — so the route's mapping found them,
+ * and a spec even asserted `item.type` matched /^registry:(ui|hook|lib|block)$/ and passed.
+ * Meanwhile `getAllComponents()` returns registry items whose fields are `type` and
+ * `registryDependencies`, so in production both keys were `undefined` and `JSON.stringify`
+ * dropped them. The fixture agreed with the defect, so the test certified it.
+ *
+ * The fixtures below are `RegistryItem`s — the shape the reader really returns. If a future
+ * change makes a spec fail, check the SHAPE before changing the assertion.
+ */
 import { describe, it, expect, vi, beforeEach } from "vitest"
 
 // Mock next/server
@@ -11,12 +25,10 @@ vi.mock("next/server", () => ({
   },
 }))
 
-// Mock the DB layer — registry lives in Supabase.
-const mockIsSupabaseConfigured = vi.fn()
 const mockGetAllComponents = vi.fn()
 
 vi.mock("@/lib/db", () => ({
-  isSupabaseConfigured: () => mockIsSupabaseConfigured(),
+  isSupabaseConfigured: () => true,
   getAllComponents: () => mockGetAllComponents(),
 }))
 
@@ -26,127 +38,238 @@ vi.mock("@/lib/observability", () => ({
 
 import { GET } from "@/app/api/v1/ui/route"
 
+/** A registry item as `readComponents()` produces one. */
+function item(
+  name: string,
+  over: Partial<{
+    type: string
+    description: string
+    dependencies: string[]
+    registryDependencies: string[]
+    node: number
+    nodeLabel: string
+    meta: { owner?: string; collection?: string }
+  }> = {}
+) {
+  return {
+    name,
+    type: "registry:ui",
+    description: `${name} component.`,
+    dependencies: [],
+    registryDependencies: [],
+    node: 2,
+    nodeLabel: "primitives",
+    meta: { owner: "mzizi", collection: "primitives" },
+    ...over,
+  }
+}
+
+const req = (qs = "") => new Request(`https://mzizi.dev/api/v1/ui${qs}`)
+
+type IndexItem = {
+  name: string
+  type?: string
+  description?: string
+  dependencies?: string[]
+  registryDependencies?: string[]
+  node?: number
+  nodeLabel?: string
+  owner?: string
+  collection?: string
+}
+type IndexBody = {
+  $schema: string
+  name: string
+  homepage: string
+  items: IndexItem[]
+  meta: {
+    total: number
+    count: number
+    offset: number
+    limit: number | null
+    registryTotal: number
+    filters: Record<string, unknown>
+  }
+}
+type Res = { status: number; headers: Record<string, string>; data: IndexBody }
+
 describe("GET /api/v1/ui", () => {
   beforeEach(() => {
-    mockIsSupabaseConfigured.mockReset()
     mockGetAllComponents.mockReset()
   })
 
   it("serves the registry with no database configured", async () => {
-    // This spec asserted 503 "Database not configured" — and asserting it is what kept the
-    // defect alive. `getAllComponents` reads `registry.json` and the files on disk, so the
-    // registry INDEX, the first route any consumer hits, answered 503 for content sitting in
-    // the deployed bundle and named a credential that would not have helped.
-    mockIsSupabaseConfigured.mockReturnValue(false)
-    mockGetAllComponents.mockResolvedValue([
-      {
-        name: "button",
-        registry_type: "registry:ui",
-        description: "Displays a button or a component that looks like a button.",
-        dependencies: [],
-        registry_dependencies: [],
-      },
-    ])
-
-    const res = (await GET()) as unknown as {
-      status: number
-      data: { items: Array<{ name: string }> }
-    }
+    // The registry is files on disk in the deployed bundle. This spec once asserted a 503
+    // "Database not configured", and asserting it is what kept that defect alive.
+    mockGetAllComponents.mockResolvedValue([item("button")])
+    const res = (await GET(req())) as unknown as Res
     expect(res.status).toBe(200)
     expect(res.data.items.map((i) => i.name)).toEqual(["button"])
   })
 
-  it("returns registry payload with the correct schema and items", async () => {
-    mockIsSupabaseConfigured.mockReturnValue(true)
+  it("serves type and registryDependencies — the two keys the old mapping dropped", async () => {
     mockGetAllComponents.mockResolvedValue([
-      {
-        name: "button",
-        registry_type: "registry:ui",
-        description: "Displays a button or a component that looks like a button.",
+      item("button", {
+        type: "registry:ui",
         dependencies: ["class-variance-authority"],
-        registry_dependencies: [],
-      },
-      {
-        name: "card",
-        registry_type: "registry:ui",
-        description: "Surface container.",
-        dependencies: [],
-        registry_dependencies: [],
-      },
+        registryDependencies: ["https://mzizi.dev/api/v1/ui/slot"],
+      }),
     ])
 
-    const res = (await GET()) as unknown as {
-      status: number
-      headers: Record<string, string>
-      data: {
-        $schema: string
-        name: string
-        homepage: string
-        items: Array<{ name: string; type: string; description: string }>
-      }
-    }
+    const res = (await GET(req())) as unknown as Res
+    const first = res.data.items[0]
 
+    // The regression guard. Against the old route these were `undefined`, and `undefined`
+    // is not an assertable value once it has been through JSON — so assert presence, not
+    // just equality.
+    expect(Object.keys(first)).toContain("type")
+    expect(Object.keys(first)).toContain("registryDependencies")
+    expect(first.type).toBe("registry:ui")
+    expect(first.registryDependencies).toEqual(["https://mzizi.dev/api/v1/ui/slot"])
+    expect(first.dependencies).toEqual(["class-variance-authority"])
+  })
+
+  it("projects node, nodeLabel, owner and collection so the index can be filtered", async () => {
+    mockGetAllComponents.mockResolvedValue([
+      item("nyuchi-header", {
+        node: 3,
+        nodeLabel: "brand",
+        meta: { owner: "nyuchi", collection: "brand" },
+      }),
+    ])
+
+    const res = (await GET(req())) as unknown as Res
+    expect(res.data.items[0]).toMatchObject({
+      node: 3,
+      nodeLabel: "brand",
+      owner: "nyuchi",
+      collection: "brand",
+    })
+  })
+
+  it("returns the registry payload with the correct schema, name and headers", async () => {
+    mockGetAllComponents.mockResolvedValue([item("button"), item("card")])
+
+    const res = (await GET(req())) as unknown as Res
     expect(res.status).toBe(200)
     expect(res.data.$schema).toBe("https://ui.shadcn.com/schema/registry.json")
-    expect(res.data.name).toBe("mukoko")
+    // `registry.json` says `mzizi`. This asserted `mukoko` and so pinned the wrong brand.
+    expect(res.data.name).toBe("mzizi")
     expect(res.data.homepage).toBe("https://mzizi.dev")
     expect(res.data.items).toHaveLength(2)
-    expect(res.data.items[0]).toMatchObject({
-      name: "button",
-      type: "registry:ui",
-    })
     expect(res.headers["Access-Control-Allow-Origin"]).toBe("*")
   })
 
   it("each item has required fields and a recognisable type", async () => {
-    mockIsSupabaseConfigured.mockReturnValue(true)
     mockGetAllComponents.mockResolvedValue([
-      {
-        name: "button",
-        registry_type: "registry:ui",
-        description: "A button.",
-        dependencies: [],
-        registry_dependencies: [],
-      },
-      {
-        name: "use-toast",
-        registry_type: "registry:hook",
-        description: "Toast state hook.",
-        dependencies: [],
-        registry_dependencies: [],
-      },
-      {
-        name: "retry",
-        registry_type: "registry:lib",
-        description: "Retry utility.",
-        dependencies: [],
-        registry_dependencies: [],
-      },
-      {
-        name: "dashboard-01",
-        registry_type: "registry:block",
-        description: "Dashboard block.",
-        dependencies: [],
-        registry_dependencies: [],
-      },
+      item("button", { type: "registry:ui" }),
+      item("use-toast", { type: "registry:hook" }),
+      item("retry", { type: "registry:lib" }),
+      item("dashboard-01", { type: "registry:block" }),
     ])
 
-    const res = (await GET()) as unknown as {
-      data: { items: Array<{ name: string; type: string; description: string }> }
-    }
-
-    for (const item of res.data.items) {
-      expect(item.name).toBeTruthy()
-      expect(item.type).toMatch(/^registry:(ui|hook|lib|block)$/)
-      expect(item.description).toBeTruthy()
+    const res = (await GET(req())) as unknown as Res
+    for (const i of res.data.items) {
+      expect(i.name).toBeTruthy()
+      expect(i.type).toMatch(/^registry:(ui|hook|lib|block)$/)
+      expect(i.description).toBeTruthy()
     }
   })
 
-  it("returns 500 when the DB query throws", async () => {
-    mockIsSupabaseConfigured.mockReturnValue(true)
-    mockGetAllComponents.mockRejectedValue(new Error("connection failed"))
+  describe("filters", () => {
+    const corpus = [
+      item("button", { node: 2, meta: { owner: "mzizi", collection: "primitives" } }),
+      item("nyuchi-header", { node: 3, meta: { owner: "nyuchi", collection: "brand" } }),
+      item("retry", {
+        node: 5,
+        type: "registry:lib",
+        meta: { owner: "mzizi", collection: "resilience" },
+      }),
+    ]
 
-    const res = (await GET()) as unknown as { status: number; data: { error: string } }
+    beforeEach(() => mockGetAllComponents.mockResolvedValue(corpus))
+
+    it("narrows by node", async () => {
+      const res = (await GET(req("?node=3"))) as unknown as Res
+      expect(res.data.items.map((i) => i.name)).toEqual(["nyuchi-header"])
+      expect(res.data.meta.total).toBe(1)
+      expect(res.data.meta.registryTotal).toBe(3)
+    })
+
+    it("narrows by owner, collection and type", async () => {
+      expect(
+        ((await GET(req("?owner=nyuchi"))) as unknown as Res).data.items.map((i) => i.name)
+      ).toEqual(["nyuchi-header"])
+      expect(
+        ((await GET(req("?collection=resilience"))) as unknown as Res).data.items.map((i) => i.name)
+      ).toEqual(["retry"])
+      expect(
+        ((await GET(req("?type=registry:lib"))) as unknown as Res).data.items.map((i) => i.name)
+      ).toEqual(["retry"])
+    })
+
+    it("combines filters", async () => {
+      const res = (await GET(req("?owner=mzizi&node=5"))) as unknown as Res
+      expect(res.data.items.map((i) => i.name)).toEqual(["retry"])
+    })
+
+    it("answers an unknown node with an empty list, never a 400", async () => {
+      // §9: the node set is uncapped and grows. A bound is the defect regardless of its
+      // value — a cap of 10 hid N11, a cap of 11 would hide N12. An unknown node is a
+      // legitimate empty result, and `registryTotal` lets a caller tell "filtered to
+      // nothing" from "the registry is empty".
+      const res = (await GET(req("?node=99"))) as unknown as Res
+      expect(res.status).toBe(200)
+      expect(res.data.items).toEqual([])
+      expect(res.data.meta.total).toBe(0)
+      expect(res.data.meta.registryTotal).toBe(3)
+    })
+
+    it("ignores an unparseable filter rather than failing the index", async () => {
+      const res = (await GET(req("?node=abc"))) as unknown as Res
+      expect(res.status).toBe(200)
+      expect(res.data.items).toHaveLength(3)
+    })
+  })
+
+  describe("pagination", () => {
+    const corpus = ["a", "b", "c", "d", "e"].map((n) => item(n))
+    beforeEach(() => mockGetAllComponents.mockResolvedValue(corpus))
+
+    it("returns everything when limit is unset — existing consumers are unaffected", async () => {
+      const res = (await GET(req())) as unknown as Res
+      expect(res.data.items).toHaveLength(5)
+      expect(res.data.meta.limit).toBeNull()
+    })
+
+    it("pages with limit and offset, reporting total separately from count", async () => {
+      const res = (await GET(req("?limit=2&offset=1"))) as unknown as Res
+      expect(res.data.items.map((i) => i.name)).toEqual(["b", "c"])
+      expect(res.data.meta).toMatchObject({ total: 5, count: 2, offset: 1, limit: 2 })
+    })
+
+    it("pages a FILTERED set, so total reflects the filter and not the registry", async () => {
+      mockGetAllComponents.mockResolvedValue([
+        item("x", { node: 2 }),
+        item("y", { node: 2 }),
+        item("z", { node: 7 }),
+      ])
+      const res = (await GET(req("?node=2&limit=1"))) as unknown as Res
+      expect(res.data.items.map((i) => i.name)).toEqual(["x"])
+      expect(res.data.meta).toMatchObject({ total: 2, count: 1, registryTotal: 3 })
+    })
+
+    it("returns an empty page past the end rather than erroring", async () => {
+      const res = (await GET(req("?offset=99"))) as unknown as Res
+      expect(res.status).toBe(200)
+      expect(res.data.items).toEqual([])
+      expect(res.data.meta.total).toBe(5)
+    })
+  })
+
+  it("returns 500 when the registry read throws", async () => {
+    mockGetAllComponents.mockRejectedValue(new Error("read failed"))
+    const res = (await GET(req())) as unknown as { status: number; data: { error: string } }
     expect(res.status).toBe(500)
     expect(res.data.error).toBe("Internal server error")
   })

--- a/app/api/chaos/[name]/route.ts
+++ b/app/api/chaos/[name]/route.ts
@@ -108,8 +108,10 @@ export async function GET(_request: Request, { params }: { params: Promise<{ nam
       {
         name: component.name,
         description: `Chaos surface for ${component.name}. Faults are injected in-process via the N8 chaos lib — install with \`npx shadcn@latest add https://mzizi.dev/api/v1/ui/chaos\`.`,
-        layer: component.layer ?? null,
-        registry_type: component.registry_type,
+        // `layer` and `registry_type` were retired-shape reads that always served
+        // `undefined`. `node` replaces `layer` (§9); `type` is the real field name.
+        node: component.node ?? null,
+        type: component.type ?? null,
         supported_faults: faults,
         engine: {
           runtime: "in-process",

--- a/app/api/health/[name]/route.ts
+++ b/app/api/health/[name]/route.ts
@@ -26,7 +26,7 @@ const COMPONENT_NAME_PATTERN = /^[a-z][a-z0-9-]*$/
  *   410 — component exists but `status: "deprecated"`
  *   503 — Supabase unconfigured (operator action required)
  *
- * The body is small JSON (name, status, layer, registry_type, last_checked).
+ * The body is small JSON (name, status, node, type, last_checked).
  * `Cache-Control: no-cache, no-store` because callers want a fresh probe
  * — same convention as `/api/v1/health`.
  */
@@ -81,10 +81,15 @@ export async function GET(_request: Request, { params }: { params: Promise<{ nam
     const probe = {
       status: "stable" as const,
       name: component.name,
-      registry_type: component.registry_type,
-      layer: component.layer ?? null,
-      category: component.category ?? null,
-      added_in_version: component.added_in_version ?? null,
+      // Was `registry_type` / `layer` / `category` / `added_in_version`: four columns
+      // from the retired Supabase row shape, every one of them `undefined` on a registry
+      // item and dropped by JSON.stringify. `layer` does not return under any name — the
+      // axis/layer model is retired (§9) and `node` is the unit that replaced it.
+      // `added_in_version` has no equivalent on disk; version history lives in
+      // /api/v1/ui/{name}/versions, so this probe stops pretending to carry it.
+      type: component.type ?? null,
+      node: component.node ?? null,
+      collection: component.meta?.collection ?? null,
       last_checked: new Date().toISOString(),
     }
 

--- a/app/api/v1/ui/[name]/docs/route.ts
+++ b/app/api/v1/ui/[name]/docs/route.ts
@@ -65,8 +65,16 @@ export async function GET(_request: Request, { params }: { params: Promise<{ nam
       {
         name: component.name,
         description: component.description,
-        layer: component.layer,
-        category: component.category,
+        // `layer` and `category` were served here off `ComponentRow`, a shape this value
+        // has not had since the registry moved to disk — both were always `undefined` and
+        // `JSON.stringify` dropped them, so the payload silently lost two documented keys.
+        // `layer` does not come back under any name: the axis/layer model is retired and
+        // must not be served, nested or relabelled (§9). `node` is the unit that replaced
+        // it, and unlike `layer` it is real — derived from the directory on disk.
+        node: component.node,
+        nodeLabel: component.nodeLabel,
+        owner: component.meta?.owner,
+        collection: component.meta?.collection,
         docs: component.docs ?? null,
         demo: component.demo ?? null,
       },

--- a/app/api/v1/ui/[name]/route.ts
+++ b/app/api/v1/ui/[name]/route.ts
@@ -74,7 +74,9 @@ export async function GET(_request: Request, { params }: { params: Promise<{ nam
       )
     }
 
-    const files = component.files.map((file, i) => ({
+    // `files` is optional on a registry item, and an item without one is not installable.
+    // Falling through to `.map()` would have thrown a 500 where a 404 is the honest answer.
+    const files = (component.files ?? []).map((file, i) => ({
       path: file.path,
       type: file.type,
       content: i === 0 ? source : "",
@@ -95,10 +97,10 @@ export async function GET(_request: Request, { params }: { params: Promise<{ nam
       {
         $schema: "https://ui.shadcn.com/schema/registry-item.json",
         name: component.name,
-        type: component.registry_type,
+        type: component.type,
         description: component.description,
         dependencies: component.dependencies,
-        registryDependencies: component.registry_dependencies,
+        registryDependencies: component.registryDependencies,
         files,
       },
       { headers: CORS_CACHE }

--- a/app/api/v1/ui/route.ts
+++ b/app/api/v1/ui/route.ts
@@ -10,36 +10,114 @@ const CORS_CACHE = {
 }
 
 /**
- * GET /api/v1/ui — Registry index
- *
- * Reads all components from Supabase.
+ * Parse a positive integer query param. Returns undefined for absent/invalid rather than
+ * erroring: a bad `limit` should not fail the one route every consumer hits first.
  */
-export async function GET() {
+function positiveInt(raw: string | null): number | undefined {
+  if (raw === null || raw.trim() === "") return undefined
+  const n = Number(raw)
+  if (!Number.isInteger(n) || n < 0) return undefined
+  return n
+}
+
+/**
+ * GET /api/v1/ui — the registry index.
+ *
+ * This is the first route any consumer hits, and until now it served three fields per item:
+ * `name`, `description`, `dependencies`. It looked like it served five — the mapping named
+ * `type` and `registryDependencies` — but it read them off `c.registry_type` and
+ * `c.registry_dependencies`, column names from the retired Supabase row shape. Those are
+ * `undefined` on a registry item, and `JSON.stringify` drops undefined keys, so both
+ * vanished silently. `getAllComponents` claimed `ComponentRow` through an `as unknown as`
+ * cast, so TypeScript approved the whole thing.
+ *
+ * The index therefore violated its own advertised `$schema` (a shadcn registry item
+ * requires `type`) and carried nothing to filter on, which is why the MCP's `node`, `owner`
+ * and `category` filters returned zero rows for every value — they were filtering fields
+ * that were never sent.
+ *
+ * FILTERS. `node`, `owner`, `collection` and `type` narrow the index server-side. Every
+ * value comes from data already on the item — `node` from the directory the file lives in,
+ * `owner`/`collection` from the authored `meta` block in `registry.json` (§6.1).
+ *
+ * `node` is UNCAPPED and an unknown one returns an empty list, never a 400 (§9). The node
+ * set grows; a bound here is the defect regardless of its value.
+ *
+ * PAGINATION. `limit`/`offset` are opt-in and unset means "everything", so every existing
+ * consumer — including `npx shadcn` — sees exactly what it saw before. They exist because
+ * the full index is ~135 KB, which overflows an MCP client's token budget in one call.
+ *
+ * The shadcn keys (`$schema`, `name`, `homepage`, `items`) keep their shape and position;
+ * `meta` is additive and ignored by the CLI.
+ */
+export async function GET(request: Request) {
   try {
     // The `isSupabaseConfigured()` guard that stood here is gone with the store it guarded.
     // `getAllComponents` reads `registry.json` and the files on disk, so a missing anon key
     // made the registry INDEX answer 503 for data in the deployed bundle — the one route a
     // consumer hits first.
 
+    const params = new URL(request.url).searchParams
+    const node = positiveInt(params.get("node"))
+    const owner = params.get("owner")?.trim() || undefined
+    const collection = params.get("collection")?.trim() || undefined
+    const type = params.get("type")?.trim() || undefined
+    const limit = positiveInt(params.get("limit"))
+    const offset = positiveInt(params.get("offset")) ?? 0
+
     const components = await getAllComponents()
-    const items = components.map((c) => ({
+
+    const matched = components.filter((c) => {
+      if (node !== undefined && c.node !== node) return false
+      if (owner !== undefined && c.meta?.owner !== owner) return false
+      if (collection !== undefined && c.meta?.collection !== collection) return false
+      if (type !== undefined && c.type !== type) return false
+      return true
+    })
+
+    const page = limit === undefined ? matched.slice(offset) : matched.slice(offset, offset + limit)
+
+    const items = page.map((c) => ({
       name: c.name,
-      type: c.registry_type,
+      type: c.type,
       description: c.description,
       dependencies: c.dependencies,
-      registryDependencies: c.registry_dependencies,
+      registryDependencies: c.registryDependencies,
+      // Everything below is what makes the index filterable. It was always on the item and
+      // never projected, which is the whole of this defect.
+      node: c.node,
+      nodeLabel: c.nodeLabel,
+      owner: c.meta?.owner,
+      collection: c.meta?.collection,
     }))
 
     logger.info("Registry index served", {
-      data: { itemCount: items.length },
+      data: { itemCount: items.length, total: matched.length, node, owner, collection, type },
     })
 
     return NextResponse.json(
       {
         $schema: "https://ui.shadcn.com/schema/registry.json",
-        name: "mukoko",
+        // `registry.json` says `mzizi`; this said `mukoko`. The manifest is the authority.
+        name: "mzizi",
         homepage: "https://mzizi.dev",
         items,
+        meta: {
+          /** Components matching the filters, before paging. */
+          total: matched.length,
+          /** Components in THIS response. */
+          count: items.length,
+          offset,
+          limit: limit ?? null,
+          /** The whole registry, ignoring filters — so a caller can tell a narrow filter from an empty registry. */
+          registryTotal: components.length,
+          filters: {
+            node: node ?? null,
+            owner: owner ?? null,
+            collection: collection ?? null,
+            type: type ?? null,
+          },
+        },
       },
       { headers: CORS_CACHE }
     )

--- a/app/changelog/[name]/page.tsx
+++ b/app/changelog/[name]/page.tsx
@@ -89,9 +89,16 @@ export default async function ComponentChangelogPage({
         <p className="mt-3 max-w-2xl text-base leading-relaxed text-muted-foreground">
           {component.description}
         </p>
-        {component.added_in_version ? (
+        {/*
+          `added_in_version` was a Supabase column and is `undefined` on a registry item,
+          so this line never rendered. It is not replaced by a disk field: when a component
+          was added is history, and history is what the `versions` list below already
+          shows — deriving a second, possibly disagreeing answer would be the drift this
+          repo keeps removing.
+        */}
+        {component.node ? (
           <p className="mt-3 font-mono text-xs text-muted-foreground">
-            Added in v{component.added_in_version}
+            N{component.node} · {component.nodeLabel ?? "registry"}
           </p>
         ) : null}
       </header>

--- a/app/components/[name]/opengraph-image.tsx
+++ b/app/components/[name]/opengraph-image.tsx
@@ -18,7 +18,7 @@ export default async function Image({ params }: { params: Promise<{ name: string
   const item = await getComponent(name).catch(() => null)
   return renderMziziOg({
     title: item?.name ?? name,
-    eyebrow: item?.layer ? `component · N${item.layer}` : "mzizi component",
+    eyebrow: item?.node ? `component · N${item.node}` : "mzizi component",
     description: item?.description ?? "A component in the Mzizi registry.",
   })
 }

--- a/app/components/[name]/page.tsx
+++ b/app/components/[name]/page.tsx
@@ -42,7 +42,7 @@ export default async function ComponentPage({ params }: { params: Promise<{ name
   // Source lives on disk, not in the registry document (@/lib/registry-source).
   const sourceCode = readComponentSource(name) ?? "// Source not available"
   const firstFilePath = item.files?.[0]?.path ?? ""
-  const registryType = item.registry_type?.replace("registry:", "") ?? "component"
+  const registryType = item.type?.replace("registry:", "") ?? "component"
   const installUrl = `https://mzizi.dev/api/v1/ui/${item.name}`
   // Every component is a real file, so every one can be rendered. There is no
   // hand-written demo list any more -- that list gated the Preview tab off for 525
@@ -79,9 +79,9 @@ export default async function ComponentPage({ params }: { params: Promise<{ name
           <Badge variant="outline" className="font-mono text-xs">
             {registryType}
           </Badge>
-          {item.layer && (
+          {item.node && (
             <Badge variant="secondary" className="font-mono text-xs">
-              N{item.layer}
+              N{item.node}
             </Badge>
           )}
         </div>
@@ -120,7 +120,7 @@ export default async function ComponentPage({ params }: { params: Promise<{ name
 
       {/* Dependencies */}
       {((item.dependencies && item.dependencies.length > 0) ||
-        (item.registry_dependencies && item.registry_dependencies.length > 0)) && (
+        (item.registryDependencies && item.registryDependencies.length > 0)) && (
         <SafeSection section="Dependencies">
           <section className="space-y-3">
             <h2 className="text-xl font-semibold">Dependencies</h2>
@@ -130,7 +130,7 @@ export default async function ComponentPage({ params }: { params: Promise<{ name
                   {dep}
                 </Badge>
               ))}
-              {item.registry_dependencies?.map((dep) => (
+              {item.registryDependencies?.map((dep) => (
                 <Badge key={dep} variant="outline">
                   <a href={`/components/${dep}`} className="hover:underline">
                     {dep}

--- a/app/playground/[name]/page.tsx
+++ b/app/playground/[name]/page.tsx
@@ -62,7 +62,7 @@ export default async function PlaygroundComponentPage({
   // Source lives on disk, not in the registry document (@/lib/registry-source).
   const sourceCode = readComponentSource(name) ?? "// Source not available"
   const firstFilePath = item.files?.[0]?.path ?? ""
-  const registryType = item.registry_type?.replace("registry:", "") ?? "component"
+  const registryType = item.type?.replace("registry:", "") ?? "component"
   const installUrl = `https://mzizi.dev/api/v1/ui/${item.name}`
   // Every component has source on disk, so one without a hand-written demo can still
   // be rendered directly. `sourcePath` is repo-relative and comes from the file that
@@ -99,9 +99,9 @@ export default async function PlaygroundComponentPage({
           <Badge variant="outline" className="font-mono text-xs">
             {registryType}
           </Badge>
-          {item.layer && (
+          {item.node && (
             <Badge variant="secondary" className="font-mono text-xs">
-              N{item.layer}
+              N{item.node}
             </Badge>
           )}
         </div>
@@ -162,7 +162,7 @@ export default async function PlaygroundComponentPage({
 
       {/* Dependencies */}
       {((item.dependencies && item.dependencies.length > 0) ||
-        (item.registry_dependencies && item.registry_dependencies.length > 0)) && (
+        (item.registryDependencies && item.registryDependencies.length > 0)) && (
         <SafeSection section="Dependencies">
           <section className="space-y-3">
             <h2 className="text-xl font-semibold">Dependencies</h2>
@@ -172,7 +172,7 @@ export default async function PlaygroundComponentPage({
                   {dep}
                 </Badge>
               ))}
-              {item.registry_dependencies?.map((dep) => (
+              {item.registryDependencies?.map((dep) => (
                 <Badge key={dep} variant="outline">
                   <a href={`/playground/${dep}`} className="hover:underline">
                     {dep}

--- a/app/source/[name]/page.tsx
+++ b/app/source/[name]/page.tsx
@@ -54,7 +54,7 @@ export default async function SourcePage({ params }: { params: Promise<{ name: s
     return (
       <article className="mx-auto max-w-4xl py-12">
         <p className="font-mono text-[11px] tracking-widest text-muted-foreground uppercase">
-          {component.layer ?? "—"} · {component.category ?? "—"}
+          {component.node ? `N${component.node}` : "—"} · {component.meta?.collection ?? "—"}
         </p>
         <h1 className="mt-3 font-serif text-3xl font-bold">{component.name}</h1>
         <p className="mt-4 max-w-2xl text-sm leading-relaxed text-muted-foreground">
@@ -90,8 +90,8 @@ export default async function SourcePage({ params }: { params: Promise<{ name: s
 
       <header className="mb-6">
         <p className="mb-3 font-mono text-[11px] tracking-widest text-muted-foreground uppercase">
-          Source · {component.registry_type} · {component.layer ?? "—"} ·{" "}
-          {component.category ?? "—"}
+          Source · {component.type ?? "—"} · {component.node ? `N${component.node}` : "—"} ·{" "}
+          {component.meta?.collection ?? "—"}
         </p>
         <h1 className="font-serif text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
           {component.name}

--- a/components/playground/component-gallery.tsx
+++ b/components/playground/component-gallery.tsx
@@ -1,36 +1,43 @@
-import { getAllComponents, isSupabaseConfigured } from "@/lib/db"
+import { getAllComponents } from "@/lib/db"
 import { ComponentGalleryClient, type GalleryItem } from "./component-gallery-client"
 
 /**
- * Server component that fetches the full registry from Supabase and hands it
- * to the client filter UI. Replaces the previous `registry.json` import so
- * the catalog reflects live DB state (545+ components, 10 architecture layers).
+ * Server component that reads the registry and hands it to the client filter UI.
+ *
+ * Two defects lived here, both invisible because each produced a plausible page:
+ *
+ *  1. It mapped `c.registry_type` — a column name from the retired Supabase row shape.
+ *     A registry item's field is `type`, so EVERY card's type was `undefined`, the
+ *     `TYPE_LABELS` lookup missed, and the type filter had nothing to filter on. The
+ *     `as unknown as ComponentRow[]` cast in `getAllComponents` is what let it compile.
+ *  2. It was gated on `isSupabaseConfigured()`. The registry is files on disk in the
+ *     deployed bundle (CLAUDE.md §8.3), so with no anon key this rendered "Registry is
+ *     currently unavailable" over content that was right there — and named an env var
+ *     that would not have helped. `/api/v1/ui` had exactly this bug and it was fixed
+ *     there; this copy was missed.
  *
  * `basePath` controls where the per-card links go — `/components` (the docs
  * surface) by default, `/playground` when rendered from the playground index.
  */
 export async function ComponentGallery({ basePath }: { basePath?: string } = {}) {
-  let items: GalleryItem[] = []
+  let items: GalleryItem[]
 
-  if (isSupabaseConfigured()) {
-    try {
-      const components = await getAllComponents()
-      items = components.map((c) => ({
-        name: c.name,
-        type: c.registry_type,
-        description: c.description,
-      }))
-    } catch {
-      items = []
-    }
+  try {
+    const components = await getAllComponents()
+    items = components.map((c) => ({
+      name: c.name,
+      type: c.type ?? "registry:ui",
+      description: c.description ?? "",
+    }))
+  } catch {
+    items = []
   }
 
   if (items.length === 0) {
     return (
       <div className="rounded-xl border border-border bg-muted/30 p-8 text-center text-sm text-muted-foreground">
-        Registry is currently unavailable. Check that{" "}
-        <code className="font-mono">NEXT_PUBLIC_SUPABASE_URL</code> is set and the database is
-        seeded.
+        The component registry could not be read. This is a build problem rather than a
+        configuration one — the registry ships with the app.
       </div>
     )
   }

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -197,8 +197,8 @@ function docRowFromMeta(name: string, meta: RegistryMeta): ComponentDocRow {
 /**
  * Get a single component by name.
  */
-export async function getComponent(name: string): Promise<ComponentRow | null> {
-  return readComponent(name) as unknown as ComponentRow | null
+export async function getComponent(name: string): Promise<RegistryItem | null> {
+  return readComponent(name)
 }
 
 /**

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -37,7 +37,7 @@
  */
 
 import { doctrineRows, readDoctrineSorted, DOCTRINE } from "@/lib/doctrine"
-import { readComponent, readComponents, readNodeCounts } from "@/lib/registry"
+import { readComponent, readComponents, readNodeCounts, type RegistryItem } from "@/lib/registry"
 import { createClient } from "@supabase/supabase-js"
 import type {
   ComponentRow,
@@ -203,9 +203,17 @@ export async function getComponent(name: string): Promise<ComponentRow | null> {
 
 /**
  * Get all components, sorted by name.
+ *
+ * Returns `RegistryItem`, which is what `readComponents()` actually produces. It used to
+ * claim `ComponentRow` — the retired Supabase row shape — through an `as unknown as` cast,
+ * and that cast was not cosmetic: `ComponentRow` names `registry_type` and
+ * `registry_dependencies` where a registry item has `type` and `registryDependencies`, so
+ * `/api/v1/ui` read two fields that do not exist, TypeScript approved, and the index
+ * silently served every item without its `type`. A cast that renames fields is a lie the
+ * compiler is obliged to believe.
  */
-export async function getAllComponents(): Promise<ComponentRow[]> {
-  return readComponents() as unknown as ComponentRow[]
+export async function getAllComponents(): Promise<RegistryItem[]> {
+  return readComponents()
 }
 
 /**

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -6,6 +6,8 @@
  * indexable, and protected by RLS.
  */
 
+import type { RegistryItem } from "@/lib/registry"
+
 // ── Row types (what comes back from Supabase) ───────────────────────
 
 export interface ComponentRow {
@@ -108,7 +110,15 @@ export type ComponentCategory =
 
 // ── Enriched types ──────────────────────────────────────────────────
 
-export interface ComponentWithDocs extends ComponentRow {
+/**
+ * A registry item plus its docs and demo flag.
+ *
+ * Extends `RegistryItem` — what the registry reader actually produces — not `ComponentRow`,
+ * which is the retired Supabase row shape and names `registry_type` where an item has
+ * `type`. Anything typed as `ComponentRow` while holding a registry item can read fields
+ * that are always `undefined` and the compiler will agree with it.
+ */
+export interface ComponentWithDocs extends RegistryItem {
   docs?: ComponentDocRow | null
   demo?: ComponentDemoRow | null
 }

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -45,6 +45,27 @@ function safeSourcePath(...segments: string[]): string | null {
 
 export type RegistryFile = { path: string; type?: string }
 
+/**
+ * The authored `meta` block from `registry.json` — a component's documented contract.
+ *
+ * It was spread into every item by `readComponents()` and declared nowhere, so nothing
+ * could read `owner` or `collection` without a cast. That is how `/api/v1/ui` shipped an
+ * index with no way to filter by either: the data was always there, the type said it was
+ * not. Declaring it is what makes the index able to serve it (CLAUDE.md §6.1).
+ */
+export type RegistryMeta = {
+  useCases?: string[]
+  variants?: string[]
+  sizes?: string[]
+  features?: string[]
+  a11y?: string[]
+  /** `mzizi` | `nyuchi` | `bundu` | `framework`. */
+  owner?: string
+  /** The authored collection, e.g. `primitives`, `brand`, `pages`. */
+  collection?: string
+  hasDemo?: boolean
+}
+
 export type RegistryItem = {
   name: string
   type?: string
@@ -52,6 +73,8 @@ export type RegistryItem = {
   dependencies?: string[]
   registryDependencies?: string[]
   files?: RegistryFile[]
+  /** The authored contract from `registry.json`. */
+  meta?: RegistryMeta
   /** Derived from the directory on disk, e.g. `n2-primitives` → 2. */
   node?: number
   /** The directory label on disk, e.g. `primitives`. */


### PR DESCRIPTION
Started as "make the MCP's filters work". The cast that caused it was hiding a much worse defect one route over.

## `npx shadcn add` has been installing components without their dependencies

`/api/v1/ui/{name}` is what the CLI consumes. It mapped `component.registry_type` and `component.registry_dependencies` — **retired Supabase column names** — so both were `undefined`, and `JSON.stringify` drops undefined keys. Verified against production, right now:

```
GET https://mzizi.dev/api/v1/ui/nyuchi-listing-card
  keys: $schema, dependencies, description, files, name
  type: null      registryDependencies: null
```

What `registry.json` says that component needs:

```json
["card", "badge", "avatar", "https://mzizi.dev/api/v1/ui/nyuchi-harness"]
```

So the install produced a listing card with no card, badge, avatar or harness beneath it.

**Across the registry: 333 of 573 components declare `registryDependencies`, and 798 dependency edges were being dropped.** Every one is a consumer app missing files it was told it would get. The payload also carried no `type`, which its own `$schema` (`registry-item.json`) requires.

## The original symptom: an index nothing could filter

`/api/v1/ui` served three fields — `name`, `description`, `dependencies` — while appearing to serve five, for the same reason. So the MCP's `node` / `owner` / `category` filters compared against `undefined` and returned `count: 0` for **every value of every filter**, which reads exactly like "no such components".

## Why none of it was visible

1. **`getAllComponents()` / `getComponent()` claimed `ComponentRow` through `as unknown as`.** A cast that renames fields is a lie the compiler is obliged to believe.
2. **The tests fed the retired shape.** Fixtures used `registry_type`, so the mapping found them — and a spec asserted `item.type` matched `/^registry:(ui|hook|lib|block)$/` and **passed**, while production sent no `type`. The fixture agreed with the defect, so the test certified it.

## Deleting the cast enumerated the rest

31 phantom reads across 8 files, every one rendering or serving blank, none failing:

| Surface | Was reading | Visible effect |
| --- | --- | --- |
| `components/[name]`, `playground/[name]` | `layer`, `registry_type`, `registry_dependencies` | N-badge blank, type label wrong, dependency list empty |
| `source/[name]` | `layer`, `category`, `registry_type` | subtitle and header showed `—` |
| `components/[name]/opengraph-image` | `layer` | every component's OG eyebrow fell back to a generic string |
| `changelog/[name]` | `added_in_version` | "Added in v…" never rendered |
| `api/health/[name]`, `api/chaos/[name]` | 6 retired columns | nulls |
| `playground/component-gallery` | `registry_type` **+ an `isSupabaseConfigured()` gate** | card types undefined; and "Registry is currently unavailable" shown over content **in the bundle** — the same defect fixed in the API route and missed in this copy |

`layer` returns under **no name**: the axis/layer model is retired and must not be served, nested or relabelled (§9). `node` replaced it and is real — derived from the directory on disk. `added_in_version` is **not** invented back: when a component was added is history, and `/api/v1/ui/{name}/versions` already answers it; deriving a second, possibly disagreeing answer is the drift this repo keeps removing.

## What the index serves now

`type` and `registryDependencies` restored, plus `node`, `nodeLabel`, `owner`, `collection` — none of it new data. `owner`/`collection` come from the authored `meta` block, which `readComponents()` spread into every item and **declared nowhere**, so nothing could read it without a cast.

Filters (`node`/`owner`/`collection`/`type`) and paging (`limit`/`offset`) apply server-side. **Unset `limit` means everything**, so `npx shadcn` and every existing consumer are unaffected. `node` is uncapped and an unknown one returns an empty list, never a 400 (§9). `meta.registryTotal` sits beside `meta.total` so a caller can tell "your filter matched nothing" from "the registry is empty" — identical-looking empty arrays, and only the first is a query to rewrite.

Also: the payload announced `name: "mukoko"`. `registry.json` says `mzizi`, and the manifest is the authority.

## Verification — run against the real registry, not fixtures

| Check | Result |
| --- | --- |
| `pnpm typecheck` | 0 errors |
| `eslint --max-warnings=0` | clean |
| `pnpm test` | **200 passed**, 20 files |
| `pnpm registry:validate` | every item resolves and installs |

Live, against a dev server on the real 573-component registry:

```
/ui/button              keys now include type + registryDependencies
/ui/nyuchi-listing-card type=registry:ui, registryDeps=4   (was 0)
/ui                     573/573 items carry node, owner, collection, type
?node=2       → 371     ?node=11 → 1       ?node=99 → 0 (200, registryTotal 573)
?owner=nyuchi → 143     ?owner=bundu → 17
?collection=brand → 63  ?type=registry:lib → 46
?owner=mzizi&node=2 → 228        ?limit=5&offset=10 → 5 of 573
```

Every count matches what `registry.json` independently predicts.

## Deploy order

Ship this **before** mzizi-tools#60. An API that does not know the filter params ignores them and returns the whole registry; a client assuming otherwise would label 400 unrelated components as a filtered result. The MCP side carries a guard that refuses to do that, but app-first is the clean order.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED