### PR TITLE
fix(registry): give the theme item a node so N1 lists the tokens

### DIFF
--- a/__tests__/lib/registry-data-items.test.ts
+++ b/__tests__/lib/registry-data-items.test.ts
@@ -1,0 +1,53 @@
+/**
+ * A DATA item's node, read against the real `registry.json` and the real files on disk.
+ *
+ * This is deliberately an integration test rather than a fixture test. The defect it pins
+ * could not be reproduced with a fixture, because the fixture would have to invent the one
+ * thing that was missing: `readComponents()` derives a component's node from the directory
+ * its file lives in, and a data item — `cssVars`/`css`, no file — has no directory. Its node
+ * was therefore `undefined`, and `undefined` is not neutral. It dropped `nyuchi-tokens` out
+ * of `/api/v1/ui?node=1` and out of `mzizi_list_components({ node: 1 })`, so an agent asking
+ * the registry for node 1 got the 17 N1 libraries and not the tokens those libraries and 431
+ * components are built on — the one item every consumer is told to install first.
+ *
+ * Reading the real manifest is the point: the manifest is now the ONLY source for a data
+ * item's node, so a test that mocks it away tests nothing.
+ */
+import { describe, it, expect } from "vitest"
+import { readComponents, readNodeCounts } from "@/lib/registry"
+
+const items = readComponents()
+const dataItems = items.filter((i) => !i.files?.length && (i.cssVars || i.css))
+
+describe("data items in the registry", () => {
+  it("has at least one, or the rest of this file is vacuous", () => {
+    expect(dataItems.length).toBeGreaterThan(0)
+  })
+
+  it("gives every data item a node and a label", () => {
+    for (const i of dataItems) {
+      expect(typeof i.node, `${i.name} has no node`).toBe("number")
+      expect(i.node, `${i.name} has a node below 1`).toBeGreaterThanOrEqual(1)
+      expect(i.nodeLabel, `${i.name} has no nodeLabel`).toBeTruthy()
+    }
+  })
+
+  it("places nyuchi-tokens in N1 as a theme", () => {
+    const tokens = items.find((i) => i.name === "nyuchi-tokens")
+    expect(tokens).toBeDefined()
+    expect(tokens?.type).toBe("registry:theme")
+    expect(tokens?.node).toBe(1)
+    expect(tokens?.nodeLabel).toBe("tokens")
+    // The payload is the tokens themselves; a file here would mean the tokens went back to
+    // being React-only, which is the whole thing the theme item exists to undo.
+    expect(tokens?.files ?? []).toHaveLength(0)
+    expect(Object.keys(tokens?.cssVars ?? {}).sort()).toEqual(["dark", "light", "theme"])
+  })
+
+  it("counts data items in their node, since they are components of it", () => {
+    const counts = readNodeCounts()
+    const n1 = items.filter((i) => i.node === 1)
+    expect(counts[1]).toBe(n1.length)
+    expect(n1.map((i) => i.name)).toContain("nyuchi-tokens")
+  })
+})

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -64,6 +64,21 @@ export type RegistryMeta = {
   /** The authored collection, e.g. `primitives`, `brand`, `pages`. */
   collection?: string
   hasDemo?: boolean
+  /**
+   * The node, for a DATA item only — one with `cssVars`/`css` and no file.
+   *
+   * Every other item derives its node from the directory the file lives in, which is what
+   * stops the node disagreeing with where the code actually is. A data item has no
+   * directory, so there is nothing to derive from and the manifest is the only source.
+   *
+   * Declaring it is not cosmetic. Without it `nyuchi-tokens` carried no `node`, so
+   * `/api/v1/ui?node=1` — and `mzizi_list_components({ node: 1 })` on top of it — returned
+   * the 17 N1 libraries and silently omitted the tokens themselves: the one item that IS
+   * N1, and the one every consumer is told to install first.
+   */
+  node?: number
+  /** The node's label, for a DATA item only. See `node` above. */
+  nodeLabel?: string
 }
 
 export type RegistryItem = {
@@ -229,7 +244,15 @@ export function readComponents(): RegistryItem[] {
     // Without this branch the item is dropped here and `/api/v1/ui/nyuchi-tokens` answers
     // 404 — the tokens would be correct in the manifest and invisible to every consumer.
     if (!item.files?.length && (item.cssVars || item.css)) {
-      out.push({ ...item })
+      // The node comes from the manifest here and ONLY here, because there is no directory
+      // to read it from. Every filed component still derives it from disk below, so the
+      // invariant that matters — a component's node cannot disagree with where its code is
+      // — is untouched: an item with no code has no place to disagree with.
+      out.push({
+        ...item,
+        ...(typeof item.meta?.node === "number" ? { node: item.meta.node } : {}),
+        ...(item.meta?.nodeLabel ? { nodeLabel: item.meta.nodeLabel } : {}),
+      })
       continue
     }
 

--- a/registry.json
+++ b/registry.json
@@ -19112,6 +19112,8 @@
           "Multi-platform generators"
         ],
         "hasDemo": true,
+        "node": 1,
+        "nodeLabel": "tokens",
         "owner": "bundu",
         "useCases": [
           "Design token provider for all Nyuchi apps",

--- a/scripts/validate-registry.mjs
+++ b/scripts/validate-registry.mjs
@@ -276,6 +276,26 @@ function main() {
     const hasFiles = Array.isArray(item.files) && item.files.length > 0
 
     if (!hasFiles && !isDataItem) err(n, "has no files[] and no cssVars/css — it installs nothing")
+
+    // — a data item must declare its node, because nothing else can —
+    //
+    // Every filed component gets its node from the directory it lives in. A data item has no
+    // directory, so an undeclared node is simply absent, and absent is not neutral: it drops
+    // the item out of `/api/v1/ui?node=N` and out of `mzizi_list_components({ node: N })`.
+    // That is exactly what happened — listing N1 returned the 17 libraries and omitted
+    // `nyuchi-tokens`, the item those libraries and 431 components depend on.
+    if (isDataItem && !hasFiles) {
+      if (typeof item.meta?.node !== "number" || item.meta.node < 1) {
+        err(
+          n,
+          "is a data item with no file, so its node cannot be derived from a directory — " +
+            "declare `meta.node` (a positive integer) or it vanishes from every node-filtered list."
+        )
+      }
+      if (typeof item.meta?.nodeLabel !== "string" || !item.meta.nodeLabel) {
+        err(n, "is a data item with no file — declare `meta.nodeLabel` alongside `meta.node`.")
+      }
+    }
     if (isDataItem && hasFiles) {
       err(
         n,


### PR DESCRIPTION
## Summary

Found while verifying #246 against the live MCP: `mzizi_list_components({ node: 1 })` returns
the 17 N1 libraries and **omits `nyuchi-tokens`** — the item those libraries and 431
components are built on, and the one every consumer is told to install first.
`/api/v1/ui?node=1` has the same hole, because the MCP tool reads that route.

**Why it was missing.** `readComponents()` derives a component's node from the directory its
file lives in — that is what stops the node disagreeing with where the code actually is. A
data item (`cssVars`/`css`, no file) has no directory, so its node came out `undefined`. That
is not neutral: the filter compares `c.node !== node`, so an item with no node matches *no*
node at all. The tokens dropped out of every node-filtered list the moment they stopped being
a `.ts` file — a regression introduced by #246 and not caught there, because I checked that
the theme item served and not that it was still discoverable.

## Changes

- For a file-less data item, **and only for one**, the node comes from the manifest:
  `meta.node` / `meta.nodeLabel`, declared on `nyuchi-tokens` as `1` / `"tokens"`. The 573
  filed components still derive theirs from disk, so the invariant that matters is untouched —
  an item with no code has no place on disk to disagree with.
- `readNodeCounts()` now counts it, which is correct: it is a component of N1 (17 → 18).
- A **validator gate**: a file-less data item without `meta.node` and `meta.nodeLabel` is an
  error. The next theme item cannot lose its node silently the way this one did.
- An **integration test** against the real `registry.json`. A fixture cannot reproduce this —
  the fixture would have to invent the very field whose absence is the bug. Reverted against
  the fix, three of its four specs fail (verified).

## Type

- [x] Bug fix

## Pre-commit Gate

- [x] `pnpm lint` — zero warnings
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm test` — 204 tests pass (4 new)
- [x] `pnpm audit` — no known vulnerabilities

## Quality Checklist

- [x] New tests added for new functionality, and confirmed to fail without the fix
- [x] No hardcoded colors
- [x] Brand wordmarks lowercase

## Registry / Design System

- [x] `registry.json` updated and `pnpm registry:normalize` run
- [x] `registry:verify` + `registry:validate` green (574 items)
- [x] `tokens:registry:check` green — `{"dark":110,"light":111,"theme":103}`
- [x] `registry:metadata:check` green — 574 items
- [ ] MCP tool verified against production — pending this deploy, per deploy → test → merge

## Verified on production before this fix

The #246 deploy is live and healthy — this PR is the one gap it left:

- 574-item index, all fields projected; 573 components serving real source, **0 empty files**
- `nyuchi-tokens` serves `registry:theme` with 324 cssVars; a real `npx shadcn add` writes
  387 custom properties into the consumer's stylesheet
- all ten MCP tools respond; `mzizi_get_component('nyuchi-tokens')` returns the full theme

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_