### PR TITLE
fix(registry): stop serving empty files — 9 empty installs across 5 components

### DIFF
--- a/app/api/v1/ui/[name]/route.ts
+++ b/app/api/v1/ui/[name]/route.ts
@@ -76,10 +76,46 @@ export async function GET(_request: Request, { params }: { params: Promise<{ nam
 
     // `files` is optional on a registry item, and an item without one is not installable.
     // Falling through to `.map()` would have thrown a 500 where a 404 is the honest answer.
-    const files = (component.files ?? []).map((file, i) => ({
+    const declared = component.files ?? []
+
+    // A component is ONE source file. `readComponentSource(name)` resolves it by component
+    // NAME (components/registry/n<N>-<label>/<name>.<ext>), not by the install path, so
+    // there is no second file to read and never was.
+    //
+    // This used to be `content: i === 0 ? source : ""` — every file after the first was
+    // hardcoded to an empty string. Five components declared more files than exist, so
+    // `npx shadcn add nyuchi-tokens` wrote lib/tokens/primitives.ts, semantic.ts and
+    // components.ts as EMPTY FILES over whatever the consumer had. The doc comment on this
+    // route promised the opposite in as many words — "a component whose file is missing is
+    // a 404 and never a 200 with an empty body" — while the code below it did exactly that.
+    //
+    // Refusing is the only honest answer: an empty file is indistinguishable from a
+    // deliberately empty module, so it fails at the consumer's build rather than here.
+    if (declared.length > 1) {
+      logger.error("Registry item declares more files than it has sources", {
+        data: { name, declared: declared.map((f) => f.path) },
+      })
+      trackApiCall({
+        endpoint: `/api/v1/ui/${name}`,
+        durationMs: Date.now() - start,
+        statusCode: 500,
+        componentName: name,
+      })
+      return NextResponse.json(
+        {
+          error:
+            `Registry item "${name}" declares ${declared.length} files but a component has ` +
+            `exactly one source. This is a manifest bug in registry.json, not a bad request — ` +
+            `serving it would hand you empty files.`,
+        },
+        { status: 500, headers: { "Access-Control-Allow-Origin": "*" } }
+      )
+    }
+
+    const files = declared.map((file) => ({
       path: file.path,
       type: file.type,
-      content: i === 0 ? source : "",
+      content: source,
     }))
 
     logger.info("Component served", {

--- a/registry.json
+++ b/registry.json
@@ -27,19 +27,19 @@
           "WCAG 2.1 contrast ratio computation per simulated pair",
           "Configurable contrast floor (default 3.0 for WCAG AA large text)",
           "audit_exempt flag skips decorative pairs per WCAG 1.4.11 exemption",
-          "Regression detection \u2014 files Fundi issues only for NEW failures, not existing ones",
-          "Severity assignment \u2014 high for foreground/error/success pairs, medium for others",
+          "Regression detection — files Fundi issues only for NEW failures, not existing ones",
+          "Severity assignment — high for foreground/error/success pairs, medium for others",
           "Scheduled via pg_cron (daily 02:00 UTC)",
-          "SQL-only implementation \u2014 no edge function required"
+          "SQL-only implementation — no edge function required"
         ],
         "hasDemo": true,
         "owner": "mzizi",
         "useCases": [
           "Daily WCAG and color-blindness validation across every semantic-color pair",
-          "Continuous regression detection \u2014 any token change that breaks a11y is caught within 24h",
-          "Pre-launch accessibility gate \u2014 ensures palette is colorblind-safe before each release",
-          "Fundi-integrated healing loop \u2014 new failures create GitHub issues automatically",
-          "On-demand validation \u2014 call run_accessibility_audit() in migrations or CI"
+          "Continuous regression detection — any token change that breaks a11y is caught within 24h",
+          "Pre-launch accessibility gate — ensures palette is colorblind-safe before each release",
+          "Fundi-integrated healing loop — new failures create GitHub issues automatically",
+          "On-demand validation — call run_accessibility_audit() in migrations or CI"
         ],
         "variants": [
           "scheduled-daily",
@@ -186,7 +186,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -519,7 +519,7 @@
     },
     {
       "dependencies": [],
-      "description": "Analytics dashboard page. KPI cards, time-series charts, data tables, date range picker, export controls. Used by Mukoko Console, Nyuchi Web Services, and B2B partners. Open data compatible \u2014 sections can be made public. Competitors: Grafana, Google Analytics, Metabase.",
+      "description": "Analytics dashboard page. KPI cards, time-series charts, data tables, date range picker, export controls. Used by Mukoko Console, Nyuchi Web Services, and B2B partners. Open data compatible — sections can be made public. Competitors: Grafana, Google Analytics, Metabase.",
       "files": [
         {
           "path": "components/ui/analytics-dashboard-page.tsx",
@@ -536,7 +536,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -656,7 +656,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -767,7 +767,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7\u2192L8\u2192L9)",
+          "Cross-layer wiring (L7→L8→L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -833,7 +833,7 @@
     },
     {
       "dependencies": [],
-      "description": "SVG radial arc gauge (270\u00b0 sweep, open at bottom). Displays a percentage value as a filled arc with the value text centered inside. Uses stroke-dasharray animation. Proper role=\"meter\" with aria-valuenow/min/max. Used for UV index, trust scores, completion percentages, health metrics, battery levels \u2014 any bounded numeric value. Production-proven in mukoko-weather MetricCard.",
+      "description": "SVG radial arc gauge (270° sweep, open at bottom). Displays a percentage value as a filled arc with the value text centered inside. Uses stroke-dasharray animation. Proper role=\"meter\" with aria-valuenow/min/max. Used for UV index, trust scores, completion percentages, health metrics, battery levels — any bounded numeric value. Production-proven in mukoko-weather MetricCard.",
       "files": [
         {
           "path": "components/ui/arc-gauge.tsx",
@@ -871,7 +871,7 @@
     },
     {
       "dependencies": [],
-      "description": "Nyuchi ecosystem architecture specification \u2014 local-first data strategy and sovereignty assessment.",
+      "description": "Nyuchi ecosystem architecture specification — local-first data strategy and sovereignty assessment.",
       "files": [
         {
           "path": "lib/architecture.ts",
@@ -923,7 +923,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -1367,7 +1367,7 @@
       "dependencies": [
         "class-variance-authority"
       ],
-      "description": "Asymmetric grid layout with varying tile sizes. Japanese-inspired content layout pattern for dashboards, feature showcases, and landing pages. Supports responsive breakpoint-aware tile resizing. Audit flagged as missing UX pattern. ALPHA \u2014 awaiting frontend implementation.",
+      "description": "Asymmetric grid layout with varying tile sizes. Japanese-inspired content layout pattern for dashboards, feature showcases, and landing pages. Supports responsive breakpoint-aware tile resizing. Audit flagged as missing UX pattern. ALPHA — awaiting frontend implementation.",
       "files": [
         {
           "path": "components/ui/bento-grid.tsx",
@@ -1429,7 +1429,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -1549,7 +1549,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -1984,7 +1984,7 @@
         "chart.js",
         "react-chartjs-2"
       ],
-      "description": "Chart.js Canvas-based chart renderer for data-heavy dashboards. Use INSTEAD of the Recharts chart when you have 100+ data points per chart or multiple charts per page. Canvas renders everything to a single DOM element regardless of data volume, while SVG (Recharts) creates a DOM node per data point. Includes CSS variable resolution for Canvas 2D context (which cannot read var() natively), theme-aware color fallbacks, mobile performance optimisation (reduced DPR, disabled animations), and automatic Chart.js instance cleanup on unmount to prevent canvas memory leaks. Production-proven in mukoko-weather with 7 charts \u00d7 365 data points.",
+      "description": "Chart.js Canvas-based chart renderer for data-heavy dashboards. Use INSTEAD of the Recharts chart when you have 100+ data points per chart or multiple charts per page. Canvas renders everything to a single DOM element regardless of data volume, while SVG (Recharts) creates a DOM node per data point. Includes CSS variable resolution for Canvas 2D context (which cannot read var() natively), theme-aware color fallbacks, mobile performance optimisation (reduced DPR, disabled animations), and automatic Chart.js instance cleanup on unmount to prevent canvas memory leaks. Production-proven in mukoko-weather with 7 charts × 365 data points.",
       "files": [
         {
           "path": "components/ui/canvas-chart.tsx",
@@ -2395,7 +2395,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart \u2014 axes variant.",
+      "description": "Area chart — axes variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-axes.tsx",
@@ -2435,7 +2435,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart \u2014 default variant.",
+      "description": "Area chart — default variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-default.tsx",
@@ -2475,7 +2475,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart \u2014 gradient variant.",
+      "description": "Area chart — gradient variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-gradient.tsx",
@@ -2515,7 +2515,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart \u2014 icons variant.",
+      "description": "Area chart — icons variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-icons.tsx",
@@ -2555,7 +2555,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart \u2014 interactive variant.",
+      "description": "Area chart — interactive variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-interactive.tsx",
@@ -2595,7 +2595,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart \u2014 legend variant.",
+      "description": "Area chart — legend variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-legend.tsx",
@@ -2635,7 +2635,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart \u2014 linear variant.",
+      "description": "Area chart — linear variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-linear.tsx",
@@ -2675,7 +2675,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart \u2014 stacked variant.",
+      "description": "Area chart — stacked variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-stacked.tsx",
@@ -2715,7 +2715,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart \u2014 stacked expand variant.",
+      "description": "Area chart — stacked expand variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-stacked-expand.tsx",
@@ -2755,7 +2755,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart \u2014 step variant.",
+      "description": "Area chart — step variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-step.tsx",
@@ -2795,7 +2795,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart \u2014 active variant.",
+      "description": "Bar chart — active variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-active.tsx",
@@ -2835,7 +2835,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart \u2014 default variant.",
+      "description": "Bar chart — default variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-default.tsx",
@@ -2875,7 +2875,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart \u2014 horizontal variant.",
+      "description": "Bar chart — horizontal variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-horizontal.tsx",
@@ -2915,7 +2915,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart \u2014 interactive variant.",
+      "description": "Bar chart — interactive variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-interactive.tsx",
@@ -2955,7 +2955,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart \u2014 label variant.",
+      "description": "Bar chart — label variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-label.tsx",
@@ -2995,7 +2995,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart \u2014 label custom variant.",
+      "description": "Bar chart — label custom variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-label-custom.tsx",
@@ -3035,7 +3035,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart \u2014 mixed variant.",
+      "description": "Bar chart — mixed variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-mixed.tsx",
@@ -3075,7 +3075,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart \u2014 multiple variant.",
+      "description": "Bar chart — multiple variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-multiple.tsx",
@@ -3115,7 +3115,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart \u2014 negative variant.",
+      "description": "Bar chart — negative variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-negative.tsx",
@@ -3155,7 +3155,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart \u2014 stacked variant.",
+      "description": "Bar chart — stacked variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-stacked.tsx",
@@ -3195,7 +3195,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart \u2014 default variant.",
+      "description": "Line chart — default variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-default.tsx",
@@ -3235,7 +3235,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart \u2014 dots variant.",
+      "description": "Line chart — dots variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-dots.tsx",
@@ -3275,7 +3275,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart \u2014 dots colors variant.",
+      "description": "Line chart — dots colors variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-dots-colors.tsx",
@@ -3315,7 +3315,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart \u2014 dots custom variant.",
+      "description": "Line chart — dots custom variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-dots-custom.tsx",
@@ -3355,7 +3355,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart \u2014 interactive variant.",
+      "description": "Line chart — interactive variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-interactive.tsx",
@@ -3395,7 +3395,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart \u2014 label variant.",
+      "description": "Line chart — label variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-label.tsx",
@@ -3435,7 +3435,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart \u2014 label custom variant.",
+      "description": "Line chart — label custom variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-label-custom.tsx",
@@ -3475,7 +3475,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart \u2014 linear variant.",
+      "description": "Line chart — linear variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-linear.tsx",
@@ -3515,7 +3515,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart \u2014 multiple variant.",
+      "description": "Line chart — multiple variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-multiple.tsx",
@@ -3555,7 +3555,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart \u2014 step variant.",
+      "description": "Line chart — step variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-step.tsx",
@@ -3595,7 +3595,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart \u2014 donut variant.",
+      "description": "Pie chart — donut variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-donut.tsx",
@@ -3635,7 +3635,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart \u2014 donut active variant.",
+      "description": "Pie chart — donut active variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-donut-active.tsx",
@@ -3675,7 +3675,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart \u2014 donut text variant.",
+      "description": "Pie chart — donut text variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-donut-text.tsx",
@@ -3715,7 +3715,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart \u2014 interactive variant.",
+      "description": "Pie chart — interactive variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-interactive.tsx",
@@ -3755,7 +3755,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart \u2014 label variant.",
+      "description": "Pie chart — label variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-label.tsx",
@@ -3795,7 +3795,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart \u2014 label custom variant.",
+      "description": "Pie chart — label custom variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-label-custom.tsx",
@@ -3835,7 +3835,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart \u2014 label list variant.",
+      "description": "Pie chart — label list variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-label-list.tsx",
@@ -3875,7 +3875,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart \u2014 legend variant.",
+      "description": "Pie chart — legend variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-legend.tsx",
@@ -3915,7 +3915,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart \u2014 separator none variant.",
+      "description": "Pie chart — separator none variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-separator-none.tsx",
@@ -3955,7 +3955,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart \u2014 simple variant.",
+      "description": "Pie chart — simple variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-simple.tsx",
@@ -3995,7 +3995,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart \u2014 stacked variant.",
+      "description": "Pie chart — stacked variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-stacked.tsx",
@@ -4035,7 +4035,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart \u2014 default variant.",
+      "description": "Radar chart — default variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-default.tsx",
@@ -4075,7 +4075,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart \u2014 dots variant.",
+      "description": "Radar chart — dots variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-dots.tsx",
@@ -4115,7 +4115,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart \u2014 grid circle variant.",
+      "description": "Radar chart — grid circle variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-grid-circle.tsx",
@@ -4155,7 +4155,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart \u2014 grid circle fill variant.",
+      "description": "Radar chart — grid circle fill variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-grid-circle-fill.tsx",
@@ -4195,7 +4195,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart \u2014 grid circle no lines variant.",
+      "description": "Radar chart — grid circle no lines variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-grid-circle-no-lines.tsx",
@@ -4235,7 +4235,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart \u2014 grid custom variant.",
+      "description": "Radar chart — grid custom variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-grid-custom.tsx",
@@ -4275,7 +4275,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart \u2014 grid fill variant.",
+      "description": "Radar chart — grid fill variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-grid-fill.tsx",
@@ -4315,7 +4315,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart \u2014 grid none variant.",
+      "description": "Radar chart — grid none variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-grid-none.tsx",
@@ -4355,7 +4355,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart \u2014 icons variant.",
+      "description": "Radar chart — icons variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-icons.tsx",
@@ -4395,7 +4395,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart \u2014 label custom variant.",
+      "description": "Radar chart — label custom variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-label-custom.tsx",
@@ -4435,7 +4435,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart \u2014 legend variant.",
+      "description": "Radar chart — legend variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-legend.tsx",
@@ -4475,7 +4475,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart \u2014 lines only variant.",
+      "description": "Radar chart — lines only variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-lines-only.tsx",
@@ -4515,7 +4515,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart \u2014 multiple variant.",
+      "description": "Radar chart — multiple variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-multiple.tsx",
@@ -4555,7 +4555,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart \u2014 radius variant.",
+      "description": "Radar chart — radius variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-radius.tsx",
@@ -4595,7 +4595,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radial chart \u2014 grid variant.",
+      "description": "Radial chart — grid variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radial-grid.tsx",
@@ -4635,7 +4635,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radial chart \u2014 label variant.",
+      "description": "Radial chart — label variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radial-label.tsx",
@@ -4675,7 +4675,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radial chart \u2014 shape variant.",
+      "description": "Radial chart — shape variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radial-shape.tsx",
@@ -4715,7 +4715,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radial chart \u2014 simple variant.",
+      "description": "Radial chart — simple variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radial-simple.tsx",
@@ -4755,7 +4755,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radial chart \u2014 stacked variant.",
+      "description": "Radial chart — stacked variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radial-stacked.tsx",
@@ -4795,7 +4795,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radial chart \u2014 text variant.",
+      "description": "Radial chart — text variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radial-text.tsx",
@@ -4835,7 +4835,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Tooltip chart \u2014 advanced variant.",
+      "description": "Tooltip chart — advanced variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-tooltip-advanced.tsx",
@@ -4875,7 +4875,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Tooltip chart \u2014 default variant.",
+      "description": "Tooltip chart — default variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-tooltip-default.tsx",
@@ -4915,7 +4915,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Tooltip chart \u2014 formatter variant.",
+      "description": "Tooltip chart — formatter variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-tooltip-formatter.tsx",
@@ -4955,7 +4955,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Tooltip chart \u2014 icons variant.",
+      "description": "Tooltip chart — icons variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-tooltip-icons.tsx",
@@ -4995,7 +4995,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Tooltip chart \u2014 indicator line variant.",
+      "description": "Tooltip chart — indicator line variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-tooltip-indicator-line.tsx",
@@ -5035,7 +5035,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Tooltip chart \u2014 indicator none variant.",
+      "description": "Tooltip chart — indicator none variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-tooltip-indicator-none.tsx",
@@ -5075,7 +5075,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Tooltip chart \u2014 label custom variant.",
+      "description": "Tooltip chart — label custom variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-tooltip-label-custom.tsx",
@@ -5115,7 +5115,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Tooltip chart \u2014 label formatter variant.",
+      "description": "Tooltip chart — label formatter variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-tooltip-label-formatter.tsx",
@@ -5155,7 +5155,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Tooltip chart \u2014 label none variant.",
+      "description": "Tooltip chart — label none variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-tooltip-label-none.tsx",
@@ -5363,7 +5363,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -5480,7 +5480,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -5892,7 +5892,7 @@
     },
     {
       "dependencies": [],
-      "description": "Inline paragraph-level commenting \u2014 the Medium-style annotation pattern. Users highlight text in a chapter and leave comments anchored to that specific passage. Maps to a future comments schema on novels.chapter.",
+      "description": "Inline paragraph-level commenting — the Medium-style annotation pattern. Users highlight text in a chapter and leave comments anchored to that specific passage. Maps to a future comments schema on novels.chapter.",
       "files": [
         {
           "path": "components/ui/comment-on-paragraph.tsx",
@@ -5986,7 +5986,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -6372,7 +6372,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -6439,7 +6439,7 @@
     },
     {
       "dependencies": [],
-      "description": "Smart date display that shows relative time for recent dates (\"2 hours ago\", \"yesterday\") and absolute dates for older ones (\"15 May 2026\"). Respects locale from nyuchi-locale. A micro-primitive used everywhere \u2014 message timestamps, card metadata, activity feeds, task due dates.",
+      "description": "Smart date display that shows relative time for recent dates (\"2 hours ago\", \"yesterday\") and absolute dates for older ones (\"15 May 2026\"). Respects locale from nyuchi-locale. A micro-primitive used everywhere — message timestamps, card metadata, activity feeds, task due dates.",
       "files": [
         {
           "path": "components/ui/date-label.tsx",
@@ -6558,7 +6558,7 @@
     },
     {
       "dependencies": [],
-      "description": "Visual dependency/relationship display between items \u2014 task depends on task, event requires event, etc. Shows directed edges between nodes. Used in project planning (Planner), workflow visualization (Console), and content relationship mapping.",
+      "description": "Visual dependency/relationship display between items — task depends on task, event requires event, etc. Shows directed edges between nodes. Used in project planning (Planner), workflow visualization (Console), and content relationship mapping.",
       "files": [
         {
           "path": "components/ui/dependency-graph.tsx",
@@ -7136,7 +7136,7 @@
     },
     {
       "dependencies": [],
-      "description": "BushTrade escrow payment status tracker. Shows payment lifecycle stages: initiated \u2192 held \u2192 released/disputed. Maps to wallet.payment_intents with escrow state. Used in BushTrade transaction views and seller dashboards.",
+      "description": "BushTrade escrow payment status tracker. Shows payment lifecycle stages: initiated → held → released/disputed. Maps to wallet.payment_intents with escrow state. Used in BushTrade transaction views and seller dashboards.",
       "files": [
         {
           "path": "components/ui/escrow-status.tsx",
@@ -7248,7 +7248,7 @@
     },
     {
       "dependencies": [],
-      "description": "Currency pair display with live rate, conversion calculator, and trend indicator. Supports MXT \u2194 fiat pairs across 42 African currencies. Used in Wallet swap interface and BushTrade cross-border commerce.",
+      "description": "Currency pair display with live rate, conversion calculator, and trend indicator. Supports MXT ↔ fiat pairs across 42 African currencies. Used in Wallet swap interface and BushTrade cross-border commerce.",
       "files": [
         {
           "path": "components/ui/exchange-rate.tsx",
@@ -7284,7 +7284,7 @@
     },
     {
       "dependencies": [],
-      "description": "Sequential fallback strategy \u2014 try stages in order, return first success.",
+      "description": "Sequential fallback strategy — try stages in order, return first success.",
       "files": [
         {
           "path": "lib/fallback-chain.ts",
@@ -7303,7 +7303,7 @@
         "hasDemo": true,
         "owner": "mzizi",
         "useCases": [
-          "Degraded-mode content delivery (full \u2192 cache \u2192 placeholder)",
+          "Degraded-mode content delivery (full → cache → placeholder)",
           "Multi-source data retrieval with fallbacks",
           "Weather data with primary and backup providers",
           "Payment processing with backup gateway",
@@ -7731,7 +7731,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -7751,7 +7751,7 @@
     },
     {
       "dependencies": [],
-      "description": "Encrypted health record summary card showing recent visits, active prescriptions, allergies, and conditions. Data sourced from the sovereign Digital Twin pod \u2014 NEVER from Supabase. Respects Covenant One.",
+      "description": "Encrypted health record summary card showing recent visits, active prescriptions, allergies, and conditions. Data sourced from the sovereign Digital Twin pod — NEVER from Supabase. Respects Covenant One.",
       "files": [
         {
           "path": "components/ui/health-record-summary.tsx",
@@ -7878,7 +7878,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -7939,7 +7939,7 @@
     },
     {
       "dependencies": [],
-      "description": "Simple label + value display row with optional icon. Used on detail pages for key-value information: \"Temperature: 28\u00b0C\", \"Location: Harare\", \"Status: Active\". Compact single-line layout with icon left, label middle, value right-aligned. Production-proven in mukoko-weather for atmospheric details.",
+      "description": "Simple label + value display row with optional icon. Used on detail pages for key-value information: \"Temperature: 28°C\", \"Location: Harare\", \"Status: Active\". Compact single-line layout with icon left, label middle, value right-aligned. Production-proven in mukoko-weather for atmospheric details.",
       "files": [
         {
           "path": "components/ui/info-row.tsx",
@@ -7994,7 +7994,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -8014,7 +8014,7 @@
     },
     {
       "dependencies": [],
-      "description": "Click-to-edit text field that transforms from display mode to input mode on interaction. Pattern for low-friction editing in admin tables, settings pages, and profile fields. Supports validation, optimistic save, and revert on escape. Audit flagged as missing UX pattern. ALPHA \u2014 awaiting frontend implementation.",
+      "description": "Click-to-edit text field that transforms from display mode to input mode on interaction. Pattern for low-friction editing in admin tables, settings pages, and profile fields. Supports validation, optimistic save, and revert on escape. Audit flagged as missing UX pattern. ALPHA — awaiting frontend implementation.",
       "files": [
         {
           "path": "components/ui/inline-edit.tsx",
@@ -8356,7 +8356,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -8489,7 +8489,7 @@
     },
     {
       "dependencies": [],
-      "description": "Key Performance Indicator card. Displays a metric label, large value, optional change percentage with trend direction. Extracted from analytics-dashboard-page, console-dashboard-page, and wallet-page where the same pattern was repeated inline. Brand-agnostic \u2014 uses semantic CSS vars only.",
+      "description": "Key Performance Indicator card. Displays a metric label, large value, optional change percentage with trend direction. Extracted from analytics-dashboard-page, console-dashboard-page, and wallet-page where the same pattern was repeated inline. Brand-agnostic — uses semantic CSS vars only.",
       "files": [
         {
           "path": "components/ui/kpi-card.tsx",
@@ -8654,7 +8654,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -9034,7 +9034,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -9223,7 +9223,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -9371,7 +9371,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -9428,7 +9428,7 @@
     },
     {
       "dependencies": [],
-      "description": "Horizontal scrollable filter/effect picker \u2014 the TikTok/Instagram paradigm. Shows filter previews as circular thumbnails with names. Applies visual effects to camera preview or captured media. Used in Bytes creation flow.",
+      "description": "Horizontal scrollable filter/effect picker — the TikTok/Instagram paradigm. Shows filter previews as circular thumbnails with names. Applies visual effects to camera preview or captured media. Used in Bytes creation flow.",
       "files": [
         {
           "path": "components/ui/media-filter-strip.tsx",
@@ -9481,7 +9481,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -9812,7 +9812,7 @@
     },
     {
       "dependencies": [],
-      "description": "Payment method picker for African mobile money services \u2014 EcoCash, MTN MoMo, Airtel Money, M-Pesa, and Innbucks. Shows provider logo, phone number input, and USSD code reference. This is HOW Africa pays \u2014 the primary payment primitive for the continent.",
+      "description": "Payment method picker for African mobile money services — EcoCash, MTN MoMo, Airtel Money, M-Pesa, and Innbucks. Shows provider logo, phone number input, and USSD code reference. This is HOW Africa pays — the primary payment primitive for the continent.",
       "files": [
         {
           "path": "components/ui/mobile-money-selector.tsx",
@@ -9934,7 +9934,7 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure \u2014 no direct a11y requirements"
+          "Non-visual infrastructure — no direct a11y requirements"
         ],
         "collection": "observability",
         "features": [
@@ -9958,7 +9958,7 @@
     },
     {
       "dependencies": [],
-      "description": "Adaptive Bitrate Content \u2014 adjusts content quality based on network conditions. Serves lower-resolution images, compressed text, and deferred media on slow connections. Based on TikTok ABR streaming but applied to all content types, not just video. Critical for Africa where 2G/3G is common.",
+      "description": "Adaptive Bitrate Content — adjusts content quality based on network conditions. Serves lower-resolution images, compressed text, and deferred media on slow connections. Based on TikTok ABR streaming but applied to all content types, not just video. Critical for Africa where 2G/3G is common.",
       "files": [
         {
           "path": "components/ui/mzizi-abr-content.tsx",
@@ -9994,7 +9994,7 @@
     },
     {
       "dependencies": [],
-      "description": "SLO/SLA tracking and threshold-based alerting with escalation. Defines budgets (error budget, latency budget), monitors them, and fires alerts when thresholds are breached. Supports severity escalation: warn \u2192 page \u2192 incident. Competitors: PagerDuty, Grafana Alerting.",
+      "description": "SLO/SLA tracking and threshold-based alerting with escalation. Defines budgets (error budget, latency budget), monitors them, and fires alerts when thresholds are breached. Supports severity escalation: warn → page → incident. Competitors: PagerDuty, Grafana Alerting.",
       "files": [
         {
           "path": "lib/mzizi-alert-engine.ts",
@@ -10003,7 +10003,7 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure \u2014 no direct a11y requirements"
+          "Non-visual infrastructure — no direct a11y requirements"
         ],
         "collection": "observability",
         "features": [
@@ -10036,7 +10036,7 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure \u2014 no direct a11y requirements"
+          "Non-visual infrastructure — no direct a11y requirements"
         ],
         "collection": "observability",
         "features": [
@@ -10134,7 +10134,7 @@
     },
     {
       "dependencies": [],
-      "description": "Reactive chaos diagnostics \u2014 N8 Assurance (Z-axis/depth). Runs through the entire 3D architecture, able to inject failures at any component on any horizontal layer, through any vertical spine. Two modes: (1) Injection \u2014 random error/latency at configurable probability per layer intersection. (2) Reactive \u2014 when a real error is caught anywhere in the 3D space, probe adjacent systems for blast radius. The depth dimension that proves X and Y axes work.",
+      "description": "Reactive chaos diagnostics — N8 Assurance (Z-axis/depth). Runs through the entire 3D architecture, able to inject failures at any component on any horizontal layer, through any vertical spine. Two modes: (1) Injection — random error/latency at configurable probability per layer intersection. (2) Reactive — when a real error is caught anywhere in the 3D space, probe adjacent systems for blast radius. The depth dimension that proves X and Y axes work.",
       "files": [
         {
           "path": "lib/mzizi-chaos.tsx",
@@ -10168,7 +10168,7 @@
     },
     {
       "dependencies": [],
-      "description": "Conformity monkey \u2014 verifies deployed components match the design registry. Scans the DOM for data-slot/data-portal attributes and cross-references with the component database. Flags: unregistered components, outdated versions, missing backlinks, components using deprecated patterns. Inspired by Netflix Conformity Monkey.",
+      "description": "Conformity monkey — verifies deployed components match the design registry. Scans the DOM for data-slot/data-portal attributes and cross-references with the component database. Flags: unregistered components, outdated versions, missing backlinks, components using deprecated patterns. Inspired by Netflix Conformity Monkey.",
       "files": [
         {
           "path": "lib/mzizi-conformity-check.ts",
@@ -10177,7 +10177,7 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure \u2014 no direct a11y requirements"
+          "Non-visual infrastructure — no direct a11y requirements"
         ],
         "collection": "observability",
         "features": [
@@ -10242,7 +10242,7 @@
     },
     {
       "dependencies": [],
-      "description": "Post-quantum cryptography fallback handler. When PQC verification fails (library not loaded, algorithm not supported on device), falls back to classical verification with a \"reduced security\" visual indicator. Based on the QuantZen overlay pattern \u2014 adds quantum-safe layer without breaking existing UX.",
+      "description": "Post-quantum cryptography fallback handler. When PQC verification fails (library not loaded, algorithm not supported on device), falls back to classical verification with a \"reduced security\" visual indicator. Based on the QuantZen overlay pattern — adds quantum-safe layer without breaking existing UX.",
       "files": [
         {
           "path": "components/ui/mzizi-crypto-fallback.tsx",
@@ -10278,7 +10278,7 @@
     },
     {
       "dependencies": [],
-      "description": "Quantum-safe cryptographic verification gate. Validates signature strength \u2014 in quantum-ready mode requires PQC dual-signature (CRYSTALS-Dilithium + classical ECDSA). Degrades gracefully showing \"reduced security\" indicator when only classical signatures are available. Based on the QuantZen dual-signature pattern.",
+      "description": "Quantum-safe cryptographic verification gate. Validates signature strength — in quantum-ready mode requires PQC dual-signature (CRYSTALS-Dilithium + classical ECDSA). Degrades gracefully showing \"reduced security\" indicator when only classical signatures are available. Based on the QuantZen dual-signature pattern.",
       "files": [
         {
           "path": "components/ui/mzizi-crypto-gate.tsx",
@@ -10316,7 +10316,7 @@
     },
     {
       "dependencies": [],
-      "description": "Configurable degradation fallback chain: personalized \u2192 cached \u2192 trending \u2192 default \u2192 static. Each level renders when the previous fails. Based on Netflix graceful degradation \u2014 the \"bookmark service\" pattern applied across all mini-apps.",
+      "description": "Configurable degradation fallback chain: personalized → cached → trending → default → static. Each level renders when the previous fails. Based on Netflix graceful degradation — the \"bookmark service\" pattern applied across all mini-apps.",
       "files": [
         {
           "path": "components/ui/mzizi-degradation-chain.tsx",
@@ -10538,7 +10538,7 @@
     },
     {
       "dependencies": [],
-      "description": "Incident lifecycle management: detect \u2192 triage \u2192 mitigate \u2192 resolve \u2192 postmortem. Tracks incidents with severity, affected components (via backlinks), timeline of actions, and generates postmortem templates. Competitors: PagerDuty, incident.io.",
+      "description": "Incident lifecycle management: detect → triage → mitigate → resolve → postmortem. Tracks incidents with severity, affected components (via backlinks), timeline of actions, and generates postmortem templates. Competitors: PagerDuty, incident.io.",
       "files": [
         {
           "path": "lib/mzizi-incident-manager.ts",
@@ -10547,7 +10547,7 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure \u2014 no direct a11y requirements"
+          "Non-visual infrastructure — no direct a11y requirements"
         ],
         "collection": "observability",
         "features": [
@@ -10645,7 +10645,7 @@
     },
     {
       "dependencies": [],
-      "description": "Offline feature availability gate. Determines if a feature works offline, with cached data, or requires a connection. Shows branded \"available offline\" or \"requires connection\" state. Critical for local-first architecture \u2014 treats connectivity as a gradient, not a binary. Based on WhatsApp offline queuing but for all feature types.",
+      "description": "Offline feature availability gate. Determines if a feature works offline, with cached data, or requires a connection. Shows branded \"available offline\" or \"requires connection\" state. Critical for local-first architecture — treats connectivity as a gradient, not a binary. Based on WhatsApp offline queuing but for all feature types.",
       "files": [
         {
           "path": "components/ui/mzizi-offline-gate.tsx",
@@ -10728,7 +10728,7 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure \u2014 no direct a11y requirements"
+          "Non-visual infrastructure — no direct a11y requirements"
         ],
         "collection": "observability",
         "features": [
@@ -10790,7 +10790,7 @@
     },
     {
       "dependencies": [],
-      "description": "Transparent platform health dashboard \u2014 N8 Assurance (Z-axis/depth). Observes the full 3D architecture: every horizontal layer (L2-L7), every vertical spine (L1 tokens, L4 safety, L5 resilience), and reports which intersections are operational, degraded, or in outage. The depth view into the system.",
+      "description": "Transparent platform health dashboard — N8 Assurance (Z-axis/depth). Observes the full 3D architecture: every horizontal layer (L2-L7), every vertical spine (L1 tokens, L4 safety, L5 resilience), and reports which intersections are operational, degraded, or in outage. The depth view into the system.",
       "files": [
         {
           "path": "components/ui/mzizi-platform-health.tsx",
@@ -10799,7 +10799,7 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure \u2014 no direct a11y requirements"
+          "Non-visual infrastructure — no direct a11y requirements"
         ],
         "collection": "observability",
         "features": [
@@ -10897,7 +10897,7 @@
     },
     {
       "dependencies": [],
-      "description": "Real User Monitoring. Collects page load timing, interaction delays, network quality, and navigation patterns from actual users. Aggregates by mini-app, page, device, and connection type. Privacy-respecting \u2014 no PII, only performance metrics. Competitors: Datadog RUM, Vercel Analytics.",
+      "description": "Real User Monitoring. Collects page load timing, interaction delays, network quality, and navigation patterns from actual users. Aggregates by mini-app, page, device, and connection type. Privacy-respecting — no PII, only performance metrics. Competitors: Datadog RUM, Vercel Analytics.",
       "files": [
         {
           "path": "lib/mzizi-rum.ts",
@@ -10906,7 +10906,7 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure \u2014 no direct a11y requirements"
+          "Non-visual infrastructure — no direct a11y requirements"
         ],
         "collection": "observability",
         "features": [
@@ -10977,7 +10977,7 @@
     },
     {
       "dependencies": [],
-      "description": "DEPRECATED \u2014 Loading states are built into each component from Layer 2 up via the loading prop. Every component renders its own shaped skeleton matching its exact proportions. This top-down skeleton set is a legacy pattern. Use <NyuchiListingCard loading /> instead of <ListingSkeleton />. Will be removed in the next major version.",
+      "description": "DEPRECATED — Loading states are built into each component from Layer 2 up via the loading prop. Every component renders its own shaped skeleton matching its exact proportions. This top-down skeleton set is a legacy pattern. Use <NyuchiListingCard loading /> instead of <ListingSkeleton />. Will be removed in the next major version.",
       "files": [
         {
           "path": "components/ui/mzizi-skeleton-set.tsx",
@@ -10989,7 +10989,7 @@
           "aria-busy=true on parent container",
           "aria-live=polite for updates when loading completes",
           "Screen reader silent during shimmer (decorative)",
-          "Non-interactive \u2014 no focus traps"
+          "Non-interactive — no focus traps"
         ],
         "collection": "resilience",
         "features": [
@@ -11061,7 +11061,7 @@
     },
     {
       "dependencies": [],
-      "description": "Synthetic user journey probes that run on schedule. Defines step-by-step user flows (login \u2192 navigate \u2192 action \u2192 verify) and executes them against live or staging environments. Reports pass/fail with latency per step. Competitors: Datadog Synthetic Monitoring, Checkly.",
+      "description": "Synthetic user journey probes that run on schedule. Defines step-by-step user flows (login → navigate → action → verify) and executes them against live or staging environments. Reports pass/fail with latency per step. Competitors: Datadog Synthetic Monitoring, Checkly.",
       "files": [
         {
           "path": "lib/mzizi-synthetic-probe.ts",
@@ -11070,7 +11070,7 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure \u2014 no direct a11y requirements"
+          "Non-visual infrastructure — no direct a11y requirements"
         ],
         "collection": "observability",
         "features": [
@@ -11094,7 +11094,7 @@
     },
     {
       "dependencies": [],
-      "description": "Trust score threshold gate. Blocks features that require a minimum trust score. Shows the user's current score, the required threshold, and actionable steps to improve. Maps to the Ubuntu Layer trust model: Status \u00d7 Verification Tier \u2192 Trust Score. Used for: posting requires > 0.1, selling requires > 0.3, moderating requires > 0.5.",
+      "description": "Trust score threshold gate. Blocks features that require a minimum trust score. Shows the user's current score, the required threshold, and actionable steps to improve. Maps to the Ubuntu Layer trust model: Status × Verification Tier → Trust Score. Used for: posting requires > 0.1, selling requires > 0.3, moderating requires > 0.5.",
       "files": [
         {
           "path": "components/ui/mzizi-trust-gate.tsx",
@@ -11535,7 +11535,7 @@
     },
     {
       "dependencies": [],
-      "description": "Full-screen or drawer notification management surface. Extends notification-center (existing Layer 2 component) with filter/search, archive, bulk actions, and grouped conversations view. Audit flagged as missing UX pattern for mature notification UX. ALPHA \u2014 awaiting frontend implementation.",
+      "description": "Full-screen or drawer notification management surface. Extends notification-center (existing Layer 2 component) with filter/search, archive, bulk actions, and grouped conversations view. Audit flagged as missing UX pattern for mature notification UX. ALPHA — awaiting frontend implementation.",
       "files": [
         {
           "path": "components/ui/notification-center-full.tsx",
@@ -11733,7 +11733,7 @@
     },
     {
       "dependencies": [],
-      "description": "Universal branded bottom action sheet for contextual actions on any content across the ecosystem. Share, save, report, copy link, block, follow \u2014 the standard set of actions available on listings, posts, profiles, and messages. Renders as a bottom sheet on mobile with mineral accent on destructive/primary actions. Composes sheet and share-dialog primitives.",
+      "description": "Universal branded bottom action sheet for contextual actions on any content across the ecosystem. Share, save, report, copy link, block, follow — the standard set of actions available on listings, posts, profiles, and messages. Renders as a bottom sheet on mobile with mineral accent on destructive/primary actions. Composes sheet and share-dialog primitives.",
       "files": [
         {
           "path": "components/ui/nyuchi-action-sheet.tsx",
@@ -11776,7 +11776,7 @@
     },
     {
       "dependencies": [],
-      "description": "AI context provider for N10. Generates context windows for AI assistants (Claude, Cursor, Copilot, Windsurf) with current ecosystem model, node architecture, and coding rules. No hardcoded counts \u2014 always accepts live values from get_system_counts(). Used by the MCP server and IDE integrations.",
+      "description": "AI context provider for N10. Generates context windows for AI assistants (Claude, Cursor, Copilot, Windsurf) with current ecosystem model, node architecture, and coding rules. No hardcoded counts — always accepts live values from get_system_counts(). Used by the MCP server and IDE integrations.",
       "files": [
         {
           "path": "lib/nyuchi-ai-context.ts",
@@ -11957,7 +11957,7 @@
         ],
         "collection": "agentic-components",
         "features": [
-          "Inline sign-in AND registration \u2014 never a browser tab",
+          "Inline sign-in AND registration — never a browser tab",
           "Mode toggle between login and register",
           "SSO / passwordless provider buttons",
           "Drives the MCP inline-auth handoff (OAuth 2.1 / DCR / elicitation)",
@@ -12001,7 +12001,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -12025,7 +12025,7 @@
     },
     {
       "dependencies": [],
-      "description": "Overlapping +N social-proof avatar stack \u2014 the going/attendee cue. Ring-separated avatars overlap with negative margin, each an image or an initials fallback, showing up to `max` before a +N overflow bubble, with an optional trailing <total> <label> in 13px muted. Purely presentational and server-safe (no harness, no client directive) so it renders inside React Server Components. The group carries an accessible summary label (e.g. \"128 going\") while the decorative avatars are aria-hidden. sm / md sizes.",
+      "description": "Overlapping +N social-proof avatar stack — the going/attendee cue. Ring-separated avatars overlap with negative margin, each an image or an initials fallback, showing up to `max` before a +N overflow bubble, with an optional trailing <total> <label> in 13px muted. Purely presentational and server-safe (no harness, no client directive) so it renders inside React Server Components. The group carries an accessible summary label (e.g. \"128 going\") while the decorative avatars are aria-hidden. sm / md sizes.",
       "files": [
         {
           "path": "components/ui/nyuchi-avatar-stack.tsx",
@@ -12045,7 +12045,7 @@
           "Image or initials fallback per person",
           "+N overflow bubble past max",
           "Optional trailing total + label (13px muted)",
-          "Server-safe presentational atom \u2014 no harness, no client directive",
+          "Server-safe presentational atom — no harness, no client directive",
           "sm / md size scale"
         ],
         "owner": "nyuchi",
@@ -12158,7 +12158,7 @@
       "dependencies": [
         "next"
       ],
-      "description": "Mobile-only bottom navigation bar for Nyuchi ecosystem apps. Supports a center FAB (floating action button) \u2014 a raised button in the app mineral accent colour with a glow shadow. The center FAB is the primary creation entry point, making the \"create\" action instantly recognizable across all apps.",
+      "description": "Mobile-only bottom navigation bar for Nyuchi ecosystem apps. Supports a center FAB (floating action button) — a raised button in the app mineral accent colour with a glow shadow. The center FAB is the primary creation entry point, making the \"create\" action instantly recognizable across all apps.",
       "files": [
         {
           "path": "components/ui/nyuchi-bottom-nav.tsx",
@@ -12173,7 +12173,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7\u2192L8\u2192L9)",
+          "Cross-layer wiring (L7→L8→L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -12201,7 +12201,7 @@
         "react-day-picker",
         "date-fns"
       ],
-      "description": "Brand calendar component wrapping react-day-picker with Mukoko event dot indicators, mineral-colored day highlights, and integrated agenda view for the selected day. Used by nhimbe (events), planner, and any Mukoko app that shows date-anchored content. The event dots are the key differentiator \u2014 small mineral-colored circles beneath dates that have associated content.",
+      "description": "Brand calendar component wrapping react-day-picker with Mukoko event dot indicators, mineral-colored day highlights, and integrated agenda view for the selected day. Used by nhimbe (events), planner, and any Mukoko app that shows date-anchored content. The event dots are the key differentiator — small mineral-colored circles beneath dates that have associated content.",
       "files": [
         {
           "path": "components/ui/nyuchi-calendar.tsx",
@@ -12373,7 +12373,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7\u2192L8\u2192L9)",
+          "Cross-layer wiring (L7→L8→L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -12396,7 +12396,7 @@
     },
     {
       "dependencies": [],
-      "description": "Universal freeform content creation component \u2014 the branded way to compose posts, updates, stories, and messages across the ecosystem. Combines text input, media attachment, mention tagging, and mineral-accented submit button. Used in Circles (posts), Pulse (updates), Campfire (messages), Novels (chapter drafts), and anywhere users create unstructured content. Distinct from nyuchi-create-listing which handles structured form-based creation.",
+      "description": "Universal freeform content creation component — the branded way to compose posts, updates, stories, and messages across the ecosystem. Combines text input, media attachment, mention tagging, and mineral-accented submit button. Used in Circles (posts), Pulse (updates), Campfire (messages), Novels (chapter drafts), and anywhere users create unstructured content. Distinct from nyuchi-create-listing which handles structured form-based creation.",
       "files": [
         {
           "path": "components/ui/nyuchi-content-composer.tsx",
@@ -12519,7 +12519,7 @@
     },
     {
       "dependencies": [],
-      "description": "Event/detail header composite that derives the whole page tint and CTA colour from its cover \u2014 the 4.2.0 cover-wash signature. A full-bleed image or gradient cover with a legibility scrim carries an overlaid title, optional kicker/subtitle, a small inline meta row (date \u00b7 location \u00b7 host) and a CTA slot (children). From an accent (or mineral) prop it emits --event-primary and --wash as inline custom properties on the root, seeding the wash context that every descendant \u2014 and the rest of the detail page \u2014 inherits. Accent defaults to --brand-accent so each app swaps its own mineral; harness-wired for reduced-motion entry and observability.",
+      "description": "Event/detail header composite that derives the whole page tint and CTA colour from its cover — the 4.2.0 cover-wash signature. A full-bleed image or gradient cover with a legibility scrim carries an overlaid title, optional kicker/subtitle, a small inline meta row (date · location · host) and a CTA slot (children). From an accent (or mineral) prop it emits --event-primary and --wash as inline custom properties on the root, seeding the wash context that every descendant — and the rest of the detail page — inherits. Accent defaults to --brand-accent so each app swaps its own mineral; harness-wired for reduced-motion entry and observability.",
       "files": [
         {
           "path": "components/ui/nyuchi-cover-wash-header.tsx",
@@ -12535,7 +12535,7 @@
         ],
         "collection": "brand",
         "features": [
-          "4.2.0 cover-wash signature \u2014 seeds --event-primary + --wash on the root",
+          "4.2.0 cover-wash signature — seeds --event-primary + --wash on the root",
           "Full-bleed image or gradient cover with legibility scrim",
           "Accent from prop or mineral, --brand-accent neutral default",
           "Inline meta row (date / location / host) + CTA slot via children",
@@ -12562,7 +12562,7 @@
       "dependencies": [
         "class-variance-authority"
       ],
-      "description": "Universal create/edit form layout for all Mukoko content types \u2014 events, products, news, bush trade listings, directories. Provides the standardized brand creation flow: cover theme picker, grouped form sections in cards, toggle/dropdown rows, description editor, and sticky publish CTA. Every \"Create\" or \"Edit\" screen across the super app uses this composition.",
+      "description": "Universal create/edit form layout for all Mukoko content types — events, products, news, bush trade listings, directories. Provides the standardized brand creation flow: cover theme picker, grouped form sections in cards, toggle/dropdown rows, description editor, and sticky publish CTA. Every \"Create\" or \"Edit\" screen across the super app uses this composition.",
       "files": [
         {
           "path": "components/ui/nyuchi-create-listing.tsx",
@@ -12628,7 +12628,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -12717,7 +12717,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -12747,7 +12747,7 @@
     },
     {
       "dependencies": [],
-      "description": "Data fetching and state management bridge between the 7-layer architecture and the UI. Exports useNyuchiQuery hook (local-first fetch: try SQLite/IndexedDB \u2192 edge D1 \u2192 cloud Supabase, with automatic background sync), NyuchiListView (declarative feed composition: listing-card + infinite scroll + pull-to-refresh + empty state + skeleton + error card), NyuchiSearchView (search input + filter bar + results + recent searches), and optimistic update utilities. Every data-driven screen in every Nyuchi app uses these patterns instead of raw fetch calls. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
+      "description": "Data fetching and state management bridge between the 7-layer architecture and the UI. Exports useNyuchiQuery hook (local-first fetch: try SQLite/IndexedDB → edge D1 → cloud Supabase, with automatic background sync), NyuchiListView (declarative feed composition: listing-card + infinite scroll + pull-to-refresh + empty state + skeleton + error card), NyuchiSearchView (search input + filter bar + results + recent searches), and optimistic update utilities. Every data-driven screen in every Nyuchi app uses these patterns instead of raw fetch calls. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
       "files": [
         {
           "path": "lib/data/index.tsx",
@@ -12801,7 +12801,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7\u2192L8\u2192L9)",
+          "Cross-layer wiring (L7→L8→L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -12824,7 +12824,7 @@
     },
     {
       "dependencies": [],
-      "description": "Shared detail page layout for all content types across the Nyuchi ecosystem \u2014 events, articles, products, bush trade listings, places. Supports a hero gradient variant with floating back/like/share action buttons, mineral-colored category badges, and verified badge display for the host/author. The detail-layout is the brand-standard way to present any single piece of content at full depth.",
+      "description": "Shared detail page layout for all content types across the Nyuchi ecosystem — events, articles, products, bush trade listings, places. Supports a hero gradient variant with floating back/like/share action buttons, mineral-colored category badges, and verified badge display for the host/author. The detail-layout is the brand-standard way to present any single piece of content at full depth.",
       "files": [
         {
           "path": "components/ui/nyuchi-detail-layout.tsx",
@@ -12841,7 +12841,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -12888,7 +12888,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -12917,7 +12917,7 @@
     },
     {
       "dependencies": [],
-      "description": "Documentation read API for N10. Runs as a Supabase Deno edge function (`Deno.serve`, `jsr:@supabase/supabase-js@2`) \u2014 NOT a Cloudflare Worker and not Rust/WASM, which is what this description claimed while the file said otherwise. Serves documentation pages, AI instructions, architecture nodes and changelog entries over PostgREST: /docs, /ai-instructions, /architecture, /changelog, /counts. Public read, no auth. Deno-runtime source, so it is excluded from tsconfig and is not installable into a React app via the shadcn CLI.",
+      "description": "Documentation read API for N10. Runs as a Supabase Deno edge function (`Deno.serve`, `jsr:@supabase/supabase-js@2`) — NOT a Cloudflare Worker and not Rust/WASM, which is what this description claimed while the file said otherwise. Serves documentation pages, AI instructions, architecture nodes and changelog entries over PostgREST: /docs, /ai-instructions, /architecture, /changelog, /counts. Public read, no auth. Deno-runtime source, so it is excluded from tsconfig and is not installable into a React app via the shadcn CLI.",
       "files": [
         {
           "path": "lib/nyuchi-docs-api.ts",
@@ -13038,7 +13038,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -13062,7 +13062,7 @@
     },
     {
       "dependencies": [],
-      "description": "Universal branded empty state with dynamic mineral accent, contextual illustration placeholder, title, description, and optional action CTA. Every screen across the ecosystem uses this when there is no content to display \u2014 \"No events yet\", \"Your wallet is empty\", \"No messages\", \"Start your first lesson\". The empty state guides users toward the creation action for that domain.",
+      "description": "Universal branded empty state with dynamic mineral accent, contextual illustration placeholder, title, description, and optional action CTA. Every screen across the ecosystem uses this when there is no content to display — \"No events yet\", \"Your wallet is empty\", \"No messages\", \"Start your first lesson\". The empty state guides users toward the creation action for that domain.",
       "files": [
         {
           "path": "components/ui/nyuchi-empty-state.tsx",
@@ -13121,7 +13121,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -13283,7 +13283,7 @@
     },
     {
       "dependencies": [],
-      "description": "Standard feed page orchestrator composing header, search/filter bar, NyuchiListView infinite scroll feed, pull-to-refresh, empty state, and FAB create button into a complete screen. Every feed screen across every mini-app uses this layout \u2014 Pulse home, News feed, Circles timeline, BushTrade listings, Jobs board, Nhimbe events, Places directory. The developer provides the data source, card renderer, and filter configuration. The orchestrator handles layout, loading, errors, and responsive behaviour.",
+      "description": "Standard feed page orchestrator composing header, search/filter bar, NyuchiListView infinite scroll feed, pull-to-refresh, empty state, and FAB create button into a complete screen. Every feed screen across every mini-app uses this layout — Pulse home, News feed, Circles timeline, BushTrade listings, Jobs board, Nhimbe events, Places directory. The developer provides the data source, card renderer, and filter configuration. The orchestrator handles layout, loading, errors, and responsive behaviour.",
       "files": [
         {
           "path": "components/ui/nyuchi-feed-page.tsx",
@@ -13300,7 +13300,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -13348,7 +13348,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7\u2192L8\u2192L9)",
+          "Cross-layer wiring (L7→L8→L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -13412,7 +13412,7 @@
     },
     {
       "dependencies": [],
-      "description": "Fundi \u2014 the self-healing intelligence engine. Swahili for fixer/mechanic/technician. N9 acts on what N8 observes. Built in Rust, deployed as a Cloudflare Worker (workers-rs crate, compiled to WebAssembly). NOT a Cloudflare Worker (Rust/WASM) \u2014 Fundi is independent of the database vendor. Reads fundi_issues and observability_events from Supabase via REST API. Classifies failure patterns, deduplicates against open GitHub issues, creates structured remediation tickets. Triggered by Cloudflare Cron Triggers and Cloudflare Queues.",
+      "description": "Fundi — the self-healing intelligence engine. Swahili for fixer/mechanic/technician. N9 acts on what N8 observes. Built in Rust, deployed as a Cloudflare Worker (workers-rs crate, compiled to WebAssembly). NOT a Cloudflare Worker (Rust/WASM) — Fundi is independent of the database vendor. Reads fundi_issues and observability_events from Supabase via REST API. Classifies failure patterns, deduplicates against open GitHub issues, creates structured remediation tickets. Triggered by Cloudflare Cron Triggers and Cloudflare Queues.",
       "files": [
         {
           "path": "lib/nyuchi-fundi.tsx",
@@ -13443,7 +13443,7 @@
     },
     {
       "dependencies": [],
-      "description": "Fundi learning system. Tracks healing outcomes to improve future decisions. When an issue is resolved, records what failed, what Fundi suggested, what actually worked, and whether the same pattern recurs. Runs as part of the Fundi Cloudflare Worker \u2014 same Rust binary, different handler. Writes learned patterns to fundi_issues via Supabase REST API. Improves classification accuracy over time.",
+      "description": "Fundi learning system. Tracks healing outcomes to improve future decisions. When an issue is resolved, records what failed, what Fundi suggested, what actually worked, and whether the same pattern recurs. Runs as part of the Fundi Cloudflare Worker — same Rust binary, different handler. Writes learned patterns to fundi_issues via Supabase REST API. Improves classification accuracy over time.",
       "files": [
         {
           "path": "lib/nyuchi-fundi-learning.ts",
@@ -13452,11 +13452,11 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure \u2014 no direct a11y requirements"
+          "Non-visual infrastructure — no direct a11y requirements"
         ],
         "collection": "fundi",
         "features": [
-          "Outside actor \u2014 operates via GitHub Issues",
+          "Outside actor — operates via GitHub Issues",
           "Human-in-the-loop healing workflow",
           "DB persistence via fundi_issues table"
         ],
@@ -13477,7 +13477,7 @@
     },
     {
       "dependencies": [],
-      "description": "Bridge from N8 Assurance to N9 Fundi. When N8 components detect failures, the reporter pushes a structured signal to the Cloudflare Queue that triggers Fundi. Signal payload: component name, ecosystem node, error type, severity, diagnostic data. The Queue decouples N8 (detection) from N9 (healing) \u2014 N8 never waits for Fundi to respond. Also creates a fundi_issues row in Supabase as the append-only audit trail.",
+      "description": "Bridge from N8 Assurance to N9 Fundi. When N8 components detect failures, the reporter pushes a structured signal to the Cloudflare Queue that triggers Fundi. Signal payload: component name, ecosystem node, error type, severity, diagnostic data. The Queue decouples N8 (detection) from N9 (healing) — N8 never waits for Fundi to respond. Also creates a fundi_issues row in Supabase as the append-only audit trail.",
       "files": [
         {
           "path": "lib/nyuchi-fundi-reporter.ts",
@@ -13508,7 +13508,7 @@
     },
     {
       "dependencies": [],
-      "description": "Branded metric card with radial arc gauge, value display, label, and contextual description. The universal pattern extracted from mukoko-weather MetricCard. Used for UV index, trust scores, completion percentages, health vitals, battery levels, signal strength \u2014 any bounded numeric value displayed as a gauge. Composes the arc-gauge primitive with brand styling.",
+      "description": "Branded metric card with radial arc gauge, value display, label, and contextual description. The universal pattern extracted from mukoko-weather MetricCard. Used for UV index, trust scores, completion percentages, health vitals, battery levels, signal strength — any bounded numeric value displayed as a gauge. Composes the arc-gauge primitive with brand styling.",
       "files": [
         {
           "path": "components/ui/nyuchi-gauge-card.tsx",
@@ -13569,7 +13569,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -13636,7 +13636,7 @@
     },
     {
       "dependencies": [],
-      "description": "The Nyuchi component harness \u2014 the vertical infrastructure spine (useNyuchiHarness hook + NyuchiHarness wrapper) giving N3 brand, N4 safety, and N5 resilience components scoped logging, motion, and an accessible shared live region. Self-contained; adapt the console logger to your app observability layer.",
+      "description": "The Nyuchi component harness — the vertical infrastructure spine (useNyuchiHarness hook + NyuchiHarness wrapper) giving N3 brand, N4 safety, and N5 resilience components scoped logging, motion, and an accessible shared live region. Self-contained; adapt the console logger to your app observability layer.",
       "files": [
         {
           "path": "lib/harness/index.tsx",
@@ -13672,7 +13672,7 @@
     },
     {
       "dependencies": [],
-      "description": "Pre-wiring node that connects every brand component to the full Nyuchi infrastructure stack. Exports NyuchiHarness (declarative wrapper providing error boundary + skeleton + observability + motion + a11y) and useNyuchiHarness hook (imperative access to observability logger, motion config, locale, theme, and health reporting). When a component is wrapped in a harness, it automatically logs render timing, catches errors with branded fallback, applies entry animations, uses the correct focus ring tokens, respects reduced-motion preferences, and reports health to the global monitor. Zero manual configuration required \u2014 install the component and it works. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
+      "description": "Pre-wiring node that connects every brand component to the full Nyuchi infrastructure stack. Exports NyuchiHarness (declarative wrapper providing error boundary + skeleton + observability + motion + a11y) and useNyuchiHarness hook (imperative access to observability logger, motion config, locale, theme, and health reporting). When a component is wrapped in a harness, it automatically logs render timing, catches errors with branded fallback, applies entry animations, uses the correct focus ring tokens, respects reduced-motion preferences, and reports health to the global monitor. Zero manual configuration required — install the component and it works. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
       "files": [
         {
           "path": "lib/harness/index.tsx",
@@ -13714,7 +13714,7 @@
     },
     {
       "dependencies": [],
-      "description": "Standardized sticky header for all Nyuchi ecosystem apps. Supports desktop nav links and mobile pill action group \u2014 a capsule-shaped container with 2\u20133 icon buttons in the brand accent color (dynamic per mini-app). The pill group is the primary brand identity marker in the header.",
+      "description": "Standardized sticky header for all Nyuchi ecosystem apps. Supports desktop nav links and mobile pill action group — a capsule-shaped container with 2–3 icon buttons in the brand accent color (dynamic per mini-app). The pill group is the primary brand identity marker in the header.",
       "files": [
         {
           "path": "components/ui/nyuchi-header.tsx",
@@ -13729,7 +13729,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7\u2192L8\u2192L9)",
+          "Cross-layer wiring (L7→L8→L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -13756,7 +13756,7 @@
     },
     {
       "dependencies": [],
-      "description": "Branded health overview card composing vitals-display, medication-reminder, and appointment-card primitives with malachite mineral accent. Shows key health metrics, upcoming appointments, and medication schedule at a glance. Sovereign data \u2014 all health data stays in the user pod.",
+      "description": "Branded health overview card composing vitals-display, medication-reminder, and appointment-card primitives with malachite mineral accent. Shows key health metrics, upcoming appointments, and medication schedule at a glance. Sovereign data — all health data stays in the user pod.",
       "files": [
         {
           "path": "components/ui/nyuchi-health-dashboard.tsx",
@@ -13841,7 +13841,7 @@
     },
     {
       "dependencies": [],
-      "description": "Central icon registry for the Nyuchi Design System. Maps semantic icon names to Lucide React icons. All components should import icons from this registry, not directly from lucide-react. Provides: consistent sizing (16/20/24/32), brand icon overrides, semantic naming (icon-success vs CheckCircle), tree-shaking optimization, and custom Nyuchi icons. N1 infrastructure \u2014 consumed by all layers above. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
+      "description": "Central icon registry for the Nyuchi Design System. Maps semantic icon names to Lucide React icons. All components should import icons from this registry, not directly from lucide-react. Provides: consistent sizing (16/20/24/32), brand icon overrides, semantic naming (icon-success vs CheckCircle), tree-shaking optimization, and custom Nyuchi icons. N1 infrastructure — consumed by all layers above. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
       "files": [
         {
           "path": "lib/nyuchi-icons/index.tsx",
@@ -13925,7 +13925,7 @@
     },
     {
       "dependencies": [],
-      "description": "Responsive and adaptive layout system for Nyuchi. Exports breakpoint tokens (mobile/tablet/desktop/wide), useBreakpoint hook, NyuchiGrid responsive grid component, canonical layout definitions for the five core page types (feed, detail, create, profile, dashboard), and adaptive density support (comfortable vs compact). Ensures consistent responsive behavior across all Nyuchi apps \u2014 same breakpoints, same grid, same content flow patterns. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
+      "description": "Responsive and adaptive layout system for Nyuchi. Exports breakpoint tokens (mobile/tablet/desktop/wide), useBreakpoint hook, NyuchiGrid responsive grid component, canonical layout definitions for the five core page types (feed, detail, create, profile, dashboard), and adaptive density support (comfortable vs compact). Ensures consistent responsive behavior across all Nyuchi apps — same breakpoints, same grid, same content flow patterns. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
       "files": [
         {
           "path": "lib/layout/index.tsx",
@@ -14046,7 +14046,7 @@
       "dependencies": [
         "class-variance-authority"
       ],
-      "description": "Universal content card for all Mukoko listing types \u2014 events, products, news, bush trade, directories. Supports row, compact, and hero variants with mineral-colored category accents. The foundational brand component: every listing across the super app uses this pattern.",
+      "description": "Universal content card for all Mukoko listing types — events, products, news, bush trade, directories. Supports row, compact, and hero variants with mineral-colored category accents. The foundational brand component: every listing across the super app uses this pattern.",
       "files": [
         {
           "path": "components/ui/nyuchi-listing-card.tsx",
@@ -14222,7 +14222,7 @@
     },
     {
       "dependencies": [],
-      "description": "Universal date/location signature tile \u2014 the 4.2.0 When/Where unit. A rounded-square chip (an icon tile OR a month-over-day date chip) paired with a bold 16px primary line and a 13px muted secondary line, with an optional caption and trailing action. Purely presentational and server-safe (no client directive, no harness) so it renders inside React Server Components. The chip tint defaults to the brand accent (--brand-accent) so each app swaps its own mineral. Used on event detail When/Where rows, place cards, and any listing that anchors a date or a location.",
+      "description": "Universal date/location signature tile — the 4.2.0 When/Where unit. A rounded-square chip (an icon tile OR a month-over-day date chip) paired with a bold 16px primary line and a 13px muted secondary line, with an optional caption and trailing action. Purely presentational and server-safe (no client directive, no harness) so it renders inside React Server Components. The chip tint defaults to the brand accent (--brand-accent) so each app swaps its own mineral. Used on event detail When/Where rows, place cards, and any listing that anchors a date or a location.",
       "files": [
         {
           "path": "components/ui/nyuchi-meta-tile.tsx",
@@ -14238,7 +14238,7 @@
         "collection": "brand",
         "features": [
           "4.2.0 date/location signature pattern",
-          "Server-safe \u2014 no client directive, renders in RSC",
+          "Server-safe — no client directive, renders in RSC",
           "13px muted metadata / 16px bold primary",
           "Brand-accent chip tint (--brand-accent), color-mix surface",
           "Icon-chip or month-over-day date-chip modes"
@@ -14276,7 +14276,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7\u2192L8\u2192L9)",
+          "Cross-layer wiring (L7→L8→L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -14396,7 +14396,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7\u2192L8\u2192L9)",
+          "Cross-layer wiring (L7→L8→L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -14507,7 +14507,7 @@
     },
     {
       "dependencies": [],
-      "description": "Universal branded onboarding step card used across all ecosystem app first-use experiences. Shows an illustration area, title, description, progress dots, and next/skip actions. Dynamic mineral accent. The individual step within any onboarding flow \u2014 composable with swiper or stepper primitives for multi-step sequences.",
+      "description": "Universal branded onboarding step card used across all ecosystem app first-use experiences. Shows an illustration area, title, description, progress dots, and next/skip actions. Dynamic mineral accent. The individual step within any onboarding flow — composable with swiper or stepper primitives for multi-step sequences.",
       "files": [
         {
           "path": "components/ui/nyuchi-onboarding-step.tsx",
@@ -14567,7 +14567,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -14608,10 +14608,10 @@
         ],
         "collection": "agentic-components",
         "features": [
-          "Inline AP2 payment authorization \u2014 no checkout tab",
+          "Inline AP2 payment authorization — no checkout tab",
           "Payment-handler (rail) selection: card / bank / mobile money",
           "Shows the AP2 mandate chain (intent/cart) for transparency",
-          "No card details leave the wallet \u2014 signs a Payment Mandate",
+          "No card details leave the wallet — signs a Payment Mandate",
           "Dynamic mineral accent via --brand-accent"
         ],
         "owner": "nyuchi",
@@ -14693,7 +14693,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7\u2192L8\u2192L9)",
+          "Cross-layer wiring (L7→L8→L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -14902,7 +14902,7 @@
         ],
         "collection": "agentic-components",
         "features": [
-          "Compact top 3\u20135 UCP search results",
+          "Compact top 3–5 UCP search results",
           "Per-result price label + description",
           "Selecting a result hands the id back to the agent",
           "Empty-state messaging"
@@ -14925,7 +14925,7 @@
     },
     {
       "dependencies": [],
-      "description": "Standardized profile display block used across all Mukoko apps. Centers the avatar with verification badge, name with inline verified check, platform status indicator, trust score meter, and stat counters. The three trust indicators (verified badge, status pill, trust score) are always visible on the profile header \u2014 not just badges elsewhere in the app, but the full expanded view here.",
+      "description": "Standardized profile display block used across all Mukoko apps. Centers the avatar with verification badge, name with inline verified check, platform status indicator, trust score meter, and stat counters. The three trust indicators (verified badge, status pill, trust score) are always visible on the profile header — not just badges elsewhere in the app, but the full expanded view here.",
       "files": [
         {
           "path": "components/ui/nyuchi-profile-block.tsx",
@@ -15080,7 +15080,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -15247,7 +15247,7 @@
     },
     {
       "dependencies": [],
-      "description": "Ticket registration panel \u2014 a labelled header, a selectable ticket-tier list, a clamped quantity stepper, and one saturated accent CTA. Tiers render as radios (role=radio / aria-checked) showing name + USD-formatted price (Free for 0) and disable with a Sold out label; the Minus/Plus stepper uses 48px pill targets and clamps to [min, max]. The accent CTA (pill, --brand-accent) shows the running total and a loading spinner. Harness-wired: tier and quantity changes are announced through the live region. Accent defaults to --brand-accent so each app swaps its own mineral.",
+      "description": "Ticket registration panel — a labelled header, a selectable ticket-tier list, a clamped quantity stepper, and one saturated accent CTA. Tiers render as radios (role=radio / aria-checked) showing name + USD-formatted price (Free for 0) and disable with a Sold out label; the Minus/Plus stepper uses 48px pill targets and clamps to [min, max]. The accent CTA (pill, --brand-accent) shows the running total and a loading spinner. Harness-wired: tier and quantity changes are announced through the live region. Accent defaults to --brand-accent so each app swaps its own mineral.",
       "files": [
         {
           "path": "components/ui/nyuchi-registration-card.tsx",
@@ -15335,7 +15335,7 @@
     },
     {
       "dependencies": [],
-      "description": "Universal branded review card with trust-verified reviewer badge, star rating, review text, and helpful vote. Used across all domains where user reviews exist: Places (business reviews), BushTrade (seller reviews), Novels (book reviews), Health (provider reviews), Nhimbe (event reviews). The reviewer verification tier is always visible \u2014 Ubuntu principle: trust is earned and displayed.",
+      "description": "Universal branded review card with trust-verified reviewer badge, star rating, review text, and helpful vote. Used across all domains where user reviews exist: Places (business reviews), BushTrade (seller reviews), Novels (book reviews), Health (provider reviews), Nhimbe (event reviews). The reviewer verification tier is always visible — Ubuntu principle: trust is earned and displayed.",
       "files": [
         {
           "path": "components/ui/nyuchi-review-card.tsx",
@@ -15432,7 +15432,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7\u2192L8\u2192L9)",
+          "Cross-layer wiring (L7→L8→L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -15585,7 +15585,7 @@
       "dependencies": [
         "next"
       ],
-      "description": "SEO metadata component for Next.js App Router. Generates head metadata, Open Graph tags, Twitter Cards, Schema.org JSON-LD structured data, and canonical URLs. Server component \u2014 runs at build/request time. Supports all Schema.org types used by the platform: JobPosting, VideoObject, MedicalWebPage, RentalCarReservation, Product, Event, Article, Recipe, etc.",
+      "description": "SEO metadata component for Next.js App Router. Generates head metadata, Open Graph tags, Twitter Cards, Schema.org JSON-LD structured data, and canonical URLs. Server component — runs at build/request time. Supports all Schema.org types used by the platform: JobPosting, VideoObject, MedicalWebPage, RentalCarReservation, Product, Event, Article, Recipe, etc.",
       "files": [
         {
           "path": "lib/nyuchi-seo.ts",
@@ -15602,7 +15602,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -15643,7 +15643,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -15672,7 +15672,7 @@
     },
     {
       "dependencies": [],
-      "description": "Universal branded share composition wrapping the share-dialog primitive. Shows a preview card of the shared content (title, image, source app), sharing options (copy link, share to Campfire, native share, social platforms), and a branded deep link. Every shareable piece of content across the ecosystem uses this pattern \u2014 listings, articles, profiles, places, events, videos, groups.",
+      "description": "Universal branded share composition wrapping the share-dialog primitive. Shows a preview card of the shared content (title, image, source app), sharing options (copy link, share to Campfire, native share, social platforms), and a branded deep link. Every shareable piece of content across the ecosystem uses this pattern — listings, articles, profiles, places, events, videos, groups.",
       "files": [
         {
           "path": "components/ui/nyuchi-share-card.tsx",
@@ -15734,7 +15734,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7\u2192L8\u2192L9)",
+          "Cross-layer wiring (L7→L8→L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -15861,7 +15861,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -15887,7 +15887,7 @@
       "dependencies": [
         "class-variance-authority"
       ],
-      "description": "Horizontal compact stats bar for dashboards, home screens, and admin views. Displays 2\u20134 metric blocks inline with icon, label, value, and optional trend indicator. Uses mineral-colored icon backgrounds. The brand-standard way to show key metrics at a glance across all Mukoko apps.",
+      "description": "Horizontal compact stats bar for dashboards, home screens, and admin views. Displays 2–4 metric blocks inline with icon, label, value, and optional trend indicator. Uses mineral-colored icon backgrounds. The brand-standard way to show key metrics at a glance across all Mukoko apps.",
       "files": [
         {
           "path": "components/ui/nyuchi-stats-row.tsx",
@@ -16027,7 +16027,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7\u2192L8\u2192L9)",
+          "Cross-layer wiring (L7→L8→L9)",
           "data-slot + data-portal DOM attributes"
         ],
         "hasDemo": true,
@@ -16095,7 +16095,7 @@
     },
     {
       "dependencies": [],
-      "description": "Universal date-railed discovery list \u2014 the 4.2.0 signature timeline. Groups items by day: each day is a left rail (weekday, big day numeral, month) beside a stack of tight horizontal rows. Each row reads time, title, host, location with an overlapping avatar stack and a right-edge thumbnail. Harness-wired for reduced-motion staggered entry and observability. Quiet rows, full 1px borders, 13px muted metadata \u2014 the 4.2.0 density. Used for event/agenda discovery across the ecosystem (nhimbe events, planner schedules, any date-anchored feed).",
+      "description": "Universal date-railed discovery list — the 4.2.0 signature timeline. Groups items by day: each day is a left rail (weekday, big day numeral, month) beside a stack of tight horizontal rows. Each row reads time, title, host, location with an overlapping avatar stack and a right-edge thumbnail. Harness-wired for reduced-motion staggered entry and observability. Quiet rows, full 1px borders, 13px muted metadata — the 4.2.0 density. Used for event/agenda discovery across the ecosystem (nhimbe events, planner schedules, any date-anchored feed).",
       "files": [
         {
           "path": "components/ui/nyuchi-timeline.tsx",
@@ -16113,7 +16113,7 @@
         "features": [
           "4.2.0 date-rail signature pattern",
           "Day-grouped with weekday/day/month rail",
-          "Harness integration \u2014 reduced-motion staggered entry + observability",
+          "Harness integration — reduced-motion staggered entry + observability",
           "Full 1px borders, 13px muted metadata, 16px title (4.2.0 density)",
           "Avatar stack + right thumbnail per row",
           "Mineral event dot per row"
@@ -16154,7 +16154,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7\u2192L8\u2192L9)",
+          "Cross-layer wiring (L7→L8→L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -16177,7 +16177,7 @@
     },
     {
       "dependencies": [],
-      "description": "W3C Design Tokens (2025.10) compliant token system for the entire Nyuchi ecosystem. Three-tier architecture: primitive tokens (Five African Minerals with light/dark pairs, container/onContainer colours, Five Heritage Colors, spacing, type scale, radii, shadows, motion, touch targets), semantic tokens (four-level AAA surface system), and component tokens. Brand overrides for all mini-apps. Multi-platform output: CSS (web), TypeScript (React/Svelte), Swift (iOS/macOS), Kotlin (Android/Compose), ArkTS (HarmonyOS), React Native (iOS+Android), Rust (services), Python (analytics/ML). The N1 vertical node \u2014 the only node allowed to define values. Every other node reads from here via var() or the relevant platform constant.",
+      "description": "W3C Design Tokens (2025.10) compliant token system for the entire Nyuchi ecosystem. Three-tier architecture: primitive tokens (Five African Minerals with light/dark pairs, container/onContainer colours, Five Heritage Colors, spacing, type scale, radii, shadows, motion, touch targets), semantic tokens (four-level AAA surface system), and component tokens. Brand overrides for all mini-apps. Multi-platform output: CSS (web), TypeScript (React/Svelte), Swift (iOS/macOS), Kotlin (Android/Compose), ArkTS (HarmonyOS), React Native (iOS+Android), Rust (services), Python (analytics/ML). The N1 vertical node — the only node allowed to define values. Every other node reads from here via var() or the relevant platform constant.",
       "files": [
         {
           "path": "lib/tokens/index.ts",
@@ -16218,7 +16218,7 @@
     },
     {
       "dependencies": [],
-      "description": "Mzizi design tokens for ArkTS / HarmonyOS. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties \u2014 seven African Minerals + seven Heritage tones, both themes. Colour constants, spacing, radius and typography for HarmonyOS. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md \u00a78.4.1).",
+      "description": "Mzizi design tokens for ArkTS / HarmonyOS. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties — seven African Minerals + seven Heritage tones, both themes. Colour constants, spacing, radius and typography for HarmonyOS. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md §8.4.1).",
       "files": [
         {
           "path": "lib/tokens/nyuchi-tokens-arkts.ets",
@@ -16235,7 +16235,7 @@
     },
     {
       "dependencies": [],
-      "description": "Mzizi design tokens for Kotlin / Jetpack Compose. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties \u2014 seven African Minerals + seven Heritage tones, both themes. Color objects, spacing Dp values, radius and typography constants for Android. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md \u00a78.4.1).",
+      "description": "Mzizi design tokens for Kotlin / Jetpack Compose. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties — seven African Minerals + seven Heritage tones, both themes. Color objects, spacing Dp values, radius and typography constants for Android. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md §8.4.1).",
       "files": [
         {
           "path": "lib/tokens/nyuchi-tokens-kotlin.kt",
@@ -16252,7 +16252,7 @@
     },
     {
       "dependencies": [],
-      "description": "Mzizi design tokens for Python. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties \u2014 seven African Minerals + seven Heritage tones, both themes. Frozen dataclasses of colour values for analytics pipelines, data visualisation (matplotlib, plotly, altair), report generation and ML tooling. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md \u00a78.4.1).",
+      "description": "Mzizi design tokens for Python. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties — seven African Minerals + seven Heritage tones, both themes. Frozen dataclasses of colour values for analytics pipelines, data visualisation (matplotlib, plotly, altair), report generation and ML tooling. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md §8.4.1).",
       "files": [
         {
           "path": "lib/tokens/nyuchi-tokens-python.py",
@@ -16269,7 +16269,7 @@
     },
     {
       "dependencies": [],
-      "description": "Mzizi design tokens for React Native. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties \u2014 seven African Minerals + seven Heritage tones, both themes. A StyleSheet-ready token object for React Native. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md \u00a78.4.1).",
+      "description": "Mzizi design tokens for React Native. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties — seven African Minerals + seven Heritage tones, both themes. A StyleSheet-ready token object for React Native. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md §8.4.1).",
       "files": [
         {
           "path": "lib/tokens/nyuchi-tokens-react-native.ts",
@@ -16286,7 +16286,7 @@
     },
     {
       "dependencies": [],
-      "description": "Mzizi design tokens for Rust. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties \u2014 seven African Minerals + seven Heritage tones, both themes, as `const` values plus `Palette`, `Spacing`, `Radius` and `Fonts`. This is what the Dioxus half of the registry consumes, via the `mzizi-tokens` crate. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md \u00a78.4.1).",
+      "description": "Mzizi design tokens for Rust. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties — seven African Minerals + seven Heritage tones, both themes, as `const` values plus `Palette`, `Spacing`, `Radius` and `Fonts`. This is what the Dioxus half of the registry consumes, via the `mzizi-tokens` crate. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md §8.4.1).",
       "files": [
         {
           "path": "src/tokens/nyuchi_tokens.rs",
@@ -16303,7 +16303,7 @@
     },
     {
       "dependencies": [],
-      "description": "Mzizi design tokens for Swift / SwiftUI. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties \u2014 seven African Minerals + seven Heritage tones, both themes. Color extensions, spacing, radius and typography constants for iOS, macOS, watchOS and tvOS. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md \u00a78.4.1).",
+      "description": "Mzizi design tokens for Swift / SwiftUI. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties — seven African Minerals + seven Heritage tones, both themes. Color extensions, spacing, radius and typography constants for iOS, macOS, watchOS and tvOS. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md §8.4.1).",
       "files": [
         {
           "path": "lib/tokens/nyuchi-tokens-swift.swift",
@@ -16360,7 +16360,7 @@
     },
     {
       "dependencies": [],
-      "description": "Full trust score visualization showing the three-signal breakdown: Verification Tier (are you real?), Platform Status (are you active?), and Ubuntu Contribution (are you helpful?). Displays the composite score as a meter bar with individual signal breakdowns. Used on profile detail pages, admin views, and trust audit screens. This is the expanded view of trust \u2014 the verified badge is the compact view.",
+      "description": "Full trust score visualization showing the three-signal breakdown: Verification Tier (are you real?), Platform Status (are you active?), and Ubuntu Contribution (are you helpful?). Displays the composite score as a meter bar with individual signal breakdowns. Used on profile detail pages, admin views, and trust audit screens. This is the expanded view of trust — the verified badge is the compact view.",
       "files": [
         {
           "path": "components/ui/nyuchi-trust-meter.tsx",
@@ -16422,7 +16422,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7\u2192L8\u2192L9)",
+          "Cross-layer wiring (L7→L8→L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -16532,7 +16532,7 @@
       "dependencies": [
         "class-variance-authority"
       ],
-      "description": "Verification badge tied to the three-axis Mukoko trust model: Status (platform lifecycle) \u00d7 Verification Tier (identity ladder) \u2192 Trust Score. Renders the appropriate mineral-colored badge for each tier \u2014 Terracotta (Community 0.10), Cobalt (OTP 0.20), Gold (Government 0.30), Tanzanite (Licensed 0.50). Suspended/ancestral accounts show a dimmed or memorial variant. Used inline next to names, on profile headers, listing cards, and anywhere trust needs to be communicated.",
+      "description": "Verification badge tied to the three-axis Mukoko trust model: Status (platform lifecycle) × Verification Tier (identity ladder) → Trust Score. Renders the appropriate mineral-colored badge for each tier — Terracotta (Community 0.10), Cobalt (OTP 0.20), Gold (Government 0.30), Tanzanite (Licensed 0.50). Suspended/ancestral accounts show a dimmed or memorial variant. Used inline next to names, on profile headers, listing cards, and anywhere trust needs to be communicated.",
       "files": [
         {
           "path": "components/ui/nyuchi-verified-badge.tsx",
@@ -16547,7 +16547,7 @@
         ],
         "collection": "brand",
         "features": [
-          "Three-axis trust model: Status \u00d7 Tier \u2192 Score",
+          "Three-axis trust model: Status × Tier → Score",
           "Mineral-colored per tier",
           "Tooltip with tier explanation",
           "Maps to system.verification_tier"
@@ -16674,7 +16674,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -16723,7 +16723,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -16802,7 +16802,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -16998,7 +16998,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -17365,7 +17365,7 @@
     },
     {
       "dependencies": [],
-      "description": "Task/item priority picker with visual indicators \u2014 none, low, medium, high, urgent. Mineral-colored dots: grey=none, cobalt=low, gold=medium, terracotta=high, destructive=urgent. Compact inline selector for use in task forms, issue trackers, and ticket systems.",
+      "description": "Task/item priority picker with visual indicators — none, low, medium, high, urgent. Mineral-colored dots: grey=none, cobalt=low, gold=medium, terracotta=high, destructive=urgent. Compact inline selector for use in task forms, issue trackers, and ticket systems.",
       "files": [
         {
           "path": "components/ui/priority-selector.tsx",
@@ -17858,7 +17858,7 @@
     },
     {
       "dependencies": [],
-      "description": "Recurrence pattern selector for scheduling \u2014 daily, weekly, monthly, yearly with day-of-week/month selectors and end-date or occurrence-count options. Used for recurring tasks, events, medication schedules, and any repeating item across the platform.",
+      "description": "Recurrence pattern selector for scheduling — daily, weekly, monthly, yearly with day-of-week/month selectors and end-date or occurrence-count options. Used for recurring tasks, events, medication schedules, and any repeating item across the platform.",
       "files": [
         {
           "path": "components/ui/recurrence-picker.tsx",
@@ -17953,7 +17953,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -18245,7 +18245,7 @@
     },
     {
       "dependencies": [],
-      "description": "N8 assurance probe that validates RTL (right-to-left) layout correctness across deployed components. Checks: logical properties (start/end vs left/right), bidi text rendering, icon mirroring rules, text alignment consistency. Audit flagged as missing accessibility infrastructure. ALPHA \u2014 awaiting edge function implementation.",
+      "description": "N8 assurance probe that validates RTL (right-to-left) layout correctness across deployed components. Checks: logical properties (start/end vs left/right), bidi text rendering, icon mirroring rules, text alignment consistency. Audit flagged as missing accessibility infrastructure. ALPHA — awaiting edge function implementation.",
       "files": [
         {
           "path": "components/ui/rtl-conformity-check.tsx",
@@ -18532,7 +18532,7 @@
       "dependencies": [
         "class-variance-authority"
       ],
-      "description": "Connected multi-option selector as a single pill-shaped control. Inline alternative to radio-group for 2-4 mutually exclusive options like view mode switchers, time range selectors, or binary choices. Audit flagged as missing primitive. ALPHA \u2014 awaiting frontend implementation.",
+      "description": "Connected multi-option selector as a single pill-shaped control. Inline alternative to radio-group for 2-4 mutually exclusive options like view mode switchers, time range selectors, or binary choices. Audit flagged as missing primitive. ALPHA — awaiting frontend implementation.",
       "files": [
         {
           "path": "components/ui/segmented-control.tsx",
@@ -18619,7 +18619,7 @@
     },
     {
       "dependencies": [],
-      "description": "Multi-step money transfer flow: recipient selection \u2192 amount entry \u2192 confirmation \u2192 receipt. Supports QR scan, contact picker, and recent recipients. The standard peer-to-peer transfer pattern for Wallet and Campfire bill splitting.",
+      "description": "Multi-step money transfer flow: recipient selection → amount entry → confirmation → receipt. Supports QR scan, contact picker, and recent recipients. The standard peer-to-peer transfer pattern for Wallet and Campfire bill splitting.",
       "files": [
         {
           "path": "components/ui/send-money-flow.tsx",
@@ -19964,7 +19964,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -20665,7 +20665,7 @@
     },
     {
       "dependencies": [],
-      "description": "Guided symptom input with body region selector, severity scale, and duration fields. Not a diagnostic tool \u2014 produces a structured symptom summary for telemedicine consultations. Used in Health mini-app pre-appointment flow.",
+      "description": "Guided symptom input with body region selector, severity scale, and duration fields. Not a diagnostic tool — produces a structured symptom summary for telemedicine consultations. Used in Health mini-app pre-appointment flow.",
       "files": [
         {
           "path": "components/ui/symptom-checker.tsx",
@@ -20876,7 +20876,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -21517,7 +21517,7 @@
       "dependencies": [
         "radix-ui"
       ],
-      "description": "Horizontal container for grouped tool actions. Persistent action bar pattern for editors, content creation, and admin surfaces. Supports segmented groups, overflow menu, and responsive collapse. Audit flagged as missing UX pattern. ALPHA \u2014 awaiting frontend implementation.",
+      "description": "Horizontal container for grouped tool actions. Persistent action bar pattern for editors, content creation, and admin surfaces. Supports segmented groups, overflow menu, and responsive collapse. Audit flagged as missing UX pattern. ALPHA — awaiting frontend implementation.",
       "files": [
         {
           "path": "components/ui/toolbar.tsx",
@@ -21619,7 +21619,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -22110,7 +22110,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -22483,7 +22483,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition \u2014 no inline UI",
+          "Pure composition — no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],

--- a/registry.json
+++ b/registry.json
@@ -27,19 +27,19 @@
           "WCAG 2.1 contrast ratio computation per simulated pair",
           "Configurable contrast floor (default 3.0 for WCAG AA large text)",
           "audit_exempt flag skips decorative pairs per WCAG 1.4.11 exemption",
-          "Regression detection — files Fundi issues only for NEW failures, not existing ones",
-          "Severity assignment — high for foreground/error/success pairs, medium for others",
+          "Regression detection \u2014 files Fundi issues only for NEW failures, not existing ones",
+          "Severity assignment \u2014 high for foreground/error/success pairs, medium for others",
           "Scheduled via pg_cron (daily 02:00 UTC)",
-          "SQL-only implementation — no edge function required"
+          "SQL-only implementation \u2014 no edge function required"
         ],
         "hasDemo": true,
         "owner": "mzizi",
         "useCases": [
           "Daily WCAG and color-blindness validation across every semantic-color pair",
-          "Continuous regression detection — any token change that breaks a11y is caught within 24h",
-          "Pre-launch accessibility gate — ensures palette is colorblind-safe before each release",
-          "Fundi-integrated healing loop — new failures create GitHub issues automatically",
-          "On-demand validation — call run_accessibility_audit() in migrations or CI"
+          "Continuous regression detection \u2014 any token change that breaks a11y is caught within 24h",
+          "Pre-launch accessibility gate \u2014 ensures palette is colorblind-safe before each release",
+          "Fundi-integrated healing loop \u2014 new failures create GitHub issues automatically",
+          "On-demand validation \u2014 call run_accessibility_audit() in migrations or CI"
         ],
         "variants": [
           "scheduled-daily",
@@ -186,7 +186,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -519,7 +519,7 @@
     },
     {
       "dependencies": [],
-      "description": "Analytics dashboard page. KPI cards, time-series charts, data tables, date range picker, export controls. Used by Mukoko Console, Nyuchi Web Services, and B2B partners. Open data compatible — sections can be made public. Competitors: Grafana, Google Analytics, Metabase.",
+      "description": "Analytics dashboard page. KPI cards, time-series charts, data tables, date range picker, export controls. Used by Mukoko Console, Nyuchi Web Services, and B2B partners. Open data compatible \u2014 sections can be made public. Competitors: Grafana, Google Analytics, Metabase.",
       "files": [
         {
           "path": "components/ui/analytics-dashboard-page.tsx",
@@ -536,7 +536,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -656,7 +656,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -767,7 +767,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7→L8→L9)",
+          "Cross-layer wiring (L7\u2192L8\u2192L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -833,7 +833,7 @@
     },
     {
       "dependencies": [],
-      "description": "SVG radial arc gauge (270° sweep, open at bottom). Displays a percentage value as a filled arc with the value text centered inside. Uses stroke-dasharray animation. Proper role=\"meter\" with aria-valuenow/min/max. Used for UV index, trust scores, completion percentages, health metrics, battery levels — any bounded numeric value. Production-proven in mukoko-weather MetricCard.",
+      "description": "SVG radial arc gauge (270\u00b0 sweep, open at bottom). Displays a percentage value as a filled arc with the value text centered inside. Uses stroke-dasharray animation. Proper role=\"meter\" with aria-valuenow/min/max. Used for UV index, trust scores, completion percentages, health metrics, battery levels \u2014 any bounded numeric value. Production-proven in mukoko-weather MetricCard.",
       "files": [
         {
           "path": "components/ui/arc-gauge.tsx",
@@ -871,7 +871,7 @@
     },
     {
       "dependencies": [],
-      "description": "Nyuchi ecosystem architecture specification — local-first data strategy and sovereignty assessment.",
+      "description": "Nyuchi ecosystem architecture specification \u2014 local-first data strategy and sovereignty assessment.",
       "files": [
         {
           "path": "lib/architecture.ts",
@@ -923,7 +923,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -1367,7 +1367,7 @@
       "dependencies": [
         "class-variance-authority"
       ],
-      "description": "Asymmetric grid layout with varying tile sizes. Japanese-inspired content layout pattern for dashboards, feature showcases, and landing pages. Supports responsive breakpoint-aware tile resizing. Audit flagged as missing UX pattern. ALPHA — awaiting frontend implementation.",
+      "description": "Asymmetric grid layout with varying tile sizes. Japanese-inspired content layout pattern for dashboards, feature showcases, and landing pages. Supports responsive breakpoint-aware tile resizing. Audit flagged as missing UX pattern. ALPHA \u2014 awaiting frontend implementation.",
       "files": [
         {
           "path": "components/ui/bento-grid.tsx",
@@ -1429,7 +1429,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -1549,7 +1549,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -1984,7 +1984,7 @@
         "chart.js",
         "react-chartjs-2"
       ],
-      "description": "Chart.js Canvas-based chart renderer for data-heavy dashboards. Use INSTEAD of the Recharts chart when you have 100+ data points per chart or multiple charts per page. Canvas renders everything to a single DOM element regardless of data volume, while SVG (Recharts) creates a DOM node per data point. Includes CSS variable resolution for Canvas 2D context (which cannot read var() natively), theme-aware color fallbacks, mobile performance optimisation (reduced DPR, disabled animations), and automatic Chart.js instance cleanup on unmount to prevent canvas memory leaks. Production-proven in mukoko-weather with 7 charts × 365 data points.",
+      "description": "Chart.js Canvas-based chart renderer for data-heavy dashboards. Use INSTEAD of the Recharts chart when you have 100+ data points per chart or multiple charts per page. Canvas renders everything to a single DOM element regardless of data volume, while SVG (Recharts) creates a DOM node per data point. Includes CSS variable resolution for Canvas 2D context (which cannot read var() natively), theme-aware color fallbacks, mobile performance optimisation (reduced DPR, disabled animations), and automatic Chart.js instance cleanup on unmount to prevent canvas memory leaks. Production-proven in mukoko-weather with 7 charts \u00d7 365 data points.",
       "files": [
         {
           "path": "components/ui/canvas-chart.tsx",
@@ -2395,7 +2395,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart — axes variant.",
+      "description": "Area chart \u2014 axes variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-axes.tsx",
@@ -2435,7 +2435,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart — default variant.",
+      "description": "Area chart \u2014 default variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-default.tsx",
@@ -2475,7 +2475,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart — gradient variant.",
+      "description": "Area chart \u2014 gradient variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-gradient.tsx",
@@ -2515,7 +2515,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart — icons variant.",
+      "description": "Area chart \u2014 icons variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-icons.tsx",
@@ -2555,7 +2555,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart — interactive variant.",
+      "description": "Area chart \u2014 interactive variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-interactive.tsx",
@@ -2595,7 +2595,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart — legend variant.",
+      "description": "Area chart \u2014 legend variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-legend.tsx",
@@ -2635,7 +2635,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart — linear variant.",
+      "description": "Area chart \u2014 linear variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-linear.tsx",
@@ -2675,7 +2675,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart — stacked variant.",
+      "description": "Area chart \u2014 stacked variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-stacked.tsx",
@@ -2715,7 +2715,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart — stacked expand variant.",
+      "description": "Area chart \u2014 stacked expand variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-stacked-expand.tsx",
@@ -2755,7 +2755,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Area chart — step variant.",
+      "description": "Area chart \u2014 step variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-area-step.tsx",
@@ -2795,7 +2795,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart — active variant.",
+      "description": "Bar chart \u2014 active variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-active.tsx",
@@ -2835,7 +2835,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart — default variant.",
+      "description": "Bar chart \u2014 default variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-default.tsx",
@@ -2875,7 +2875,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart — horizontal variant.",
+      "description": "Bar chart \u2014 horizontal variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-horizontal.tsx",
@@ -2915,7 +2915,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart — interactive variant.",
+      "description": "Bar chart \u2014 interactive variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-interactive.tsx",
@@ -2955,7 +2955,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart — label variant.",
+      "description": "Bar chart \u2014 label variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-label.tsx",
@@ -2995,7 +2995,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart — label custom variant.",
+      "description": "Bar chart \u2014 label custom variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-label-custom.tsx",
@@ -3035,7 +3035,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart — mixed variant.",
+      "description": "Bar chart \u2014 mixed variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-mixed.tsx",
@@ -3075,7 +3075,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart — multiple variant.",
+      "description": "Bar chart \u2014 multiple variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-multiple.tsx",
@@ -3115,7 +3115,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart — negative variant.",
+      "description": "Bar chart \u2014 negative variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-negative.tsx",
@@ -3155,7 +3155,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Bar chart — stacked variant.",
+      "description": "Bar chart \u2014 stacked variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-bar-stacked.tsx",
@@ -3195,7 +3195,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart — default variant.",
+      "description": "Line chart \u2014 default variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-default.tsx",
@@ -3235,7 +3235,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart — dots variant.",
+      "description": "Line chart \u2014 dots variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-dots.tsx",
@@ -3275,7 +3275,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart — dots colors variant.",
+      "description": "Line chart \u2014 dots colors variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-dots-colors.tsx",
@@ -3315,7 +3315,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart — dots custom variant.",
+      "description": "Line chart \u2014 dots custom variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-dots-custom.tsx",
@@ -3355,7 +3355,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart — interactive variant.",
+      "description": "Line chart \u2014 interactive variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-interactive.tsx",
@@ -3395,7 +3395,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart — label variant.",
+      "description": "Line chart \u2014 label variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-label.tsx",
@@ -3435,7 +3435,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart — label custom variant.",
+      "description": "Line chart \u2014 label custom variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-label-custom.tsx",
@@ -3475,7 +3475,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart — linear variant.",
+      "description": "Line chart \u2014 linear variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-linear.tsx",
@@ -3515,7 +3515,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart — multiple variant.",
+      "description": "Line chart \u2014 multiple variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-multiple.tsx",
@@ -3555,7 +3555,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Line chart — step variant.",
+      "description": "Line chart \u2014 step variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-line-step.tsx",
@@ -3595,7 +3595,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart — donut variant.",
+      "description": "Pie chart \u2014 donut variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-donut.tsx",
@@ -3635,7 +3635,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart — donut active variant.",
+      "description": "Pie chart \u2014 donut active variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-donut-active.tsx",
@@ -3675,7 +3675,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart — donut text variant.",
+      "description": "Pie chart \u2014 donut text variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-donut-text.tsx",
@@ -3715,7 +3715,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart — interactive variant.",
+      "description": "Pie chart \u2014 interactive variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-interactive.tsx",
@@ -3755,7 +3755,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart — label variant.",
+      "description": "Pie chart \u2014 label variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-label.tsx",
@@ -3795,7 +3795,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart — label custom variant.",
+      "description": "Pie chart \u2014 label custom variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-label-custom.tsx",
@@ -3835,7 +3835,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart — label list variant.",
+      "description": "Pie chart \u2014 label list variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-label-list.tsx",
@@ -3875,7 +3875,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart — legend variant.",
+      "description": "Pie chart \u2014 legend variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-legend.tsx",
@@ -3915,7 +3915,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart — separator none variant.",
+      "description": "Pie chart \u2014 separator none variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-separator-none.tsx",
@@ -3955,7 +3955,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart — simple variant.",
+      "description": "Pie chart \u2014 simple variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-simple.tsx",
@@ -3995,7 +3995,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Pie chart — stacked variant.",
+      "description": "Pie chart \u2014 stacked variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-pie-stacked.tsx",
@@ -4035,7 +4035,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart — default variant.",
+      "description": "Radar chart \u2014 default variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-default.tsx",
@@ -4075,7 +4075,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart — dots variant.",
+      "description": "Radar chart \u2014 dots variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-dots.tsx",
@@ -4115,7 +4115,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart — grid circle variant.",
+      "description": "Radar chart \u2014 grid circle variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-grid-circle.tsx",
@@ -4155,7 +4155,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart — grid circle fill variant.",
+      "description": "Radar chart \u2014 grid circle fill variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-grid-circle-fill.tsx",
@@ -4195,7 +4195,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart — grid circle no lines variant.",
+      "description": "Radar chart \u2014 grid circle no lines variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-grid-circle-no-lines.tsx",
@@ -4235,7 +4235,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart — grid custom variant.",
+      "description": "Radar chart \u2014 grid custom variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-grid-custom.tsx",
@@ -4275,7 +4275,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart — grid fill variant.",
+      "description": "Radar chart \u2014 grid fill variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-grid-fill.tsx",
@@ -4315,7 +4315,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart — grid none variant.",
+      "description": "Radar chart \u2014 grid none variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-grid-none.tsx",
@@ -4355,7 +4355,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart — icons variant.",
+      "description": "Radar chart \u2014 icons variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-icons.tsx",
@@ -4395,7 +4395,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart — label custom variant.",
+      "description": "Radar chart \u2014 label custom variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-label-custom.tsx",
@@ -4435,7 +4435,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart — legend variant.",
+      "description": "Radar chart \u2014 legend variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-legend.tsx",
@@ -4475,7 +4475,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart — lines only variant.",
+      "description": "Radar chart \u2014 lines only variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-lines-only.tsx",
@@ -4515,7 +4515,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart — multiple variant.",
+      "description": "Radar chart \u2014 multiple variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-multiple.tsx",
@@ -4555,7 +4555,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radar chart — radius variant.",
+      "description": "Radar chart \u2014 radius variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radar-radius.tsx",
@@ -4595,7 +4595,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radial chart — grid variant.",
+      "description": "Radial chart \u2014 grid variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radial-grid.tsx",
@@ -4635,7 +4635,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radial chart — label variant.",
+      "description": "Radial chart \u2014 label variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radial-label.tsx",
@@ -4675,7 +4675,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radial chart — shape variant.",
+      "description": "Radial chart \u2014 shape variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radial-shape.tsx",
@@ -4715,7 +4715,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radial chart — simple variant.",
+      "description": "Radial chart \u2014 simple variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radial-simple.tsx",
@@ -4755,7 +4755,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radial chart — stacked variant.",
+      "description": "Radial chart \u2014 stacked variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radial-stacked.tsx",
@@ -4795,7 +4795,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Radial chart — text variant.",
+      "description": "Radial chart \u2014 text variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-radial-text.tsx",
@@ -4835,7 +4835,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Tooltip chart — advanced variant.",
+      "description": "Tooltip chart \u2014 advanced variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-tooltip-advanced.tsx",
@@ -4875,7 +4875,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Tooltip chart — default variant.",
+      "description": "Tooltip chart \u2014 default variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-tooltip-default.tsx",
@@ -4915,7 +4915,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Tooltip chart — formatter variant.",
+      "description": "Tooltip chart \u2014 formatter variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-tooltip-formatter.tsx",
@@ -4955,7 +4955,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Tooltip chart — icons variant.",
+      "description": "Tooltip chart \u2014 icons variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-tooltip-icons.tsx",
@@ -4995,7 +4995,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Tooltip chart — indicator line variant.",
+      "description": "Tooltip chart \u2014 indicator line variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-tooltip-indicator-line.tsx",
@@ -5035,7 +5035,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Tooltip chart — indicator none variant.",
+      "description": "Tooltip chart \u2014 indicator none variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-tooltip-indicator-none.tsx",
@@ -5075,7 +5075,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Tooltip chart — label custom variant.",
+      "description": "Tooltip chart \u2014 label custom variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-tooltip-label-custom.tsx",
@@ -5115,7 +5115,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Tooltip chart — label formatter variant.",
+      "description": "Tooltip chart \u2014 label formatter variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-tooltip-label-formatter.tsx",
@@ -5155,7 +5155,7 @@
       "dependencies": [
         "recharts"
       ],
-      "description": "Tooltip chart — label none variant.",
+      "description": "Tooltip chart \u2014 label none variant.",
       "files": [
         {
           "path": "components/blocks/charts/chart-tooltip-label-none.tsx",
@@ -5363,7 +5363,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -5480,7 +5480,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -5892,7 +5892,7 @@
     },
     {
       "dependencies": [],
-      "description": "Inline paragraph-level commenting — the Medium-style annotation pattern. Users highlight text in a chapter and leave comments anchored to that specific passage. Maps to a future comments schema on novels.chapter.",
+      "description": "Inline paragraph-level commenting \u2014 the Medium-style annotation pattern. Users highlight text in a chapter and leave comments anchored to that specific passage. Maps to a future comments schema on novels.chapter.",
       "files": [
         {
           "path": "components/ui/comment-on-paragraph.tsx",
@@ -5986,7 +5986,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -6372,7 +6372,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -6439,7 +6439,7 @@
     },
     {
       "dependencies": [],
-      "description": "Smart date display that shows relative time for recent dates (\"2 hours ago\", \"yesterday\") and absolute dates for older ones (\"15 May 2026\"). Respects locale from nyuchi-locale. A micro-primitive used everywhere — message timestamps, card metadata, activity feeds, task due dates.",
+      "description": "Smart date display that shows relative time for recent dates (\"2 hours ago\", \"yesterday\") and absolute dates for older ones (\"15 May 2026\"). Respects locale from nyuchi-locale. A micro-primitive used everywhere \u2014 message timestamps, card metadata, activity feeds, task due dates.",
       "files": [
         {
           "path": "components/ui/date-label.tsx",
@@ -6558,7 +6558,7 @@
     },
     {
       "dependencies": [],
-      "description": "Visual dependency/relationship display between items — task depends on task, event requires event, etc. Shows directed edges between nodes. Used in project planning (Planner), workflow visualization (Console), and content relationship mapping.",
+      "description": "Visual dependency/relationship display between items \u2014 task depends on task, event requires event, etc. Shows directed edges between nodes. Used in project planning (Planner), workflow visualization (Console), and content relationship mapping.",
       "files": [
         {
           "path": "components/ui/dependency-graph.tsx",
@@ -7136,7 +7136,7 @@
     },
     {
       "dependencies": [],
-      "description": "BushTrade escrow payment status tracker. Shows payment lifecycle stages: initiated → held → released/disputed. Maps to wallet.payment_intents with escrow state. Used in BushTrade transaction views and seller dashboards.",
+      "description": "BushTrade escrow payment status tracker. Shows payment lifecycle stages: initiated \u2192 held \u2192 released/disputed. Maps to wallet.payment_intents with escrow state. Used in BushTrade transaction views and seller dashboards.",
       "files": [
         {
           "path": "components/ui/escrow-status.tsx",
@@ -7248,7 +7248,7 @@
     },
     {
       "dependencies": [],
-      "description": "Currency pair display with live rate, conversion calculator, and trend indicator. Supports MXT ↔ fiat pairs across 42 African currencies. Used in Wallet swap interface and BushTrade cross-border commerce.",
+      "description": "Currency pair display with live rate, conversion calculator, and trend indicator. Supports MXT \u2194 fiat pairs across 42 African currencies. Used in Wallet swap interface and BushTrade cross-border commerce.",
       "files": [
         {
           "path": "components/ui/exchange-rate.tsx",
@@ -7284,7 +7284,7 @@
     },
     {
       "dependencies": [],
-      "description": "Sequential fallback strategy — try stages in order, return first success.",
+      "description": "Sequential fallback strategy \u2014 try stages in order, return first success.",
       "files": [
         {
           "path": "lib/fallback-chain.ts",
@@ -7303,7 +7303,7 @@
         "hasDemo": true,
         "owner": "mzizi",
         "useCases": [
-          "Degraded-mode content delivery (full → cache → placeholder)",
+          "Degraded-mode content delivery (full \u2192 cache \u2192 placeholder)",
           "Multi-source data retrieval with fallbacks",
           "Weather data with primary and backup providers",
           "Payment processing with backup gateway",
@@ -7731,7 +7731,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -7751,7 +7751,7 @@
     },
     {
       "dependencies": [],
-      "description": "Encrypted health record summary card showing recent visits, active prescriptions, allergies, and conditions. Data sourced from the sovereign Digital Twin pod — NEVER from Supabase. Respects Covenant One.",
+      "description": "Encrypted health record summary card showing recent visits, active prescriptions, allergies, and conditions. Data sourced from the sovereign Digital Twin pod \u2014 NEVER from Supabase. Respects Covenant One.",
       "files": [
         {
           "path": "components/ui/health-record-summary.tsx",
@@ -7878,7 +7878,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -7939,7 +7939,7 @@
     },
     {
       "dependencies": [],
-      "description": "Simple label + value display row with optional icon. Used on detail pages for key-value information: \"Temperature: 28°C\", \"Location: Harare\", \"Status: Active\". Compact single-line layout with icon left, label middle, value right-aligned. Production-proven in mukoko-weather for atmospheric details.",
+      "description": "Simple label + value display row with optional icon. Used on detail pages for key-value information: \"Temperature: 28\u00b0C\", \"Location: Harare\", \"Status: Active\". Compact single-line layout with icon left, label middle, value right-aligned. Production-proven in mukoko-weather for atmospheric details.",
       "files": [
         {
           "path": "components/ui/info-row.tsx",
@@ -7994,7 +7994,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -8014,7 +8014,7 @@
     },
     {
       "dependencies": [],
-      "description": "Click-to-edit text field that transforms from display mode to input mode on interaction. Pattern for low-friction editing in admin tables, settings pages, and profile fields. Supports validation, optimistic save, and revert on escape. Audit flagged as missing UX pattern. ALPHA — awaiting frontend implementation.",
+      "description": "Click-to-edit text field that transforms from display mode to input mode on interaction. Pattern for low-friction editing in admin tables, settings pages, and profile fields. Supports validation, optimistic save, and revert on escape. Audit flagged as missing UX pattern. ALPHA \u2014 awaiting frontend implementation.",
       "files": [
         {
           "path": "components/ui/inline-edit.tsx",
@@ -8356,7 +8356,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -8489,7 +8489,7 @@
     },
     {
       "dependencies": [],
-      "description": "Key Performance Indicator card. Displays a metric label, large value, optional change percentage with trend direction. Extracted from analytics-dashboard-page, console-dashboard-page, and wallet-page where the same pattern was repeated inline. Brand-agnostic — uses semantic CSS vars only.",
+      "description": "Key Performance Indicator card. Displays a metric label, large value, optional change percentage with trend direction. Extracted from analytics-dashboard-page, console-dashboard-page, and wallet-page where the same pattern was repeated inline. Brand-agnostic \u2014 uses semantic CSS vars only.",
       "files": [
         {
           "path": "components/ui/kpi-card.tsx",
@@ -8654,7 +8654,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -9034,7 +9034,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -9223,7 +9223,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -9371,7 +9371,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -9428,7 +9428,7 @@
     },
     {
       "dependencies": [],
-      "description": "Horizontal scrollable filter/effect picker — the TikTok/Instagram paradigm. Shows filter previews as circular thumbnails with names. Applies visual effects to camera preview or captured media. Used in Bytes creation flow.",
+      "description": "Horizontal scrollable filter/effect picker \u2014 the TikTok/Instagram paradigm. Shows filter previews as circular thumbnails with names. Applies visual effects to camera preview or captured media. Used in Bytes creation flow.",
       "files": [
         {
           "path": "components/ui/media-filter-strip.tsx",
@@ -9481,7 +9481,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -9812,7 +9812,7 @@
     },
     {
       "dependencies": [],
-      "description": "Payment method picker for African mobile money services — EcoCash, MTN MoMo, Airtel Money, M-Pesa, and Innbucks. Shows provider logo, phone number input, and USSD code reference. This is HOW Africa pays — the primary payment primitive for the continent.",
+      "description": "Payment method picker for African mobile money services \u2014 EcoCash, MTN MoMo, Airtel Money, M-Pesa, and Innbucks. Shows provider logo, phone number input, and USSD code reference. This is HOW Africa pays \u2014 the primary payment primitive for the continent.",
       "files": [
         {
           "path": "components/ui/mobile-money-selector.tsx",
@@ -9934,7 +9934,7 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure — no direct a11y requirements"
+          "Non-visual infrastructure \u2014 no direct a11y requirements"
         ],
         "collection": "observability",
         "features": [
@@ -9958,7 +9958,7 @@
     },
     {
       "dependencies": [],
-      "description": "Adaptive Bitrate Content — adjusts content quality based on network conditions. Serves lower-resolution images, compressed text, and deferred media on slow connections. Based on TikTok ABR streaming but applied to all content types, not just video. Critical for Africa where 2G/3G is common.",
+      "description": "Adaptive Bitrate Content \u2014 adjusts content quality based on network conditions. Serves lower-resolution images, compressed text, and deferred media on slow connections. Based on TikTok ABR streaming but applied to all content types, not just video. Critical for Africa where 2G/3G is common.",
       "files": [
         {
           "path": "components/ui/mzizi-abr-content.tsx",
@@ -9994,7 +9994,7 @@
     },
     {
       "dependencies": [],
-      "description": "SLO/SLA tracking and threshold-based alerting with escalation. Defines budgets (error budget, latency budget), monitors them, and fires alerts when thresholds are breached. Supports severity escalation: warn → page → incident. Competitors: PagerDuty, Grafana Alerting.",
+      "description": "SLO/SLA tracking and threshold-based alerting with escalation. Defines budgets (error budget, latency budget), monitors them, and fires alerts when thresholds are breached. Supports severity escalation: warn \u2192 page \u2192 incident. Competitors: PagerDuty, Grafana Alerting.",
       "files": [
         {
           "path": "lib/mzizi-alert-engine.ts",
@@ -10003,7 +10003,7 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure — no direct a11y requirements"
+          "Non-visual infrastructure \u2014 no direct a11y requirements"
         ],
         "collection": "observability",
         "features": [
@@ -10036,7 +10036,7 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure — no direct a11y requirements"
+          "Non-visual infrastructure \u2014 no direct a11y requirements"
         ],
         "collection": "observability",
         "features": [
@@ -10134,7 +10134,7 @@
     },
     {
       "dependencies": [],
-      "description": "Reactive chaos diagnostics — N8 Assurance (Z-axis/depth). Runs through the entire 3D architecture, able to inject failures at any component on any horizontal layer, through any vertical spine. Two modes: (1) Injection — random error/latency at configurable probability per layer intersection. (2) Reactive — when a real error is caught anywhere in the 3D space, probe adjacent systems for blast radius. The depth dimension that proves X and Y axes work.",
+      "description": "Reactive chaos diagnostics \u2014 N8 Assurance (Z-axis/depth). Runs through the entire 3D architecture, able to inject failures at any component on any horizontal layer, through any vertical spine. Two modes: (1) Injection \u2014 random error/latency at configurable probability per layer intersection. (2) Reactive \u2014 when a real error is caught anywhere in the 3D space, probe adjacent systems for blast radius. The depth dimension that proves X and Y axes work.",
       "files": [
         {
           "path": "lib/mzizi-chaos.tsx",
@@ -10168,7 +10168,7 @@
     },
     {
       "dependencies": [],
-      "description": "Conformity monkey — verifies deployed components match the design registry. Scans the DOM for data-slot/data-portal attributes and cross-references with the component database. Flags: unregistered components, outdated versions, missing backlinks, components using deprecated patterns. Inspired by Netflix Conformity Monkey.",
+      "description": "Conformity monkey \u2014 verifies deployed components match the design registry. Scans the DOM for data-slot/data-portal attributes and cross-references with the component database. Flags: unregistered components, outdated versions, missing backlinks, components using deprecated patterns. Inspired by Netflix Conformity Monkey.",
       "files": [
         {
           "path": "lib/mzizi-conformity-check.ts",
@@ -10177,7 +10177,7 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure — no direct a11y requirements"
+          "Non-visual infrastructure \u2014 no direct a11y requirements"
         ],
         "collection": "observability",
         "features": [
@@ -10242,7 +10242,7 @@
     },
     {
       "dependencies": [],
-      "description": "Post-quantum cryptography fallback handler. When PQC verification fails (library not loaded, algorithm not supported on device), falls back to classical verification with a \"reduced security\" visual indicator. Based on the QuantZen overlay pattern — adds quantum-safe layer without breaking existing UX.",
+      "description": "Post-quantum cryptography fallback handler. When PQC verification fails (library not loaded, algorithm not supported on device), falls back to classical verification with a \"reduced security\" visual indicator. Based on the QuantZen overlay pattern \u2014 adds quantum-safe layer without breaking existing UX.",
       "files": [
         {
           "path": "components/ui/mzizi-crypto-fallback.tsx",
@@ -10278,7 +10278,7 @@
     },
     {
       "dependencies": [],
-      "description": "Quantum-safe cryptographic verification gate. Validates signature strength — in quantum-ready mode requires PQC dual-signature (CRYSTALS-Dilithium + classical ECDSA). Degrades gracefully showing \"reduced security\" indicator when only classical signatures are available. Based on the QuantZen dual-signature pattern.",
+      "description": "Quantum-safe cryptographic verification gate. Validates signature strength \u2014 in quantum-ready mode requires PQC dual-signature (CRYSTALS-Dilithium + classical ECDSA). Degrades gracefully showing \"reduced security\" indicator when only classical signatures are available. Based on the QuantZen dual-signature pattern.",
       "files": [
         {
           "path": "components/ui/mzizi-crypto-gate.tsx",
@@ -10316,7 +10316,7 @@
     },
     {
       "dependencies": [],
-      "description": "Configurable degradation fallback chain: personalized → cached → trending → default → static. Each level renders when the previous fails. Based on Netflix graceful degradation — the \"bookmark service\" pattern applied across all mini-apps.",
+      "description": "Configurable degradation fallback chain: personalized \u2192 cached \u2192 trending \u2192 default \u2192 static. Each level renders when the previous fails. Based on Netflix graceful degradation \u2014 the \"bookmark service\" pattern applied across all mini-apps.",
       "files": [
         {
           "path": "components/ui/mzizi-degradation-chain.tsx",
@@ -10538,7 +10538,7 @@
     },
     {
       "dependencies": [],
-      "description": "Incident lifecycle management: detect → triage → mitigate → resolve → postmortem. Tracks incidents with severity, affected components (via backlinks), timeline of actions, and generates postmortem templates. Competitors: PagerDuty, incident.io.",
+      "description": "Incident lifecycle management: detect \u2192 triage \u2192 mitigate \u2192 resolve \u2192 postmortem. Tracks incidents with severity, affected components (via backlinks), timeline of actions, and generates postmortem templates. Competitors: PagerDuty, incident.io.",
       "files": [
         {
           "path": "lib/mzizi-incident-manager.ts",
@@ -10547,7 +10547,7 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure — no direct a11y requirements"
+          "Non-visual infrastructure \u2014 no direct a11y requirements"
         ],
         "collection": "observability",
         "features": [
@@ -10645,7 +10645,7 @@
     },
     {
       "dependencies": [],
-      "description": "Offline feature availability gate. Determines if a feature works offline, with cached data, or requires a connection. Shows branded \"available offline\" or \"requires connection\" state. Critical for local-first architecture — treats connectivity as a gradient, not a binary. Based on WhatsApp offline queuing but for all feature types.",
+      "description": "Offline feature availability gate. Determines if a feature works offline, with cached data, or requires a connection. Shows branded \"available offline\" or \"requires connection\" state. Critical for local-first architecture \u2014 treats connectivity as a gradient, not a binary. Based on WhatsApp offline queuing but for all feature types.",
       "files": [
         {
           "path": "components/ui/mzizi-offline-gate.tsx",
@@ -10728,7 +10728,7 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure — no direct a11y requirements"
+          "Non-visual infrastructure \u2014 no direct a11y requirements"
         ],
         "collection": "observability",
         "features": [
@@ -10790,7 +10790,7 @@
     },
     {
       "dependencies": [],
-      "description": "Transparent platform health dashboard — N8 Assurance (Z-axis/depth). Observes the full 3D architecture: every horizontal layer (L2-L7), every vertical spine (L1 tokens, L4 safety, L5 resilience), and reports which intersections are operational, degraded, or in outage. The depth view into the system.",
+      "description": "Transparent platform health dashboard \u2014 N8 Assurance (Z-axis/depth). Observes the full 3D architecture: every horizontal layer (L2-L7), every vertical spine (L1 tokens, L4 safety, L5 resilience), and reports which intersections are operational, degraded, or in outage. The depth view into the system.",
       "files": [
         {
           "path": "components/ui/mzizi-platform-health.tsx",
@@ -10799,7 +10799,7 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure — no direct a11y requirements"
+          "Non-visual infrastructure \u2014 no direct a11y requirements"
         ],
         "collection": "observability",
         "features": [
@@ -10897,7 +10897,7 @@
     },
     {
       "dependencies": [],
-      "description": "Real User Monitoring. Collects page load timing, interaction delays, network quality, and navigation patterns from actual users. Aggregates by mini-app, page, device, and connection type. Privacy-respecting — no PII, only performance metrics. Competitors: Datadog RUM, Vercel Analytics.",
+      "description": "Real User Monitoring. Collects page load timing, interaction delays, network quality, and navigation patterns from actual users. Aggregates by mini-app, page, device, and connection type. Privacy-respecting \u2014 no PII, only performance metrics. Competitors: Datadog RUM, Vercel Analytics.",
       "files": [
         {
           "path": "lib/mzizi-rum.ts",
@@ -10906,7 +10906,7 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure — no direct a11y requirements"
+          "Non-visual infrastructure \u2014 no direct a11y requirements"
         ],
         "collection": "observability",
         "features": [
@@ -10977,7 +10977,7 @@
     },
     {
       "dependencies": [],
-      "description": "DEPRECATED — Loading states are built into each component from Layer 2 up via the loading prop. Every component renders its own shaped skeleton matching its exact proportions. This top-down skeleton set is a legacy pattern. Use <NyuchiListingCard loading /> instead of <ListingSkeleton />. Will be removed in the next major version.",
+      "description": "DEPRECATED \u2014 Loading states are built into each component from Layer 2 up via the loading prop. Every component renders its own shaped skeleton matching its exact proportions. This top-down skeleton set is a legacy pattern. Use <NyuchiListingCard loading /> instead of <ListingSkeleton />. Will be removed in the next major version.",
       "files": [
         {
           "path": "components/ui/mzizi-skeleton-set.tsx",
@@ -10989,7 +10989,7 @@
           "aria-busy=true on parent container",
           "aria-live=polite for updates when loading completes",
           "Screen reader silent during shimmer (decorative)",
-          "Non-interactive — no focus traps"
+          "Non-interactive \u2014 no focus traps"
         ],
         "collection": "resilience",
         "features": [
@@ -11061,7 +11061,7 @@
     },
     {
       "dependencies": [],
-      "description": "Synthetic user journey probes that run on schedule. Defines step-by-step user flows (login → navigate → action → verify) and executes them against live or staging environments. Reports pass/fail with latency per step. Competitors: Datadog Synthetic Monitoring, Checkly.",
+      "description": "Synthetic user journey probes that run on schedule. Defines step-by-step user flows (login \u2192 navigate \u2192 action \u2192 verify) and executes them against live or staging environments. Reports pass/fail with latency per step. Competitors: Datadog Synthetic Monitoring, Checkly.",
       "files": [
         {
           "path": "lib/mzizi-synthetic-probe.ts",
@@ -11070,7 +11070,7 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure — no direct a11y requirements"
+          "Non-visual infrastructure \u2014 no direct a11y requirements"
         ],
         "collection": "observability",
         "features": [
@@ -11094,7 +11094,7 @@
     },
     {
       "dependencies": [],
-      "description": "Trust score threshold gate. Blocks features that require a minimum trust score. Shows the user's current score, the required threshold, and actionable steps to improve. Maps to the Ubuntu Layer trust model: Status × Verification Tier → Trust Score. Used for: posting requires > 0.1, selling requires > 0.3, moderating requires > 0.5.",
+      "description": "Trust score threshold gate. Blocks features that require a minimum trust score. Shows the user's current score, the required threshold, and actionable steps to improve. Maps to the Ubuntu Layer trust model: Status \u00d7 Verification Tier \u2192 Trust Score. Used for: posting requires > 0.1, selling requires > 0.3, moderating requires > 0.5.",
       "files": [
         {
           "path": "components/ui/mzizi-trust-gate.tsx",
@@ -11535,7 +11535,7 @@
     },
     {
       "dependencies": [],
-      "description": "Full-screen or drawer notification management surface. Extends notification-center (existing Layer 2 component) with filter/search, archive, bulk actions, and grouped conversations view. Audit flagged as missing UX pattern for mature notification UX. ALPHA — awaiting frontend implementation.",
+      "description": "Full-screen or drawer notification management surface. Extends notification-center (existing Layer 2 component) with filter/search, archive, bulk actions, and grouped conversations view. Audit flagged as missing UX pattern for mature notification UX. ALPHA \u2014 awaiting frontend implementation.",
       "files": [
         {
           "path": "components/ui/notification-center-full.tsx",
@@ -11733,7 +11733,7 @@
     },
     {
       "dependencies": [],
-      "description": "Universal branded bottom action sheet for contextual actions on any content across the ecosystem. Share, save, report, copy link, block, follow — the standard set of actions available on listings, posts, profiles, and messages. Renders as a bottom sheet on mobile with mineral accent on destructive/primary actions. Composes sheet and share-dialog primitives.",
+      "description": "Universal branded bottom action sheet for contextual actions on any content across the ecosystem. Share, save, report, copy link, block, follow \u2014 the standard set of actions available on listings, posts, profiles, and messages. Renders as a bottom sheet on mobile with mineral accent on destructive/primary actions. Composes sheet and share-dialog primitives.",
       "files": [
         {
           "path": "components/ui/nyuchi-action-sheet.tsx",
@@ -11776,7 +11776,7 @@
     },
     {
       "dependencies": [],
-      "description": "AI context provider for N10. Generates context windows for AI assistants (Claude, Cursor, Copilot, Windsurf) with current ecosystem model, node architecture, and coding rules. No hardcoded counts — always accepts live values from get_system_counts(). Used by the MCP server and IDE integrations.",
+      "description": "AI context provider for N10. Generates context windows for AI assistants (Claude, Cursor, Copilot, Windsurf) with current ecosystem model, node architecture, and coding rules. No hardcoded counts \u2014 always accepts live values from get_system_counts(). Used by the MCP server and IDE integrations.",
       "files": [
         {
           "path": "lib/nyuchi-ai-context.ts",
@@ -11957,7 +11957,7 @@
         ],
         "collection": "agentic-components",
         "features": [
-          "Inline sign-in AND registration — never a browser tab",
+          "Inline sign-in AND registration \u2014 never a browser tab",
           "Mode toggle between login and register",
           "SSO / passwordless provider buttons",
           "Drives the MCP inline-auth handoff (OAuth 2.1 / DCR / elicitation)",
@@ -12001,7 +12001,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -12025,7 +12025,7 @@
     },
     {
       "dependencies": [],
-      "description": "Overlapping +N social-proof avatar stack — the going/attendee cue. Ring-separated avatars overlap with negative margin, each an image or an initials fallback, showing up to `max` before a +N overflow bubble, with an optional trailing <total> <label> in 13px muted. Purely presentational and server-safe (no harness, no client directive) so it renders inside React Server Components. The group carries an accessible summary label (e.g. \"128 going\") while the decorative avatars are aria-hidden. sm / md sizes.",
+      "description": "Overlapping +N social-proof avatar stack \u2014 the going/attendee cue. Ring-separated avatars overlap with negative margin, each an image or an initials fallback, showing up to `max` before a +N overflow bubble, with an optional trailing <total> <label> in 13px muted. Purely presentational and server-safe (no harness, no client directive) so it renders inside React Server Components. The group carries an accessible summary label (e.g. \"128 going\") while the decorative avatars are aria-hidden. sm / md sizes.",
       "files": [
         {
           "path": "components/ui/nyuchi-avatar-stack.tsx",
@@ -12045,7 +12045,7 @@
           "Image or initials fallback per person",
           "+N overflow bubble past max",
           "Optional trailing total + label (13px muted)",
-          "Server-safe presentational atom — no harness, no client directive",
+          "Server-safe presentational atom \u2014 no harness, no client directive",
           "sm / md size scale"
         ],
         "owner": "nyuchi",
@@ -12158,7 +12158,7 @@
       "dependencies": [
         "next"
       ],
-      "description": "Mobile-only bottom navigation bar for Nyuchi ecosystem apps. Supports a center FAB (floating action button) — a raised button in the app mineral accent colour with a glow shadow. The center FAB is the primary creation entry point, making the \"create\" action instantly recognizable across all apps.",
+      "description": "Mobile-only bottom navigation bar for Nyuchi ecosystem apps. Supports a center FAB (floating action button) \u2014 a raised button in the app mineral accent colour with a glow shadow. The center FAB is the primary creation entry point, making the \"create\" action instantly recognizable across all apps.",
       "files": [
         {
           "path": "components/ui/nyuchi-bottom-nav.tsx",
@@ -12173,7 +12173,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7→L8→L9)",
+          "Cross-layer wiring (L7\u2192L8\u2192L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -12201,7 +12201,7 @@
         "react-day-picker",
         "date-fns"
       ],
-      "description": "Brand calendar component wrapping react-day-picker with Mukoko event dot indicators, mineral-colored day highlights, and integrated agenda view for the selected day. Used by nhimbe (events), planner, and any Mukoko app that shows date-anchored content. The event dots are the key differentiator — small mineral-colored circles beneath dates that have associated content.",
+      "description": "Brand calendar component wrapping react-day-picker with Mukoko event dot indicators, mineral-colored day highlights, and integrated agenda view for the selected day. Used by nhimbe (events), planner, and any Mukoko app that shows date-anchored content. The event dots are the key differentiator \u2014 small mineral-colored circles beneath dates that have associated content.",
       "files": [
         {
           "path": "components/ui/nyuchi-calendar.tsx",
@@ -12373,7 +12373,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7→L8→L9)",
+          "Cross-layer wiring (L7\u2192L8\u2192L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -12396,7 +12396,7 @@
     },
     {
       "dependencies": [],
-      "description": "Universal freeform content creation component — the branded way to compose posts, updates, stories, and messages across the ecosystem. Combines text input, media attachment, mention tagging, and mineral-accented submit button. Used in Circles (posts), Pulse (updates), Campfire (messages), Novels (chapter drafts), and anywhere users create unstructured content. Distinct from nyuchi-create-listing which handles structured form-based creation.",
+      "description": "Universal freeform content creation component \u2014 the branded way to compose posts, updates, stories, and messages across the ecosystem. Combines text input, media attachment, mention tagging, and mineral-accented submit button. Used in Circles (posts), Pulse (updates), Campfire (messages), Novels (chapter drafts), and anywhere users create unstructured content. Distinct from nyuchi-create-listing which handles structured form-based creation.",
       "files": [
         {
           "path": "components/ui/nyuchi-content-composer.tsx",
@@ -12519,7 +12519,7 @@
     },
     {
       "dependencies": [],
-      "description": "Event/detail header composite that derives the whole page tint and CTA colour from its cover — the 4.2.0 cover-wash signature. A full-bleed image or gradient cover with a legibility scrim carries an overlaid title, optional kicker/subtitle, a small inline meta row (date · location · host) and a CTA slot (children). From an accent (or mineral) prop it emits --event-primary and --wash as inline custom properties on the root, seeding the wash context that every descendant — and the rest of the detail page — inherits. Accent defaults to --brand-accent so each app swaps its own mineral; harness-wired for reduced-motion entry and observability.",
+      "description": "Event/detail header composite that derives the whole page tint and CTA colour from its cover \u2014 the 4.2.0 cover-wash signature. A full-bleed image or gradient cover with a legibility scrim carries an overlaid title, optional kicker/subtitle, a small inline meta row (date \u00b7 location \u00b7 host) and a CTA slot (children). From an accent (or mineral) prop it emits --event-primary and --wash as inline custom properties on the root, seeding the wash context that every descendant \u2014 and the rest of the detail page \u2014 inherits. Accent defaults to --brand-accent so each app swaps its own mineral; harness-wired for reduced-motion entry and observability.",
       "files": [
         {
           "path": "components/ui/nyuchi-cover-wash-header.tsx",
@@ -12535,7 +12535,7 @@
         ],
         "collection": "brand",
         "features": [
-          "4.2.0 cover-wash signature — seeds --event-primary + --wash on the root",
+          "4.2.0 cover-wash signature \u2014 seeds --event-primary + --wash on the root",
           "Full-bleed image or gradient cover with legibility scrim",
           "Accent from prop or mineral, --brand-accent neutral default",
           "Inline meta row (date / location / host) + CTA slot via children",
@@ -12562,7 +12562,7 @@
       "dependencies": [
         "class-variance-authority"
       ],
-      "description": "Universal create/edit form layout for all Mukoko content types — events, products, news, bush trade listings, directories. Provides the standardized brand creation flow: cover theme picker, grouped form sections in cards, toggle/dropdown rows, description editor, and sticky publish CTA. Every \"Create\" or \"Edit\" screen across the super app uses this composition.",
+      "description": "Universal create/edit form layout for all Mukoko content types \u2014 events, products, news, bush trade listings, directories. Provides the standardized brand creation flow: cover theme picker, grouped form sections in cards, toggle/dropdown rows, description editor, and sticky publish CTA. Every \"Create\" or \"Edit\" screen across the super app uses this composition.",
       "files": [
         {
           "path": "components/ui/nyuchi-create-listing.tsx",
@@ -12628,7 +12628,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -12717,7 +12717,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -12747,10 +12747,10 @@
     },
     {
       "dependencies": [],
-      "description": "Data fetching and state management bridge between the 7-layer architecture and the UI. Exports useNyuchiQuery hook (local-first fetch: try SQLite/IndexedDB → edge D1 → cloud Supabase, with automatic background sync), NyuchiListView (declarative feed composition: listing-card + infinite scroll + pull-to-refresh + empty state + skeleton + error card), NyuchiSearchView (search input + filter bar + results + recent searches), and optimistic update utilities. Every data-driven screen in every Nyuchi app uses these patterns instead of raw fetch calls. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
+      "description": "Data fetching and state management bridge between the 7-layer architecture and the UI. Exports useNyuchiQuery hook (local-first fetch: try SQLite/IndexedDB \u2192 edge D1 \u2192 cloud Supabase, with automatic background sync), NyuchiListView (declarative feed composition: listing-card + infinite scroll + pull-to-refresh + empty state + skeleton + error card), NyuchiSearchView (search input + filter bar + results + recent searches), and optimistic update utilities. Every data-driven screen in every Nyuchi app uses these patterns instead of raw fetch calls. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
       "files": [
         {
-          "path": "lib/data/index.ts",
+          "path": "lib/data/index.tsx",
           "type": "registry:lib"
         }
       ],
@@ -12801,7 +12801,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7→L8→L9)",
+          "Cross-layer wiring (L7\u2192L8\u2192L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -12824,7 +12824,7 @@
     },
     {
       "dependencies": [],
-      "description": "Shared detail page layout for all content types across the Nyuchi ecosystem — events, articles, products, bush trade listings, places. Supports a hero gradient variant with floating back/like/share action buttons, mineral-colored category badges, and verified badge display for the host/author. The detail-layout is the brand-standard way to present any single piece of content at full depth.",
+      "description": "Shared detail page layout for all content types across the Nyuchi ecosystem \u2014 events, articles, products, bush trade listings, places. Supports a hero gradient variant with floating back/like/share action buttons, mineral-colored category badges, and verified badge display for the host/author. The detail-layout is the brand-standard way to present any single piece of content at full depth.",
       "files": [
         {
           "path": "components/ui/nyuchi-detail-layout.tsx",
@@ -12841,7 +12841,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -12888,7 +12888,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -12917,7 +12917,7 @@
     },
     {
       "dependencies": [],
-      "description": "Documentation read API for N10. Runs as a Supabase Deno edge function (`Deno.serve`, `jsr:@supabase/supabase-js@2`) — NOT a Cloudflare Worker and not Rust/WASM, which is what this description claimed while the file said otherwise. Serves documentation pages, AI instructions, architecture nodes and changelog entries over PostgREST: /docs, /ai-instructions, /architecture, /changelog, /counts. Public read, no auth. Deno-runtime source, so it is excluded from tsconfig and is not installable into a React app via the shadcn CLI.",
+      "description": "Documentation read API for N10. Runs as a Supabase Deno edge function (`Deno.serve`, `jsr:@supabase/supabase-js@2`) \u2014 NOT a Cloudflare Worker and not Rust/WASM, which is what this description claimed while the file said otherwise. Serves documentation pages, AI instructions, architecture nodes and changelog entries over PostgREST: /docs, /ai-instructions, /architecture, /changelog, /counts. Public read, no auth. Deno-runtime source, so it is excluded from tsconfig and is not installable into a React app via the shadcn CLI.",
       "files": [
         {
           "path": "lib/nyuchi-docs-api.ts",
@@ -12989,14 +12989,6 @@
         {
           "path": "lib/dx/index.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "lib/dx/status.ts",
-          "type": "registry:lib"
-        },
-        {
-          "path": "lib/dx/docs-schema.ts",
-          "type": "registry:lib"
         }
       ],
       "meta": {
@@ -13046,7 +13038,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -13070,7 +13062,7 @@
     },
     {
       "dependencies": [],
-      "description": "Universal branded empty state with dynamic mineral accent, contextual illustration placeholder, title, description, and optional action CTA. Every screen across the ecosystem uses this when there is no content to display — \"No events yet\", \"Your wallet is empty\", \"No messages\", \"Start your first lesson\". The empty state guides users toward the creation action for that domain.",
+      "description": "Universal branded empty state with dynamic mineral accent, contextual illustration placeholder, title, description, and optional action CTA. Every screen across the ecosystem uses this when there is no content to display \u2014 \"No events yet\", \"Your wallet is empty\", \"No messages\", \"Start your first lesson\". The empty state guides users toward the creation action for that domain.",
       "files": [
         {
           "path": "components/ui/nyuchi-empty-state.tsx",
@@ -13129,7 +13121,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -13291,7 +13283,7 @@
     },
     {
       "dependencies": [],
-      "description": "Standard feed page orchestrator composing header, search/filter bar, NyuchiListView infinite scroll feed, pull-to-refresh, empty state, and FAB create button into a complete screen. Every feed screen across every mini-app uses this layout — Pulse home, News feed, Circles timeline, BushTrade listings, Jobs board, Nhimbe events, Places directory. The developer provides the data source, card renderer, and filter configuration. The orchestrator handles layout, loading, errors, and responsive behaviour.",
+      "description": "Standard feed page orchestrator composing header, search/filter bar, NyuchiListView infinite scroll feed, pull-to-refresh, empty state, and FAB create button into a complete screen. Every feed screen across every mini-app uses this layout \u2014 Pulse home, News feed, Circles timeline, BushTrade listings, Jobs board, Nhimbe events, Places directory. The developer provides the data source, card renderer, and filter configuration. The orchestrator handles layout, loading, errors, and responsive behaviour.",
       "files": [
         {
           "path": "components/ui/nyuchi-feed-page.tsx",
@@ -13308,7 +13300,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -13356,7 +13348,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7→L8→L9)",
+          "Cross-layer wiring (L7\u2192L8\u2192L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -13420,7 +13412,7 @@
     },
     {
       "dependencies": [],
-      "description": "Fundi — the self-healing intelligence engine. Swahili for fixer/mechanic/technician. N9 acts on what N8 observes. Built in Rust, deployed as a Cloudflare Worker (workers-rs crate, compiled to WebAssembly). NOT a Cloudflare Worker (Rust/WASM) — Fundi is independent of the database vendor. Reads fundi_issues and observability_events from Supabase via REST API. Classifies failure patterns, deduplicates against open GitHub issues, creates structured remediation tickets. Triggered by Cloudflare Cron Triggers and Cloudflare Queues.",
+      "description": "Fundi \u2014 the self-healing intelligence engine. Swahili for fixer/mechanic/technician. N9 acts on what N8 observes. Built in Rust, deployed as a Cloudflare Worker (workers-rs crate, compiled to WebAssembly). NOT a Cloudflare Worker (Rust/WASM) \u2014 Fundi is independent of the database vendor. Reads fundi_issues and observability_events from Supabase via REST API. Classifies failure patterns, deduplicates against open GitHub issues, creates structured remediation tickets. Triggered by Cloudflare Cron Triggers and Cloudflare Queues.",
       "files": [
         {
           "path": "lib/nyuchi-fundi.tsx",
@@ -13451,7 +13443,7 @@
     },
     {
       "dependencies": [],
-      "description": "Fundi learning system. Tracks healing outcomes to improve future decisions. When an issue is resolved, records what failed, what Fundi suggested, what actually worked, and whether the same pattern recurs. Runs as part of the Fundi Cloudflare Worker — same Rust binary, different handler. Writes learned patterns to fundi_issues via Supabase REST API. Improves classification accuracy over time.",
+      "description": "Fundi learning system. Tracks healing outcomes to improve future decisions. When an issue is resolved, records what failed, what Fundi suggested, what actually worked, and whether the same pattern recurs. Runs as part of the Fundi Cloudflare Worker \u2014 same Rust binary, different handler. Writes learned patterns to fundi_issues via Supabase REST API. Improves classification accuracy over time.",
       "files": [
         {
           "path": "lib/nyuchi-fundi-learning.ts",
@@ -13460,11 +13452,11 @@
       ],
       "meta": {
         "a11y": [
-          "Non-visual infrastructure — no direct a11y requirements"
+          "Non-visual infrastructure \u2014 no direct a11y requirements"
         ],
         "collection": "fundi",
         "features": [
-          "Outside actor — operates via GitHub Issues",
+          "Outside actor \u2014 operates via GitHub Issues",
           "Human-in-the-loop healing workflow",
           "DB persistence via fundi_issues table"
         ],
@@ -13485,7 +13477,7 @@
     },
     {
       "dependencies": [],
-      "description": "Bridge from N8 Assurance to N9 Fundi. When N8 components detect failures, the reporter pushes a structured signal to the Cloudflare Queue that triggers Fundi. Signal payload: component name, ecosystem node, error type, severity, diagnostic data. The Queue decouples N8 (detection) from N9 (healing) — N8 never waits for Fundi to respond. Also creates a fundi_issues row in Supabase as the append-only audit trail.",
+      "description": "Bridge from N8 Assurance to N9 Fundi. When N8 components detect failures, the reporter pushes a structured signal to the Cloudflare Queue that triggers Fundi. Signal payload: component name, ecosystem node, error type, severity, diagnostic data. The Queue decouples N8 (detection) from N9 (healing) \u2014 N8 never waits for Fundi to respond. Also creates a fundi_issues row in Supabase as the append-only audit trail.",
       "files": [
         {
           "path": "lib/nyuchi-fundi-reporter.ts",
@@ -13516,7 +13508,7 @@
     },
     {
       "dependencies": [],
-      "description": "Branded metric card with radial arc gauge, value display, label, and contextual description. The universal pattern extracted from mukoko-weather MetricCard. Used for UV index, trust scores, completion percentages, health vitals, battery levels, signal strength — any bounded numeric value displayed as a gauge. Composes the arc-gauge primitive with brand styling.",
+      "description": "Branded metric card with radial arc gauge, value display, label, and contextual description. The universal pattern extracted from mukoko-weather MetricCard. Used for UV index, trust scores, completion percentages, health vitals, battery levels, signal strength \u2014 any bounded numeric value displayed as a gauge. Composes the arc-gauge primitive with brand styling.",
       "files": [
         {
           "path": "components/ui/nyuchi-gauge-card.tsx",
@@ -13577,7 +13569,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -13644,7 +13636,7 @@
     },
     {
       "dependencies": [],
-      "description": "The Nyuchi component harness — the vertical infrastructure spine (useNyuchiHarness hook + NyuchiHarness wrapper) giving N3 brand, N4 safety, and N5 resilience components scoped logging, motion, and an accessible shared live region. Self-contained; adapt the console logger to your app observability layer.",
+      "description": "The Nyuchi component harness \u2014 the vertical infrastructure spine (useNyuchiHarness hook + NyuchiHarness wrapper) giving N3 brand, N4 safety, and N5 resilience components scoped logging, motion, and an accessible shared live region. Self-contained; adapt the console logger to your app observability layer.",
       "files": [
         {
           "path": "lib/harness/index.tsx",
@@ -13680,7 +13672,7 @@
     },
     {
       "dependencies": [],
-      "description": "Pre-wiring node that connects every brand component to the full Nyuchi infrastructure stack. Exports NyuchiHarness (declarative wrapper providing error boundary + skeleton + observability + motion + a11y) and useNyuchiHarness hook (imperative access to observability logger, motion config, locale, theme, and health reporting). When a component is wrapped in a harness, it automatically logs render timing, catches errors with branded fallback, applies entry animations, uses the correct focus ring tokens, respects reduced-motion preferences, and reports health to the global monitor. Zero manual configuration required — install the component and it works. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
+      "description": "Pre-wiring node that connects every brand component to the full Nyuchi infrastructure stack. Exports NyuchiHarness (declarative wrapper providing error boundary + skeleton + observability + motion + a11y) and useNyuchiHarness hook (imperative access to observability logger, motion config, locale, theme, and health reporting). When a component is wrapped in a harness, it automatically logs render timing, catches errors with branded fallback, applies entry animations, uses the correct focus ring tokens, respects reduced-motion preferences, and reports health to the global monitor. Zero manual configuration required \u2014 install the component and it works. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
       "files": [
         {
           "path": "lib/harness/index.tsx",
@@ -13722,7 +13714,7 @@
     },
     {
       "dependencies": [],
-      "description": "Standardized sticky header for all Nyuchi ecosystem apps. Supports desktop nav links and mobile pill action group — a capsule-shaped container with 2–3 icon buttons in the brand accent color (dynamic per mini-app). The pill group is the primary brand identity marker in the header.",
+      "description": "Standardized sticky header for all Nyuchi ecosystem apps. Supports desktop nav links and mobile pill action group \u2014 a capsule-shaped container with 2\u20133 icon buttons in the brand accent color (dynamic per mini-app). The pill group is the primary brand identity marker in the header.",
       "files": [
         {
           "path": "components/ui/nyuchi-header.tsx",
@@ -13737,7 +13729,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7→L8→L9)",
+          "Cross-layer wiring (L7\u2192L8\u2192L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -13764,7 +13756,7 @@
     },
     {
       "dependencies": [],
-      "description": "Branded health overview card composing vitals-display, medication-reminder, and appointment-card primitives with malachite mineral accent. Shows key health metrics, upcoming appointments, and medication schedule at a glance. Sovereign data — all health data stays in the user pod.",
+      "description": "Branded health overview card composing vitals-display, medication-reminder, and appointment-card primitives with malachite mineral accent. Shows key health metrics, upcoming appointments, and medication schedule at a glance. Sovereign data \u2014 all health data stays in the user pod.",
       "files": [
         {
           "path": "components/ui/nyuchi-health-dashboard.tsx",
@@ -13849,7 +13841,7 @@
     },
     {
       "dependencies": [],
-      "description": "Central icon registry for the Nyuchi Design System. Maps semantic icon names to Lucide React icons. All components should import icons from this registry, not directly from lucide-react. Provides: consistent sizing (16/20/24/32), brand icon overrides, semantic naming (icon-success vs CheckCircle), tree-shaking optimization, and custom Nyuchi icons. N1 infrastructure — consumed by all layers above. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
+      "description": "Central icon registry for the Nyuchi Design System. Maps semantic icon names to Lucide React icons. All components should import icons from this registry, not directly from lucide-react. Provides: consistent sizing (16/20/24/32), brand icon overrides, semantic naming (icon-success vs CheckCircle), tree-shaking optimization, and custom Nyuchi icons. N1 infrastructure \u2014 consumed by all layers above. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
       "files": [
         {
           "path": "lib/nyuchi-icons/index.tsx",
@@ -13933,10 +13925,10 @@
     },
     {
       "dependencies": [],
-      "description": "Responsive and adaptive layout system for Nyuchi. Exports breakpoint tokens (mobile/tablet/desktop/wide), useBreakpoint hook, NyuchiGrid responsive grid component, canonical layout definitions for the five core page types (feed, detail, create, profile, dashboard), and adaptive density support (comfortable vs compact). Ensures consistent responsive behavior across all Nyuchi apps — same breakpoints, same grid, same content flow patterns. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
+      "description": "Responsive and adaptive layout system for Nyuchi. Exports breakpoint tokens (mobile/tablet/desktop/wide), useBreakpoint hook, NyuchiGrid responsive grid component, canonical layout definitions for the five core page types (feed, detail, create, profile, dashboard), and adaptive density support (comfortable vs compact). Ensures consistent responsive behavior across all Nyuchi apps \u2014 same breakpoints, same grid, same content flow patterns. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
       "files": [
         {
-          "path": "lib/layout/index.ts",
+          "path": "lib/layout/index.tsx",
           "type": "registry:lib"
         }
       ],
@@ -14054,7 +14046,7 @@
       "dependencies": [
         "class-variance-authority"
       ],
-      "description": "Universal content card for all Mukoko listing types — events, products, news, bush trade, directories. Supports row, compact, and hero variants with mineral-colored category accents. The foundational brand component: every listing across the super app uses this pattern.",
+      "description": "Universal content card for all Mukoko listing types \u2014 events, products, news, bush trade, directories. Supports row, compact, and hero variants with mineral-colored category accents. The foundational brand component: every listing across the super app uses this pattern.",
       "files": [
         {
           "path": "components/ui/nyuchi-listing-card.tsx",
@@ -14106,15 +14098,7 @@
       "description": "Internationalization infrastructure for the Pan-African Nyuchi platform. Exports NyuchiLocaleProvider (React context for locale, text direction, number/date/currency formatting), useLocale hook (access formatting functions), useDirection hook (RTL/LTR detection), locale-aware formatters for dates (relative and absolute), currencies (multi-currency with ZWL/ZAR/USD/KES support), numbers, and relative time. Supports all 16 Zimbabwean official languages. String token system for UI labels with locale variants so buttons, headings, and system text can be swapped without code changes. Bridges to the lingo schema in nyuchi_platform_db. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
       "files": [
         {
-          "path": "lib/locale/index.ts",
-          "type": "registry:lib"
-        },
-        {
-          "path": "lib/locale/formatters.ts",
-          "type": "registry:lib"
-        },
-        {
-          "path": "lib/locale/strings.ts",
+          "path": "lib/locale/index.tsx",
           "type": "registry:lib"
         }
       ],
@@ -14238,7 +14222,7 @@
     },
     {
       "dependencies": [],
-      "description": "Universal date/location signature tile — the 4.2.0 When/Where unit. A rounded-square chip (an icon tile OR a month-over-day date chip) paired with a bold 16px primary line and a 13px muted secondary line, with an optional caption and trailing action. Purely presentational and server-safe (no client directive, no harness) so it renders inside React Server Components. The chip tint defaults to the brand accent (--brand-accent) so each app swaps its own mineral. Used on event detail When/Where rows, place cards, and any listing that anchors a date or a location.",
+      "description": "Universal date/location signature tile \u2014 the 4.2.0 When/Where unit. A rounded-square chip (an icon tile OR a month-over-day date chip) paired with a bold 16px primary line and a 13px muted secondary line, with an optional caption and trailing action. Purely presentational and server-safe (no client directive, no harness) so it renders inside React Server Components. The chip tint defaults to the brand accent (--brand-accent) so each app swaps its own mineral. Used on event detail When/Where rows, place cards, and any listing that anchors a date or a location.",
       "files": [
         {
           "path": "components/ui/nyuchi-meta-tile.tsx",
@@ -14254,7 +14238,7 @@
         "collection": "brand",
         "features": [
           "4.2.0 date/location signature pattern",
-          "Server-safe — no client directive, renders in RSC",
+          "Server-safe \u2014 no client directive, renders in RSC",
           "13px muted metadata / 16px bold primary",
           "Brand-accent chip tint (--brand-accent), color-mix surface",
           "Icon-chip or month-over-day date-chip modes"
@@ -14292,7 +14276,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7→L8→L9)",
+          "Cross-layer wiring (L7\u2192L8\u2192L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -14364,10 +14348,6 @@
         {
           "path": "lib/motion/index.tsx",
           "type": "registry:lib"
-        },
-        {
-          "path": "lib/motion/presets.ts",
-          "type": "registry:lib"
         }
       ],
       "meta": {
@@ -14416,7 +14396,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7→L8→L9)",
+          "Cross-layer wiring (L7\u2192L8\u2192L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -14527,7 +14507,7 @@
     },
     {
       "dependencies": [],
-      "description": "Universal branded onboarding step card used across all ecosystem app first-use experiences. Shows an illustration area, title, description, progress dots, and next/skip actions. Dynamic mineral accent. The individual step within any onboarding flow — composable with swiper or stepper primitives for multi-step sequences.",
+      "description": "Universal branded onboarding step card used across all ecosystem app first-use experiences. Shows an illustration area, title, description, progress dots, and next/skip actions. Dynamic mineral accent. The individual step within any onboarding flow \u2014 composable with swiper or stepper primitives for multi-step sequences.",
       "files": [
         {
           "path": "components/ui/nyuchi-onboarding-step.tsx",
@@ -14587,7 +14567,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -14628,10 +14608,10 @@
         ],
         "collection": "agentic-components",
         "features": [
-          "Inline AP2 payment authorization — no checkout tab",
+          "Inline AP2 payment authorization \u2014 no checkout tab",
           "Payment-handler (rail) selection: card / bank / mobile money",
           "Shows the AP2 mandate chain (intent/cart) for transparency",
-          "No card details leave the wallet — signs a Payment Mandate",
+          "No card details leave the wallet \u2014 signs a Payment Mandate",
           "Dynamic mineral accent via --brand-accent"
         ],
         "owner": "nyuchi",
@@ -14713,7 +14693,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7→L8→L9)",
+          "Cross-layer wiring (L7\u2192L8\u2192L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -14823,7 +14803,7 @@
       "description": "Platform-specific utilities for PWA, native integration, and cross-platform behavior. Exports NyuchiInstallPrompt (branded PWA \"Add to Home Screen\" experience), NyuchiShareSheet (Web Share API with fallback), usePlatform hook (detect iOS/Android/web/PWA), useHaptics (haptic feedback with graceful degradation), and platform-aware navigation patterns. Makes every Nyuchi app feel native regardless of how it is accessed. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
       "files": [
         {
-          "path": "lib/platform/index.ts",
+          "path": "lib/platform/index.tsx",
           "type": "registry:lib"
         }
       ],
@@ -14922,7 +14902,7 @@
         ],
         "collection": "agentic-components",
         "features": [
-          "Compact top 3–5 UCP search results",
+          "Compact top 3\u20135 UCP search results",
           "Per-result price label + description",
           "Selecting a result hands the id back to the agent",
           "Empty-state messaging"
@@ -14945,7 +14925,7 @@
     },
     {
       "dependencies": [],
-      "description": "Standardized profile display block used across all Mukoko apps. Centers the avatar with verification badge, name with inline verified check, platform status indicator, trust score meter, and stat counters. The three trust indicators (verified badge, status pill, trust score) are always visible on the profile header — not just badges elsewhere in the app, but the full expanded view here.",
+      "description": "Standardized profile display block used across all Mukoko apps. Centers the avatar with verification badge, name with inline verified check, platform status indicator, trust score meter, and stat counters. The three trust indicators (verified badge, status pill, trust score) are always visible on the profile header \u2014 not just badges elsewhere in the app, but the full expanded view here.",
       "files": [
         {
           "path": "components/ui/nyuchi-profile-block.tsx",
@@ -15100,7 +15080,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -15267,7 +15247,7 @@
     },
     {
       "dependencies": [],
-      "description": "Ticket registration panel — a labelled header, a selectable ticket-tier list, a clamped quantity stepper, and one saturated accent CTA. Tiers render as radios (role=radio / aria-checked) showing name + USD-formatted price (Free for 0) and disable with a Sold out label; the Minus/Plus stepper uses 48px pill targets and clamps to [min, max]. The accent CTA (pill, --brand-accent) shows the running total and a loading spinner. Harness-wired: tier and quantity changes are announced through the live region. Accent defaults to --brand-accent so each app swaps its own mineral.",
+      "description": "Ticket registration panel \u2014 a labelled header, a selectable ticket-tier list, a clamped quantity stepper, and one saturated accent CTA. Tiers render as radios (role=radio / aria-checked) showing name + USD-formatted price (Free for 0) and disable with a Sold out label; the Minus/Plus stepper uses 48px pill targets and clamps to [min, max]. The accent CTA (pill, --brand-accent) shows the running total and a loading spinner. Harness-wired: tier and quantity changes are announced through the live region. Accent defaults to --brand-accent so each app swaps its own mineral.",
       "files": [
         {
           "path": "components/ui/nyuchi-registration-card.tsx",
@@ -15310,10 +15290,6 @@
       "dependencies": [],
       "description": "Self-monitoring, self-healing resilience node that wires observability, circuit-breaker, bulkhead, rate-limiter, retry, timeout, fallback-chain, and chaos testing into a single composition for brand components. Implements all 7 Resilience4j patterns (Netflix Hystrix successor): CircuitBreaker, Retry, RateLimiter, Bulkhead, TimeLimiter, FallbackChain, and ChaosInjection. Exports NyuchiSection (wraps any UI section with error boundary + skeleton + observability + health tracking), useResilientFetch (data fetching with full resilience stack), NyuchiHealthMonitor (singleton aggregating health across all sections), NyuchiHealthPanel (admin health visualization), and the withResilience decorator that composes all patterns in the correct order. Every brand component renders inside a NyuchiSection so the infrastructure permanently monitors itself. Target: Rust compiled to WebAssembly. wasm-bindgen exposes the interface to SvelteKit. One Rust codebase compiles to both WASM (browser) and native binary (server).",
       "files": [
-        {
-          "path": "lib/resilience/health-monitor.ts",
-          "type": "registry:lib"
-        },
         {
           "path": "lib/resilience/index.tsx",
           "type": "registry:lib"
@@ -15359,7 +15335,7 @@
     },
     {
       "dependencies": [],
-      "description": "Universal branded review card with trust-verified reviewer badge, star rating, review text, and helpful vote. Used across all domains where user reviews exist: Places (business reviews), BushTrade (seller reviews), Novels (book reviews), Health (provider reviews), Nhimbe (event reviews). The reviewer verification tier is always visible — Ubuntu principle: trust is earned and displayed.",
+      "description": "Universal branded review card with trust-verified reviewer badge, star rating, review text, and helpful vote. Used across all domains where user reviews exist: Places (business reviews), BushTrade (seller reviews), Novels (book reviews), Health (provider reviews), Nhimbe (event reviews). The reviewer verification tier is always visible \u2014 Ubuntu principle: trust is earned and displayed.",
       "files": [
         {
           "path": "components/ui/nyuchi-review-card.tsx",
@@ -15456,7 +15432,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7→L8→L9)",
+          "Cross-layer wiring (L7\u2192L8\u2192L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -15609,7 +15585,7 @@
       "dependencies": [
         "next"
       ],
-      "description": "SEO metadata component for Next.js App Router. Generates head metadata, Open Graph tags, Twitter Cards, Schema.org JSON-LD structured data, and canonical URLs. Server component — runs at build/request time. Supports all Schema.org types used by the platform: JobPosting, VideoObject, MedicalWebPage, RentalCarReservation, Product, Event, Article, Recipe, etc.",
+      "description": "SEO metadata component for Next.js App Router. Generates head metadata, Open Graph tags, Twitter Cards, Schema.org JSON-LD structured data, and canonical URLs. Server component \u2014 runs at build/request time. Supports all Schema.org types used by the platform: JobPosting, VideoObject, MedicalWebPage, RentalCarReservation, Product, Event, Article, Recipe, etc.",
       "files": [
         {
           "path": "lib/nyuchi-seo.ts",
@@ -15626,7 +15602,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -15667,7 +15643,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -15696,7 +15672,7 @@
     },
     {
       "dependencies": [],
-      "description": "Universal branded share composition wrapping the share-dialog primitive. Shows a preview card of the shared content (title, image, source app), sharing options (copy link, share to Campfire, native share, social platforms), and a branded deep link. Every shareable piece of content across the ecosystem uses this pattern — listings, articles, profiles, places, events, videos, groups.",
+      "description": "Universal branded share composition wrapping the share-dialog primitive. Shows a preview card of the shared content (title, image, source app), sharing options (copy link, share to Campfire, native share, social platforms), and a branded deep link. Every shareable piece of content across the ecosystem uses this pattern \u2014 listings, articles, profiles, places, events, videos, groups.",
       "files": [
         {
           "path": "components/ui/nyuchi-share-card.tsx",
@@ -15758,7 +15734,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7→L8→L9)",
+          "Cross-layer wiring (L7\u2192L8\u2192L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -15885,7 +15861,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -15911,7 +15887,7 @@
       "dependencies": [
         "class-variance-authority"
       ],
-      "description": "Horizontal compact stats bar for dashboards, home screens, and admin views. Displays 2–4 metric blocks inline with icon, label, value, and optional trend indicator. Uses mineral-colored icon backgrounds. The brand-standard way to show key metrics at a glance across all Mukoko apps.",
+      "description": "Horizontal compact stats bar for dashboards, home screens, and admin views. Displays 2\u20134 metric blocks inline with icon, label, value, and optional trend indicator. Uses mineral-colored icon backgrounds. The brand-standard way to show key metrics at a glance across all Mukoko apps.",
       "files": [
         {
           "path": "components/ui/nyuchi-stats-row.tsx",
@@ -16051,7 +16027,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7→L8→L9)",
+          "Cross-layer wiring (L7\u2192L8\u2192L9)",
           "data-slot + data-portal DOM attributes"
         ],
         "hasDemo": true,
@@ -16119,7 +16095,7 @@
     },
     {
       "dependencies": [],
-      "description": "Universal date-railed discovery list — the 4.2.0 signature timeline. Groups items by day: each day is a left rail (weekday, big day numeral, month) beside a stack of tight horizontal rows. Each row reads time, title, host, location with an overlapping avatar stack and a right-edge thumbnail. Harness-wired for reduced-motion staggered entry and observability. Quiet rows, full 1px borders, 13px muted metadata — the 4.2.0 density. Used for event/agenda discovery across the ecosystem (nhimbe events, planner schedules, any date-anchored feed).",
+      "description": "Universal date-railed discovery list \u2014 the 4.2.0 signature timeline. Groups items by day: each day is a left rail (weekday, big day numeral, month) beside a stack of tight horizontal rows. Each row reads time, title, host, location with an overlapping avatar stack and a right-edge thumbnail. Harness-wired for reduced-motion staggered entry and observability. Quiet rows, full 1px borders, 13px muted metadata \u2014 the 4.2.0 density. Used for event/agenda discovery across the ecosystem (nhimbe events, planner schedules, any date-anchored feed).",
       "files": [
         {
           "path": "components/ui/nyuchi-timeline.tsx",
@@ -16137,7 +16113,7 @@
         "features": [
           "4.2.0 date-rail signature pattern",
           "Day-grouped with weekday/day/month rail",
-          "Harness integration — reduced-motion staggered entry + observability",
+          "Harness integration \u2014 reduced-motion staggered entry + observability",
           "Full 1px borders, 13px muted metadata, 16px title (4.2.0 density)",
           "Avatar stack + right thumbnail per row",
           "Mineral event dot per row"
@@ -16178,7 +16154,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7→L8→L9)",
+          "Cross-layer wiring (L7\u2192L8\u2192L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -16201,22 +16177,10 @@
     },
     {
       "dependencies": [],
-      "description": "W3C Design Tokens (2025.10) compliant token system for the entire Nyuchi ecosystem. Three-tier architecture: primitive tokens (Five African Minerals with light/dark pairs, container/onContainer colours, Five Heritage Colors, spacing, type scale, radii, shadows, motion, touch targets), semantic tokens (four-level AAA surface system), and component tokens. Brand overrides for all mini-apps. Multi-platform output: CSS (web), TypeScript (React/Svelte), Swift (iOS/macOS), Kotlin (Android/Compose), ArkTS (HarmonyOS), React Native (iOS+Android), Rust (services), Python (analytics/ML). The N1 vertical node — the only node allowed to define values. Every other node reads from here via var() or the relevant platform constant.",
+      "description": "W3C Design Tokens (2025.10) compliant token system for the entire Nyuchi ecosystem. Three-tier architecture: primitive tokens (Five African Minerals with light/dark pairs, container/onContainer colours, Five Heritage Colors, spacing, type scale, radii, shadows, motion, touch targets), semantic tokens (four-level AAA surface system), and component tokens. Brand overrides for all mini-apps. Multi-platform output: CSS (web), TypeScript (React/Svelte), Swift (iOS/macOS), Kotlin (Android/Compose), ArkTS (HarmonyOS), React Native (iOS+Android), Rust (services), Python (analytics/ML). The N1 vertical node \u2014 the only node allowed to define values. Every other node reads from here via var() or the relevant platform constant.",
       "files": [
         {
           "path": "lib/tokens/index.ts",
-          "type": "registry:lib"
-        },
-        {
-          "path": "lib/tokens/primitives.ts",
-          "type": "registry:lib"
-        },
-        {
-          "path": "lib/tokens/semantic.ts",
-          "type": "registry:lib"
-        },
-        {
-          "path": "lib/tokens/components.ts",
           "type": "registry:lib"
         }
       ],
@@ -16254,7 +16218,7 @@
     },
     {
       "dependencies": [],
-      "description": "Mzizi design tokens for ArkTS / HarmonyOS. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties — seven African Minerals + seven Heritage tones, both themes. Colour constants, spacing, radius and typography for HarmonyOS. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md §8.4.1).",
+      "description": "Mzizi design tokens for ArkTS / HarmonyOS. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties \u2014 seven African Minerals + seven Heritage tones, both themes. Colour constants, spacing, radius and typography for HarmonyOS. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md \u00a78.4.1).",
       "files": [
         {
           "path": "lib/tokens/nyuchi-tokens-arkts.ets",
@@ -16271,7 +16235,7 @@
     },
     {
       "dependencies": [],
-      "description": "Mzizi design tokens for Kotlin / Jetpack Compose. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties — seven African Minerals + seven Heritage tones, both themes. Color objects, spacing Dp values, radius and typography constants for Android. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md §8.4.1).",
+      "description": "Mzizi design tokens for Kotlin / Jetpack Compose. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties \u2014 seven African Minerals + seven Heritage tones, both themes. Color objects, spacing Dp values, radius and typography constants for Android. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md \u00a78.4.1).",
       "files": [
         {
           "path": "lib/tokens/nyuchi-tokens-kotlin.kt",
@@ -16288,7 +16252,7 @@
     },
     {
       "dependencies": [],
-      "description": "Mzizi design tokens for Python. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties — seven African Minerals + seven Heritage tones, both themes. Frozen dataclasses of colour values for analytics pipelines, data visualisation (matplotlib, plotly, altair), report generation and ML tooling. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md §8.4.1).",
+      "description": "Mzizi design tokens for Python. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties \u2014 seven African Minerals + seven Heritage tones, both themes. Frozen dataclasses of colour values for analytics pipelines, data visualisation (matplotlib, plotly, altair), report generation and ML tooling. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md \u00a78.4.1).",
       "files": [
         {
           "path": "lib/tokens/nyuchi-tokens-python.py",
@@ -16305,7 +16269,7 @@
     },
     {
       "dependencies": [],
-      "description": "Mzizi design tokens for React Native. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties — seven African Minerals + seven Heritage tones, both themes. A StyleSheet-ready token object for React Native. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md §8.4.1).",
+      "description": "Mzizi design tokens for React Native. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties \u2014 seven African Minerals + seven Heritage tones, both themes. A StyleSheet-ready token object for React Native. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md \u00a78.4.1).",
       "files": [
         {
           "path": "lib/tokens/nyuchi-tokens-react-native.ts",
@@ -16322,7 +16286,7 @@
     },
     {
       "dependencies": [],
-      "description": "Mzizi design tokens for Rust. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties — seven African Minerals + seven Heritage tones, both themes, as `const` values plus `Palette`, `Spacing`, `Radius` and `Fonts`. This is what the Dioxus half of the registry consumes, via the `mzizi-tokens` crate. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md §8.4.1).",
+      "description": "Mzizi design tokens for Rust. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties \u2014 seven African Minerals + seven Heritage tones, both themes, as `const` values plus `Palette`, `Spacing`, `Radius` and `Fonts`. This is what the Dioxus half of the registry consumes, via the `mzizi-tokens` crate. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md \u00a78.4.1).",
       "files": [
         {
           "path": "src/tokens/nyuchi_tokens.rs",
@@ -16339,7 +16303,7 @@
     },
     {
       "dependencies": [],
-      "description": "Mzizi design tokens for Swift / SwiftUI. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties — seven African Minerals + seven Heritage tones, both themes. Color extensions, spacing, radius and typography constants for iOS, macOS, watchOS and tvOS. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md §8.4.1).",
+      "description": "Mzizi design tokens for Swift / SwiftUI. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties \u2014 seven African Minerals + seven Heritage tones, both themes. Color extensions, spacing, radius and typography constants for iOS, macOS, watchOS and tvOS. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md \u00a78.4.1).",
       "files": [
         {
           "path": "lib/tokens/nyuchi-tokens-swift.swift",
@@ -16396,7 +16360,7 @@
     },
     {
       "dependencies": [],
-      "description": "Full trust score visualization showing the three-signal breakdown: Verification Tier (are you real?), Platform Status (are you active?), and Ubuntu Contribution (are you helpful?). Displays the composite score as a meter bar with individual signal breakdowns. Used on profile detail pages, admin views, and trust audit screens. This is the expanded view of trust — the verified badge is the compact view.",
+      "description": "Full trust score visualization showing the three-signal breakdown: Verification Tier (are you real?), Platform Status (are you active?), and Ubuntu Contribution (are you helpful?). Displays the composite score as a meter bar with individual signal breakdowns. Used on profile detail pages, admin views, and trust audit screens. This is the expanded view of trust \u2014 the verified badge is the compact view.",
       "files": [
         {
           "path": "components/ui/nyuchi-trust-meter.tsx",
@@ -16458,7 +16422,7 @@
         "collection": "shell",
         "features": [
           "App shell infrastructure",
-          "Cross-layer wiring (L7→L8→L9)",
+          "Cross-layer wiring (L7\u2192L8\u2192L9)",
           "data-slot + data-portal DOM attributes",
           "Harness integration"
         ],
@@ -16568,7 +16532,7 @@
       "dependencies": [
         "class-variance-authority"
       ],
-      "description": "Verification badge tied to the three-axis Mukoko trust model: Status (platform lifecycle) × Verification Tier (identity ladder) → Trust Score. Renders the appropriate mineral-colored badge for each tier — Terracotta (Community 0.10), Cobalt (OTP 0.20), Gold (Government 0.30), Tanzanite (Licensed 0.50). Suspended/ancestral accounts show a dimmed or memorial variant. Used inline next to names, on profile headers, listing cards, and anywhere trust needs to be communicated.",
+      "description": "Verification badge tied to the three-axis Mukoko trust model: Status (platform lifecycle) \u00d7 Verification Tier (identity ladder) \u2192 Trust Score. Renders the appropriate mineral-colored badge for each tier \u2014 Terracotta (Community 0.10), Cobalt (OTP 0.20), Gold (Government 0.30), Tanzanite (Licensed 0.50). Suspended/ancestral accounts show a dimmed or memorial variant. Used inline next to names, on profile headers, listing cards, and anywhere trust needs to be communicated.",
       "files": [
         {
           "path": "components/ui/nyuchi-verified-badge.tsx",
@@ -16583,7 +16547,7 @@
         ],
         "collection": "brand",
         "features": [
-          "Three-axis trust model: Status × Tier → Score",
+          "Three-axis trust model: Status \u00d7 Tier \u2192 Score",
           "Mineral-colored per tier",
           "Tooltip with tier explanation",
           "Maps to system.verification_tier"
@@ -16710,7 +16674,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -16759,7 +16723,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -16838,7 +16802,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -17034,7 +16998,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -17401,7 +17365,7 @@
     },
     {
       "dependencies": [],
-      "description": "Task/item priority picker with visual indicators — none, low, medium, high, urgent. Mineral-colored dots: grey=none, cobalt=low, gold=medium, terracotta=high, destructive=urgent. Compact inline selector for use in task forms, issue trackers, and ticket systems.",
+      "description": "Task/item priority picker with visual indicators \u2014 none, low, medium, high, urgent. Mineral-colored dots: grey=none, cobalt=low, gold=medium, terracotta=high, destructive=urgent. Compact inline selector for use in task forms, issue trackers, and ticket systems.",
       "files": [
         {
           "path": "components/ui/priority-selector.tsx",
@@ -17894,7 +17858,7 @@
     },
     {
       "dependencies": [],
-      "description": "Recurrence pattern selector for scheduling — daily, weekly, monthly, yearly with day-of-week/month selectors and end-date or occurrence-count options. Used for recurring tasks, events, medication schedules, and any repeating item across the platform.",
+      "description": "Recurrence pattern selector for scheduling \u2014 daily, weekly, monthly, yearly with day-of-week/month selectors and end-date or occurrence-count options. Used for recurring tasks, events, medication schedules, and any repeating item across the platform.",
       "files": [
         {
           "path": "components/ui/recurrence-picker.tsx",
@@ -17989,7 +17953,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -18281,7 +18245,7 @@
     },
     {
       "dependencies": [],
-      "description": "N8 assurance probe that validates RTL (right-to-left) layout correctness across deployed components. Checks: logical properties (start/end vs left/right), bidi text rendering, icon mirroring rules, text alignment consistency. Audit flagged as missing accessibility infrastructure. ALPHA — awaiting edge function implementation.",
+      "description": "N8 assurance probe that validates RTL (right-to-left) layout correctness across deployed components. Checks: logical properties (start/end vs left/right), bidi text rendering, icon mirroring rules, text alignment consistency. Audit flagged as missing accessibility infrastructure. ALPHA \u2014 awaiting edge function implementation.",
       "files": [
         {
           "path": "components/ui/rtl-conformity-check.tsx",
@@ -18568,7 +18532,7 @@
       "dependencies": [
         "class-variance-authority"
       ],
-      "description": "Connected multi-option selector as a single pill-shaped control. Inline alternative to radio-group for 2-4 mutually exclusive options like view mode switchers, time range selectors, or binary choices. Audit flagged as missing primitive. ALPHA — awaiting frontend implementation.",
+      "description": "Connected multi-option selector as a single pill-shaped control. Inline alternative to radio-group for 2-4 mutually exclusive options like view mode switchers, time range selectors, or binary choices. Audit flagged as missing primitive. ALPHA \u2014 awaiting frontend implementation.",
       "files": [
         {
           "path": "components/ui/segmented-control.tsx",
@@ -18655,7 +18619,7 @@
     },
     {
       "dependencies": [],
-      "description": "Multi-step money transfer flow: recipient selection → amount entry → confirmation → receipt. Supports QR scan, contact picker, and recent recipients. The standard peer-to-peer transfer pattern for Wallet and Campfire bill splitting.",
+      "description": "Multi-step money transfer flow: recipient selection \u2192 amount entry \u2192 confirmation \u2192 receipt. Supports QR scan, contact picker, and recent recipients. The standard peer-to-peer transfer pattern for Wallet and Campfire bill splitting.",
       "files": [
         {
           "path": "components/ui/send-money-flow.tsx",
@@ -20000,7 +19964,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -20701,7 +20665,7 @@
     },
     {
       "dependencies": [],
-      "description": "Guided symptom input with body region selector, severity scale, and duration fields. Not a diagnostic tool — produces a structured symptom summary for telemedicine consultations. Used in Health mini-app pre-appointment flow.",
+      "description": "Guided symptom input with body region selector, severity scale, and duration fields. Not a diagnostic tool \u2014 produces a structured symptom summary for telemedicine consultations. Used in Health mini-app pre-appointment flow.",
       "files": [
         {
           "path": "components/ui/symptom-checker.tsx",
@@ -20912,7 +20876,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -21553,7 +21517,7 @@
       "dependencies": [
         "radix-ui"
       ],
-      "description": "Horizontal container for grouped tool actions. Persistent action bar pattern for editors, content creation, and admin surfaces. Supports segmented groups, overflow menu, and responsive collapse. Audit flagged as missing UX pattern. ALPHA — awaiting frontend implementation.",
+      "description": "Horizontal container for grouped tool actions. Persistent action bar pattern for editors, content creation, and admin surfaces. Supports segmented groups, overflow menu, and responsive collapse. Audit flagged as missing UX pattern. ALPHA \u2014 awaiting frontend implementation.",
       "files": [
         {
           "path": "components/ui/toolbar.tsx",
@@ -21655,7 +21619,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -22146,7 +22110,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],
@@ -22519,7 +22483,7 @@
         "collection": "pages",
         "features": [
           "X-axis page composition",
-          "Pure composition — no inline UI",
+          "Pure composition \u2014 no inline UI",
           "Semantic CSS vars only",
           "Children/slots for content"
         ],

--- a/scripts/validate-registry.mjs
+++ b/scripts/validate-registry.mjs
@@ -35,6 +35,8 @@
 
 import { readFileSync, existsSync, readdirSync } from "node:fs"
 import { basename, extname, join } from "node:path"
+// TypeScript's own parser, so the JSX check below is exact rather than a regex guess.
+import ts from "typescript"
 
 const ROOT = process.cwd()
 const REGISTRY_JSON = join(ROOT, "registry.json")
@@ -257,6 +259,65 @@ function main() {
     if (!item.name) err("(item)", "has no name")
     if (!item.type) err(n, "has no type (registry:ui | registry:lib | …)")
     if (!Array.isArray(item.files) || item.files.length === 0) err(n, "has no files[]")
+
+    // — a component is ONE source file, so it may declare exactly one —
+    //
+    // `readComponentSource(name)` resolves a component by NAME, not by install path, so
+    // there has only ever been one file's worth of content to serve. Five items declared
+    // more (nyuchi-tokens declared four), and `/api/v1/ui/{name}` filled the extras with
+    // an empty string: `npx shadcn add nyuchi-tokens` wrote three EMPTY files over the
+    // consumer's own. Nothing caught it, because every item resolved on disk — the check
+    // above passes on the component, and the defect was in the file list beside it.
+    if (Array.isArray(item.files) && item.files.length > 1) {
+      err(
+        n,
+        `declares ${item.files.length} files (${item.files.map((f) => f.path).join(", ")}) but a ` +
+          "component has exactly one source. The extra paths have no content and install as " +
+          "empty files — declare only the file that exists."
+      )
+    }
+
+    // — a source containing JSX must install to a .tsx path —
+    //
+    // `nyuchi-resilience` shipped 18 KB of JSX into `lib/resilience/health-monitor.ts`;
+    // `nyuchi-data`, `nyuchi-platform`, `nyuchi-layout` and `nyuchi-locale` each declared a
+    // JSX source as `index.ts`. TypeScript reads `<Foo>` in a .ts file as a type assertion,
+    // so these fail with a wall of syntax errors in the CONSUMER's build, with nothing
+    // pointing back here.
+    //
+    // The rule is about JSX, NOT about extensions matching. A first cut compared source and
+    // install extensions and flagged `ai-safety` — a .tsx file that contains no JSX and
+    // compiles fine as .ts. Renaming it would have been churn dressed as a fix, and worse,
+    // would have left anyone who already installed `lib/ai-safety.ts` with a second copy.
+    //
+    // TypeScript's own parser decides, because no regex can: `<T>`, `React.useState<X>` and
+    // `<b>bold</b>` inside a doc comment all look like JSX to a pattern and are not.
+    {
+      const src = disk.get(n)
+      const declaredPath = item.files?.[0]?.path
+      // `rel` is relative to components/registry (e.g. `n1-tokens/nyuchi-tokens.ts`), and a
+      // component's primary source is not always TypeScript — some are .md or .rs.
+      const isTs = src && /\.tsx?$/.test(src.rel ?? "")
+      if (src && isTs && declaredPath && !declaredPath.endsWith(".tsx")) {
+        const abs = join(ROOT, "components", "registry", src.rel)
+        const text = readFileSync(abs, "utf8")
+        const parsed = ts.createSourceFile(
+          abs,
+          text,
+          ts.ScriptTarget.Latest,
+          true,
+          ts.ScriptKind.TS
+        )
+        const syntaxErrors = parsed.parseDiagnostics?.length ?? 0
+        if (syntaxErrors > 0) {
+          err(
+            n,
+            `source contains JSX but installs to ${declaredPath}. Parsed as TypeScript it ` +
+              `produces ${syntaxErrors} syntax error(s) — it must install to a .tsx path.`
+          )
+        }
+      }
+    }
 
     // — every advertised component must exist on disk (bug 2 and 3) —
     const onDisk = disk.get(n)


### PR DESCRIPTION
**The registry has been handing consumers empty files.** `npx shadcn add nyuchi-tokens` wrote `lib/tokens/primitives.ts`, `semantic.ts` and `components.ts` as **zero-byte files** over whatever was already there. Nine empty files across five components.

## Root cause — one line

`app/api/v1/ui/[name]/route.ts`:

```ts
content: i === 0 ? source : ""
```

Only the first declared file ever got content; every other was hardcoded to an empty string. The doc comment **directly above it** promised the opposite, in these words:

> a component whose file is missing is a 404 and never a 200 with an empty body

`readComponentSource(name)` resolves a component by **name** (`components/registry/n<N>-<label>/<name>.<ext>`), not by install path — so there has only ever been one file's worth of content. Five items in `registry.json` declared more (`nyuchi-tokens` declared four), and those extra paths have **no source anywhere in the repo**. They were never written; they were invented in the manifest.

## A second, independent breakage found while fixing the first

Five components installed JSX into a `.ts` path, which TypeScript reads as a type assertion:

| Component | Installed to | Syntax errors as `.ts` |
| --- | --- | --- |
| `nyuchi-resilience` | `lib/resilience/health-monitor.ts` | **131** |
| `nyuchi-data` | `lib/data/index.ts` | 74 |
| `nyuchi-platform` | `lib/platform/index.ts` | 55 |
| `nyuchi-layout` | `lib/layout/index.ts` | 17 |
| `nyuchi-locale` | `lib/locale/index.ts` | 4 |

`nyuchi-resilience` was the worst of both: its real 18 KB source went to a path that **doesn't exist** (`health-monitor.ts`) while the path that does (`index.tsx`) got the empty string.

Every one of these fails in the **consumer's** build, with nothing pointing back here.

## The fix

- **`registry.json`** — each of the 5 declares only the file that exists, at the extension its source needs.
- **The route** — refuses with a 500 naming the manifest bug instead of padding with `""`. An empty file is indistinguishable from a deliberately empty module, so it fails at the consumer rather than here.
- **`scripts/validate-registry.mjs`** — two new gates so this cannot ship again.

### The gate uses TypeScript's own parser, and that matters

My first cut compared source and install extensions, and flagged **`ai-safety`** — a `.tsx` file containing no JSX that compiles fine as `.ts`. I had already renamed it on that false positive. Renaming it would have been churn dressed as a fix, and would have left anyone who already installed `lib/ai-safety.ts` holding a second copy.

No regex can tell `<T>`, `React.useState<X>` and `<b>bold</b>` in a doc comment apart from real JSX. The check now parses each source with `ScriptKind.TS` and errors only on genuine syntax failures. **`ai-safety` is reverted to `.ts`.**

## Verification

Swept **all 573 components** against a running server:

| | Before | After |
| --- | --- | --- |
| Empty files served | **9** | **0** |
| Components with no files | 0 | 0 |
| Non-200 | 0 | 0 |

Installed the previously-broken components exactly as shadcn does — real content, right path, every time:

```
ok  50219B  nyuchi-tokens     -> lib/tokens/index.ts
ok  18783B  nyuchi-resilience -> lib/resilience/index.tsx
ok  10243B  nyuchi-locale     -> lib/locale/index.tsx
ok  29343B  ai-safety         -> lib/ai-safety.ts
```

**Both gates proven to bite** — reinstating each original defect fails the validator:

```
nyuchi-tokens: declares 2 files … but a component has exactly one source.
               The extra paths have no content and install as empty files.
nyuchi-resilience: source contains JSX but installs to lib/resilience/health-monitor.ts.
                   Parsed as TypeScript it produces 131 syntax error(s).
```

`typecheck` 0 · `eslint` clean · **200 tests passing** · `registry:validate` green.

## Why the existing gates all stayed green

Every check passed because each asked a question this defect sat beside: the validator confirmed every *component* resolves on disk — true — while the defect was in the *file list* next to it. The API returned 200. The payload was well-formed. Only opening the installed file shows the problem.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_