### PR TITLE
fix(registry): path is the source, target is the destination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,14 @@ jobs:
       - name: Verify registry item metadata is current
         run: pnpm registry:metadata:check
 
+      # `files[].path` must be where the file IS in this repo and `files[].target` where it
+      # GOES in the consumer's. They were merged into one field for the registry's whole
+      # life — the install destination sat in `path` — which our own API hid, because it
+      # resolves sources by component name and never reads `path`. `shadcn registry
+      # validate nyuchi/mzizi` did not hide it: 574 of 574 items failed.
+      - name: Verify registry source paths and install targets
+        run: pnpm registry:paths:check
+
       # The extracted prop map is what lets a preview resolve sample data for a component
       # (§8.10). If it goes stale the previews silently degrade to empty — nothing errors,
       # they just stop showing anything, which is the failure mode this whole session has

--- a/app/api/v1/ui/[name]/route.ts
+++ b/app/api/v1/ui/[name]/route.ts
@@ -145,9 +145,16 @@ export async function GET(_request: Request, { params }: { params: Promise<{ nam
       )
     }
 
+    // `target` is the install destination and MUST be projected. shadcn defines `path` as
+    // the file's SOURCE location in the registry repo — here, `components/registry/n<N>-…` —
+    // and `target` as where it lands in the consumer's project. Dropping `target` would send
+    // the CLI back to deriving a destination from `type` plus the basename of `path`, which
+    // for `button` means `components/ui/button.tsx` (right, by luck) and for
+    // `accessibility-audit` means a `.md` file landing in `components/ui/` (wrong).
     const files = declared.map((file) => ({
       path: file.path,
       type: file.type,
+      ...(file.target ? { target: file.target } : {}),
       content: source,
     }))
 

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -43,7 +43,18 @@ function safeSourcePath(...segments: string[]): string | null {
   return candidate
 }
 
-export type RegistryFile = { path: string; type?: string }
+/**
+ * A file on a registry item, in shadcn's terms (registry-item.json):
+ *
+ *   path    where the file IS — its source location in this repository
+ *   target  where the file GOES — the destination in the consumer's project
+ *
+ * They were conflated: `path` held the destination and `target` was absent, so
+ * `shadcn registry validate` failed on every item and `npx shadcn add nyuchi/mzizi/button`
+ * — the GitHub-registry route, which reads files straight out of the repo at `path` — could
+ * not resolve a single file.
+ */
+export type RegistryFile = { path: string; type?: string; target?: string }
 
 /**
  * The authored `meta` block from `registry.json` — a component's documented contract.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "registry:metadata": "node scripts/generate-item-metadata.mjs",
     "registry:metadata:check": "node scripts/generate-item-metadata.mjs --check",
     "registry:normalize": "tsx scripts/normalize-registry.ts",
+    "registry:paths": "node scripts/generate-file-paths.mjs",
+    "registry:paths:check": "node scripts/generate-file-paths.mjs --check",
     "registry:validate": "node scripts/validate-registry.mjs",
     "registry:verify": "tsx scripts/normalize-registry.ts --check",
     "samples:push": "tsx scripts/push-samples.ts",

--- a/registry.json
+++ b/registry.json
@@ -14,7 +14,7 @@
       "docs": "Use it for: Daily WCAG and color-blindness validation across every semantic-color pair, Continuous regression detection — any token change that breaks a11y is caught within 24h, Pre-launch accessibility gate — ensures palette is colorblind-safe before each release, Fundi-integrated healing loop — new failures create GitHub issues automatically, On-demand validation — call run_accessibility_audit() in migrations or CI.\nVariants: scheduled-daily, on-demand, ci-gate.\nIncludes: Machado/Oliveira/Fernandes (2009) linear-RGB simulation matrices, Covers protanopia, deuteranopia, tritanopia, and achromatopsia, WCAG 2.1 contrast ratio computation per simulated pair, Configurable contrast floor (default 3.0 for WCAG AA large text), audit_exempt flag skips decorative pairs per WCAG 1.4.11 exemption, Regression detection — files Fundi issues only for NEW failures, not existing ones, Severity assignment — high for foreground/error/success pairs, medium for others, Scheduled via pg_cron (daily 02:00 UTC), SQL-only implementation — no edge function required.\nAccessibility: Output structured as fundi_issues row plus brand_accessibility_checks flag updates, Findings include pair_name, theme_mode, fg/bg hex, contrast ratio, simulated safety flags, Machine-readable via get_accessibility_summary() for dashboard consumption, Remediation guidance: pair with icon/label, or adjust hex to exceed floor, Results exposed through fundi_issues table and the Fundi healing loop.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/accessibility-audit",
       "files": [
         {
-          "path": "docs/accessibility-audit-pipeline.md",
+          "path": "components/registry/n8-assurance/accessibility-audit.md",
           "target": "docs/accessibility-audit-pipeline.md",
           "type": "registry:file"
         }
@@ -72,7 +72,8 @@
       "docs": "Use it for: FAQ sections with expandable questions, Product detail expandable specifications, Settings pages with collapsible sections, Documentation with expandable subsections, Multi-section forms with progressive disclosure.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/accordion",
       "files": [
         {
-          "path": "components/ui/accordion.tsx",
+          "path": "components/registry/n2-primitives/accordion.tsx",
+          "target": "components/ui/accordion.tsx",
           "type": "registry:ui"
         }
       ],
@@ -117,7 +118,8 @@
       "docs": "Use it for: User profile activity timeline, Project activity feed in dashboards, Admin audit timeline, Version history and changelog display, Team collaboration activity in workspace apps.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/activity-feed",
       "files": [
         {
-          "path": "components/ui/activity-feed.tsx",
+          "path": "components/registry/n2-primitives/activity-feed.tsx",
+          "target": "components/ui/activity-feed.tsx",
           "type": "registry:ui"
         }
       ],
@@ -160,7 +162,8 @@
       "docs": "Use it for: Checkout shipping address collection, User profile address fields, Business location registration, Event venue address input, Delivery address selection in BushTrade.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/address-input",
       "files": [
         {
-          "path": "components/ui/address-input.tsx",
+          "path": "components/registry/n2-primitives/address-input.tsx",
+          "target": "components/ui/address-input.tsx",
           "type": "registry:ui"
         }
       ],
@@ -204,7 +207,8 @@
       "docs": "Use it for: nhimbe, console, bushtrade.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/admin-page",
       "files": [
         {
-          "path": "components/ui/admin-page.tsx",
+          "path": "components/registry/n6-pages/admin-page.tsx",
+          "target": "components/ui/admin-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -249,7 +253,8 @@
       "docs": "Use it for: Calendar agenda views grouped by date, Event schedule listings, Booking timeline displays, Personal task view by due date, Appointment summary pages.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/agenda-view",
       "files": [
         {
-          "path": "components/ui/agenda-view.tsx",
+          "path": "components/registry/n2-primitives/agenda-view.tsx",
+          "target": "components/ui/agenda-view.tsx",
           "type": "registry:ui"
         }
       ],
@@ -292,7 +297,8 @@
       "docs": "Use it for: Conversational AI interfaces in Claude-style tools, Customer support chatbots with history, AI-assisted content creation flows, Developer tools with code-generating copilots, Mukoko-embedded AI features with African language support.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/ai-chat",
       "files": [
         {
-          "path": "components/ui/ai-chat.tsx",
+          "path": "components/registry/n2-primitives/ai-chat.tsx",
+          "target": "components/ui/ai-chat.tsx",
           "type": "registry:ui"
         }
       ],
@@ -336,7 +342,8 @@
       "docs": "Use it for: Quality rating on AI-generated responses, Collecting user feedback on AI accuracy, A/B testing different LLM outputs, Moderation signals for content review, Improving prompt engineering through feedback loops.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/ai-feedback",
       "files": [
         {
-          "path": "components/ui/ai-feedback.tsx",
+          "path": "components/registry/n2-primitives/ai-feedback.tsx",
+          "target": "components/ui/ai-feedback.tsx",
           "type": "registry:ui"
         }
       ],
@@ -380,7 +387,8 @@
       "docs": "Use it for: Structured AI output with action buttons (copy, share, regenerate), AI summaries with citation links, Research assistant responses with expandable sections, Code generation results with language-specific syntax, Translation results with confidence scoring.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/ai-response-card",
       "files": [
         {
-          "path": "components/ui/ai-response-card.tsx",
+          "path": "components/registry/n2-primitives/ai-response-card.tsx",
+          "target": "components/ui/ai-response-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -423,7 +431,8 @@
       "docs": "Use it for: Access control, Security gate, Verification check.\nVariants: allowed, blocked, loading.\nIncludes: Y-axis safety spine, Renders children when check passes, Branded explanation when blocked, Web3 integration.\nAccessibility: Screen reader announces gate state, Focus management on state change.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/ai-safety",
       "files": [
         {
-          "path": "lib/ai-safety.ts",
+          "path": "components/registry/n4-safety/ai-safety.tsx",
+          "target": "lib/ai-safety.ts",
           "type": "registry:lib"
         }
       ],
@@ -472,7 +481,8 @@
       "docs": "Use it for: Inline form error and success messages, Contextual warnings in admin interfaces, Informational callouts in documentation, Account status notifications, Feature announcement banners within pages.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/alert",
       "files": [
         {
-          "path": "components/ui/alert.tsx",
+          "path": "components/registry/n2-primitives/alert.tsx",
+          "target": "components/ui/alert.tsx",
           "type": "registry:ui"
         }
       ],
@@ -520,7 +530,8 @@
       "docs": "Use it for: Destructive action confirmations (delete, cancel), Irreversible operation warnings, Account closure confirmations, Critical permission changes, Data loss prevention prompts.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/alert-dialog",
       "files": [
         {
-          "path": "components/ui/alert-dialog.tsx",
+          "path": "components/registry/n2-primitives/alert-dialog.tsx",
+          "target": "components/ui/alert-dialog.tsx",
           "type": "registry:ui"
         }
       ],
@@ -569,7 +580,8 @@
       "docs": "Use it for: console.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/analytics-dashboard-card",
       "files": [
         {
-          "path": "components/ui/analytics-dashboard-card.tsx",
+          "path": "components/registry/n2-primitives/analytics-dashboard-card.tsx",
+          "target": "components/ui/analytics-dashboard-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -610,7 +622,8 @@
       "docs": "Use it for: nhimbe, news, console, wallet, bushtrade.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/analytics-dashboard-page",
       "files": [
         {
-          "path": "components/ui/analytics-dashboard-page.tsx",
+          "path": "components/registry/n6-pages/analytics-dashboard-page.tsx",
+          "target": "components/ui/analytics-dashboard-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -657,7 +670,8 @@
       "docs": "Use it for: wallet.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/ancestry-memorial",
       "files": [
         {
-          "path": "components/ui/ancestry-memorial.tsx",
+          "path": "components/registry/n2-primitives/ancestry-memorial.tsx",
+          "target": "components/ui/ancestry-memorial.tsx",
           "type": "registry:ui"
         }
       ],
@@ -703,7 +717,8 @@
       "docs": "Use it for: Site-wide announcements (new features, maintenance), Promotional campaign banners, Beta program and early access announcements, Important deadline reminders, Service degradation notifications.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/announcement-bar",
       "files": [
         {
-          "path": "components/ui/announcement-bar.tsx",
+          "path": "components/registry/n2-primitives/announcement-bar.tsx",
+          "target": "components/ui/announcement-bar.tsx",
           "type": "registry:ui"
         }
       ],
@@ -748,7 +763,8 @@
       "docs": "Use it for: console.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/api-explorer-page",
       "files": [
         {
-          "path": "components/ui/api-explorer-page.tsx",
+          "path": "components/registry/n6-pages/api-explorer-page.tsx",
+          "target": "components/ui/api-explorer-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -791,7 +807,8 @@
       "docs": "Use it for: API key display in developer dashboard, Secret reveal with copy-to-clipboard, Webhook signing secret management, OAuth client secret display, Third-party integration credential viewing.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/api-key-display",
       "files": [
         {
-          "path": "components/ui/api-key-display.tsx",
+          "path": "components/registry/n2-primitives/api-key-display.tsx",
+          "target": "components/ui/api-key-display.tsx",
           "type": "registry:ui"
         }
       ],
@@ -835,7 +852,8 @@
       "docs": "Use it for: console.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/api-usage-meter",
       "files": [
         {
-          "path": "components/ui/api-usage-meter.tsx",
+          "path": "components/registry/n2-primitives/api-usage-meter.tsx",
+          "target": "components/ui/api-usage-meter.tsx",
           "type": "registry:ui"
         }
       ],
@@ -878,7 +896,8 @@
       "docs": "Use it for: Ecosystem app navigation (Bundu/Mukoko/Nyuchi/Shamwari/Nhimbe), Cross-app launcher in shared header, Quick app-switching in multi-product suites, Mini-app grid in unified platform shell, Nyuchi super-app navigation surface.\nVariants: default.\nIncludes: App shell infrastructure, Cross-layer wiring (L7→L8→L9), data-slot + data-portal DOM attributes, Harness integration.\nAccessibility: Focus-visible ring on interactive elements, ARIA role, ARIA attributes.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/app-switcher",
       "files": [
         {
-          "path": "components/ui/app-switcher.tsx",
+          "path": "components/registry/n7-shell/app-switcher.tsx",
+          "target": "components/ui/app-switcher.tsx",
           "type": "registry:ui"
         }
       ],
@@ -927,7 +946,8 @@
       "docs": "Use it for: health.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/appointment-card",
       "files": [
         {
-          "path": "components/ui/appointment-card.tsx",
+          "path": "components/registry/n2-primitives/appointment-card.tsx",
+          "target": "components/ui/appointment-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -972,7 +992,8 @@
       "docs": "Use it for: planner, wallet, transport.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/arc-gauge",
       "files": [
         {
-          "path": "components/ui/arc-gauge.tsx",
+          "path": "components/registry/n2-primitives/arc-gauge.tsx",
+          "target": "components/ui/arc-gauge.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1016,7 +1037,8 @@
       "docs": "Use it for: Architecture specification display in design portal, Sovereignty assessment documentation, Data-layer strategy visualization, System design reference for AI assistants, Architecture review and audit tooling.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/architecture",
       "files": [
         {
-          "path": "lib/architecture.ts",
+          "path": "components/registry/n2-primitives/architecture.ts",
+          "target": "lib/architecture.ts",
           "type": "registry:lib"
         }
       ],
@@ -1057,7 +1079,8 @@
       "docs": "Use it for: pulse, bytes, news.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/article-page",
       "files": [
         {
-          "path": "components/ui/article-page.tsx",
+          "path": "components/registry/n6-pages/article-page.tsx",
+          "target": "components/ui/article-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1105,7 +1128,8 @@
       "docs": "Use it for: Video embed containers maintaining 16:9, Image cards maintaining square format, Map containers with fixed ratio, Chart containers with responsive aspect, Media previews with consistent proportions.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/aspect-ratio",
       "files": [
         {
-          "path": "components/ui/aspect-ratio.tsx",
+          "path": "components/registry/n2-primitives/aspect-ratio.tsx",
+          "target": "components/ui/aspect-ratio.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1147,7 +1171,8 @@
       "docs": "Use it for: circles, planner.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/assignee-picker",
       "files": [
         {
-          "path": "components/ui/assignee-picker.tsx",
+          "path": "components/registry/n2-primitives/assignee-picker.tsx",
+          "target": "components/ui/assignee-picker.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1192,7 +1217,8 @@
       "docs": "Use it for: Podcast playback in Mukoko media, Voice note playback in chat, Audio article playback with speed control, Language lesson audio in learning apps, Music preview players in catalog pages.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/audio-player",
       "files": [
         {
-          "path": "components/ui/audio-player.tsx",
+          "path": "components/registry/n2-primitives/audio-player.tsx",
+          "target": "components/ui/audio-player.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1236,7 +1262,8 @@
       "docs": "Use it for: campfire, bytes.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/audio-waveform",
       "files": [
         {
-          "path": "components/ui/audio-waveform.tsx",
+          "path": "components/registry/n2-primitives/audio-waveform.tsx",
+          "target": "components/ui/audio-waveform.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1275,7 +1302,8 @@
       "docs": "Use it for: Admin audit trail entries (who changed what when), Security event log display, Compliance audit history views, Moderation action log for community spaces, API access log with endpoint and response.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/audit-log-entry",
       "files": [
         {
-          "path": "components/ui/audit-log-entry.tsx",
+          "path": "components/registry/n2-primitives/audit-log-entry.tsx",
+          "target": "components/ui/audit-log-entry.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1318,7 +1346,8 @@
       "docs": "Use it for: novels.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/author-bio-card",
       "files": [
         {
-          "path": "components/ui/author-bio-card.tsx",
+          "path": "components/registry/n2-primitives/author-bio-card.tsx",
+          "target": "components/ui/author-bio-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1363,7 +1392,8 @@
       "docs": "Use it for: Search input with suggestions, Location autocomplete with city/place predictions, User mention lookups, Tag suggestions during composition, Product search with real-time suggestions.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/autocomplete",
       "files": [
         {
-          "path": "components/ui/autocomplete.tsx",
+          "path": "components/registry/n2-primitives/autocomplete.tsx",
+          "target": "components/ui/autocomplete.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1410,7 +1440,8 @@
       "docs": "Use it for: User identity in headers and comments, Profile pictures throughout the app, Team member displays, Initial-based fallbacks for missing images, Author attribution in articles and posts.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/avatar",
       "files": [
         {
-          "path": "components/ui/avatar.tsx",
+          "path": "components/registry/n2-primitives/avatar.tsx",
+          "target": "components/ui/avatar.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1454,7 +1485,8 @@
       "docs": "Use it for: Team member displays in project cards, Assignee previews on tasks, Reviewer lists on pull requests and docs, Attendee previews on events, Contributor lists with +N overflow.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/avatar-group",
       "files": [
         {
-          "path": "components/ui/avatar-group.tsx",
+          "path": "components/registry/n2-primitives/avatar-group.tsx",
+          "target": "components/ui/avatar-group.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1501,7 +1533,8 @@
       "docs": "Use it for: Status indicators (active, pending, archived), Category labels on content, Count indicators (unread, new), Priority indicators (high, low, urgent), Tag display on posts and articles.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/badge",
       "files": [
         {
-          "path": "components/ui/badge.tsx",
+          "path": "components/registry/n2-primitives/badge.tsx",
+          "target": "components/ui/badge.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1547,7 +1580,8 @@
       "docs": "Use it for: console.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/batch-action-bar",
       "files": [
         {
-          "path": "components/ui/batch-action-bar.tsx",
+          "path": "components/registry/n2-primitives/batch-action-bar.tsx",
+          "target": "components/ui/batch-action-bar.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1593,7 +1627,8 @@
       "docs": "Use it for: Dashboard with mixed-size widgets, Landing page feature showcase, Product portfolio displays, Marketing surfaces with varied tile sizes, Collection galleries with hero tiles.\nVariants: default, dense, hero-lead, with-nav.\nIncludes: Tile size presets (1x1, 1x2, 2x1, 2x2), Responsive breakpoint-aware layout, Optional drag-to-resize, Auto-flow packing algorithm, Harness integration for tile-level observability.\nAccessibility: role=list for container, Each tile role=listitem, Tile focus order follows visual flow, Tiles independently accessible, Keyboard-navigable grid.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/bento-grid",
       "files": [
         {
-          "path": "components/ui/bento-grid.tsx",
+          "path": "components/registry/n2-primitives/bento-grid.tsx",
+          "target": "components/ui/bento-grid.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1644,7 +1679,8 @@
       "docs": "Use it for: nhimbe, console, wallet, bushtrade.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/billing-page",
       "files": [
         {
-          "path": "components/ui/billing-page.tsx",
+          "path": "components/registry/n6-pages/billing-page.tsx",
+          "target": "components/ui/billing-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1690,7 +1726,8 @@
       "docs": "Use it for: nhimbe, transport, health.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/booking-calendar",
       "files": [
         {
-          "path": "components/ui/booking-calendar.tsx",
+          "path": "components/registry/n2-primitives/booking-calendar.tsx",
+          "target": "components/ui/booking-calendar.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1735,7 +1772,8 @@
       "docs": "Use it for: nhimbe, planner, transport.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/booking-confirmation",
       "files": [
         {
-          "path": "components/ui/booking-confirmation.tsx",
+          "path": "components/registry/n2-primitives/booking-confirmation.tsx",
+          "target": "components/ui/booking-confirmation.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1782,7 +1820,8 @@
       "docs": "Use it for: events, places, transport, health.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/booking-page",
       "files": [
         {
-          "path": "components/ui/booking-page.tsx",
+          "path": "components/registry/n6-pages/booking-page.tsx",
+          "target": "components/ui/booking-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1828,7 +1867,8 @@
       "docs": "Use it for: Mobile action sheets and option pickers, Mobile forms in sheet format, Detail expansions on mobile, Sharing menus in mobile context, Quick filters in mobile search.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/bottom-sheet",
       "files": [
         {
-          "path": "components/ui/bottom-sheet.tsx",
+          "path": "components/registry/n2-primitives/bottom-sheet.tsx",
+          "target": "components/ui/bottom-sheet.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1878,7 +1918,8 @@
       "docs": "Use it for: Deep-linked page navigation (folders/subfolders/files), E-commerce category hierarchy, Admin console location indicators, Documentation nested page navigation, Multi-step form progress breadcrumbs.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/breadcrumb",
       "files": [
         {
-          "path": "components/ui/breadcrumb.tsx",
+          "path": "components/registry/n2-primitives/breadcrumb.tsx",
+          "target": "components/ui/breadcrumb.tsx",
           "type": "registry:ui"
         }
       ],
@@ -1923,7 +1964,8 @@
       "docs": "Use it for: Isolating slow external API calls (Tomorrow.io, Anthropic), Preventing connection exhaustion to payment providers, Limiting concurrent database queries per service, Protecting AI service calls during traffic spikes, Third-party registry lookups with concurrency caps.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/bulkhead",
       "files": [
         {
-          "path": "lib/bulkhead.ts",
+          "path": "components/registry/n2-primitives/bulkhead.ts",
+          "target": "lib/bulkhead.ts",
           "type": "registry:lib"
         }
       ],
@@ -1970,7 +2012,8 @@
       "docs": "Use it for: Primary CTA (mineral accent), Secondary action (outline/ghost), Destructive action (delete, remove), Icon-only action, Link-style navigation.\nVariants: default, outline, secondary, ghost, destructive, link.\nSizes: default (56px), sm (48px), lg (56px wide), icon (56px square), icon-sm (48px square).\nIncludes: Pill-shaped (rounded-full) per brand standard, data-slot attribute for CSS targeting, asChild support via Radix Slot, Disabled state with pointer-events-none.\nAccessibility: Focus-visible ring with --ring token, aria-invalid styling, Minimum 48px touch target, Keyboard accessible (Enter/Space).\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/button",
       "files": [
         {
-          "path": "components/ui/button.tsx",
+          "path": "components/registry/n2-primitives/button.tsx",
+          "target": "components/ui/button.tsx",
           "type": "registry:ui"
         }
       ],
@@ -2031,7 +2074,8 @@
       "docs": "Use it for: Grouping related primary/secondary actions (save and cancel), Segmented toolbar controls with connected visual boundary, Filter toolbar with multi-state selection, View switcher (grid/list/calendar) in dashboards, Inline form action pairs (apply/reset, yes/no).\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/button-group",
       "files": [
         {
-          "path": "components/ui/button-group.tsx",
+          "path": "components/registry/n2-primitives/button-group.tsx",
+          "target": "components/ui/button-group.tsx",
           "type": "registry:ui"
         }
       ],
@@ -2082,7 +2126,8 @@
       "docs": "Use it for: Full calendar with day, week, and month views, Booking and scheduling interfaces, Event calendar displays, Availability viewers, Personal and team calendar apps.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/calendar",
       "files": [
         {
-          "path": "components/ui/calendar.tsx",
+          "path": "components/registry/n2-primitives/calendar.tsx",
+          "target": "components/ui/calendar.tsx",
           "type": "registry:ui"
         }
       ],
@@ -2129,7 +2174,8 @@
       "docs": "Use it for: Single-day detail view in booking apps, Hour-by-hour agenda displays, Daily task timeline, Appointment day view, Daily schedule in productivity apps.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/calendar-day-view",
       "files": [
         {
-          "path": "components/ui/calendar-day-view.tsx",
+          "path": "components/registry/n2-primitives/calendar-day-view.tsx",
+          "target": "components/ui/calendar-day-view.tsx",
           "type": "registry:ui"
         }
       ],
@@ -2171,7 +2217,8 @@
       "docs": "Use it for: planner, nhimbe, health.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/calendar-month-view",
       "files": [
         {
-          "path": "components/ui/calendar-month-view.tsx",
+          "path": "components/registry/n2-primitives/calendar-month-view.tsx",
+          "target": "components/ui/calendar-month-view.tsx",
           "type": "registry:ui"
         }
       ],
@@ -2215,7 +2262,8 @@
       "docs": "Use it for: Weekly schedule overview, Team calendar with week view, Work week planning interfaces, Recurring meeting visualisation, Weekly appointment browsing.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/calendar-week-view",
       "files": [
         {
-          "path": "components/ui/calendar-week-view.tsx",
+          "path": "components/registry/n2-primitives/calendar-week-view.tsx",
+          "target": "components/ui/calendar-week-view.tsx",
           "type": "registry:ui"
         }
       ],
@@ -2257,7 +2305,8 @@
       "docs": "Use it for: campfire, bytes.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/camera-viewfinder",
       "files": [
         {
-          "path": "components/ui/camera-viewfinder.tsx",
+          "path": "components/registry/n2-primitives/camera-viewfinder.tsx",
+          "target": "components/ui/camera-viewfinder.tsx",
           "type": "registry:ui"
         }
       ],
@@ -2303,7 +2352,8 @@
       "docs": "Use it for: nhimbe, planner, news.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/canvas-chart",
       "files": [
         {
-          "path": "components/ui/canvas-chart.tsx",
+          "path": "components/registry/n2-primitives/canvas-chart.tsx",
+          "target": "components/ui/canvas-chart.tsx",
           "type": "registry:ui"
         }
       ],
@@ -2346,7 +2396,8 @@
       "docs": "Use it for: bytes.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/caption-editor",
       "files": [
         {
-          "path": "components/ui/caption-editor.tsx",
+          "path": "components/registry/n2-primitives/caption-editor.tsx",
+          "target": "components/ui/caption-editor.tsx",
           "type": "registry:ui"
         }
       ],
@@ -2390,7 +2441,8 @@
       "docs": "Use it for: Content container for listings, profiles, data display, Dashboard widget container, Form section grouping, Notification/alert container.\nVariants: default, with header, with footer, with header and footer.\nIncludes: Semantic surface (bg-card), Border with --border token, Radius from --radius-xl token, data-slot on all sub-components.\nAccessibility: Landmark-compatible, Focus management for interactive cards.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/card",
       "files": [
         {
-          "path": "components/ui/card.tsx",
+          "path": "components/registry/n2-primitives/card.tsx",
+          "target": "components/ui/card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -2439,7 +2491,8 @@
       "docs": "Use it for: Image galleries with swipe on mobile, Featured product rotation on homepages, Onboarding step sequence with swipe, Testimonial and review rotation, Multi-image product showcases.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/carousel",
       "files": [
         {
-          "path": "components/ui/carousel.tsx",
+          "path": "components/registry/n2-primitives/carousel.tsx",
+          "target": "components/ui/carousel.tsx",
           "type": "registry:ui"
         }
       ],
@@ -2486,7 +2539,8 @@
       "docs": "Use it for: Shopping cart display in BushTrade checkout, Order review before payment, Saved items in wishlist management, Cart preview in header dropdown, Quantity-editable cart line items.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/cart-item",
       "files": [
         {
-          "path": "components/ui/cart-item.tsx",
+          "path": "components/registry/n2-primitives/cart-item.tsx",
+          "target": "components/ui/cart-item.tsx",
           "type": "registry:ui"
         }
       ],
@@ -2530,7 +2584,8 @@
       "docs": "Use it for: Top-level category navigation in marketplaces, Topic browsing on content sites, Course catalog browsing in learning apps, Module selection in admin consoles, Service category entry points on homepages.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/category-browser",
       "files": [
         {
-          "path": "components/ui/category-browser.tsx",
+          "path": "components/registry/n2-primitives/category-browser.tsx",
+          "target": "components/ui/category-browser.tsx",
           "type": "registry:ui"
         }
       ],
@@ -2572,7 +2627,8 @@
       "docs": "Use it for: Release notes display on mzizi.dev, Product update cards in changelog feeds, Version history in admin dashboards, API changelog entries for developer docs, Feature announcement timeline.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/changelog-entry",
       "files": [
         {
-          "path": "components/ui/changelog-entry.tsx",
+          "path": "components/registry/n2-primitives/changelog-entry.tsx",
+          "target": "components/ui/changelog-entry.tsx",
           "type": "registry:ui"
         }
       ],
@@ -2613,7 +2669,8 @@
       "docs": "Use it for: Injecting chaos in test environments to verify resilience, Validating error handling during Layer 8 assurance runs, Failure-mode testing in dev before production, Conformity check stress testing, Synthetic probe fault injection.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chaos",
       "files": [
         {
-          "path": "lib/chaos.ts",
+          "path": "components/registry/n2-primitives/chaos.ts",
+          "target": "lib/chaos.ts",
           "type": "registry:lib"
         }
       ],
@@ -2656,7 +2713,8 @@
       "docs": "Use it for: novels.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chapter-list",
       "files": [
         {
-          "path": "components/ui/chapter-list.tsx",
+          "path": "components/registry/n2-primitives/chapter-list.tsx",
+          "target": "components/ui/chapter-list.tsx",
           "type": "registry:ui"
         }
       ],
@@ -2698,7 +2756,8 @@
       "docs": "Use it for: novels.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chapter-reader",
       "files": [
         {
-          "path": "components/ui/chapter-reader.tsx",
+          "path": "components/registry/n2-primitives/chapter-reader.tsx",
+          "target": "components/ui/chapter-reader.tsx",
           "type": "registry:ui"
         }
       ],
@@ -2741,7 +2800,8 @@
       "docs": "Use it for: Foundation chart primitive for all dashboard charts, Base chart container with theming, Shared chart config and legend infrastructure, Root chart wrapper for Recharts composition, Theme-aware chart shell.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart",
       "files": [
         {
-          "path": "components/ui/chart.tsx",
+          "path": "components/registry/n2-primitives/chart.tsx",
+          "target": "components/ui/chart.tsx",
           "type": "registry:ui"
         }
       ],
@@ -2785,7 +2845,8 @@
       "docs": "Use it for: Data-rich dashboards with labelled axes, Scientific and technical visualizations, Dashboards needing explicit scale, Engineering and monitoring displays, Analytical views where values need reading.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-area-axes",
       "files": [
         {
-          "path": "components/blocks/charts/chart-area-axes.tsx",
+          "path": "components/registry/n2-primitives/chart-area-axes.tsx",
+          "target": "components/blocks/charts/chart-area-axes.tsx",
           "type": "registry:block"
         }
       ],
@@ -2832,7 +2893,8 @@
       "docs": "Use it for: Daily active users trending over time, Revenue trajectory visualisation, Resource utilization over the last 30 days, Traffic volume dashboards, Basic trend exploration.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-area-default",
       "files": [
         {
-          "path": "components/blocks/charts/chart-area-default.tsx",
+          "path": "components/registry/n2-primitives/chart-area-default.tsx",
+          "target": "components/blocks/charts/chart-area-default.tsx",
           "type": "registry:block"
         }
       ],
@@ -2879,7 +2941,8 @@
       "docs": "Use it for: Heat-tinted volume displays (warmth indicates high values), Design-forward dashboards with gradient accents, Aesthetic analytics with mineral-colored areas, Feature showcase charts, Polished presentation dashboards.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-area-gradient",
       "files": [
         {
-          "path": "components/blocks/charts/chart-area-gradient.tsx",
+          "path": "components/registry/n2-primitives/chart-area-gradient.tsx",
+          "target": "components/blocks/charts/chart-area-gradient.tsx",
           "type": "registry:block"
         }
       ],
@@ -2926,7 +2989,8 @@
       "docs": "Use it for: Category-labelled trend displays with icons, Marketing dashboards (channels with icons), Product metric trends with category identifiers, Human-readable analytics with visual cues, Executive dashboards with brand identity.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-area-icons",
       "files": [
         {
-          "path": "components/blocks/charts/chart-area-icons.tsx",
+          "path": "components/registry/n2-primitives/chart-area-icons.tsx",
+          "target": "components/blocks/charts/chart-area-icons.tsx",
           "type": "registry:block"
         }
       ],
@@ -2973,7 +3037,8 @@
       "docs": "Use it for: Interactive trend exploration with hover, Drill-down analytics dashboards, Comparison mode with click-to-highlight series, Date-range exploration in analytics, Executive dashboards with hover detail.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-area-interactive",
       "files": [
         {
-          "path": "components/blocks/charts/chart-area-interactive.tsx",
+          "path": "components/registry/n2-primitives/chart-area-interactive.tsx",
+          "target": "components/blocks/charts/chart-area-interactive.tsx",
           "type": "registry:block"
         }
       ],
@@ -3020,7 +3085,8 @@
       "docs": "Use it for: Multi-series trend with color-coded legend, Comparison dashboards (this year vs last year), Segment performance over time, A/B test result visualization, Campaign comparison analytics.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-area-legend",
       "files": [
         {
-          "path": "components/blocks/charts/chart-area-legend.tsx",
+          "path": "components/registry/n2-primitives/chart-area-legend.tsx",
+          "target": "components/blocks/charts/chart-area-legend.tsx",
           "type": "registry:block"
         }
       ],
@@ -3067,7 +3133,8 @@
       "docs": "Use it for: Linear trend over time (straight-line projections), Simple clean trajectory visualizations, Performance tracking without interpolation, Linear growth displays, Data-confidence visualisation without smoothing.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-area-linear",
       "files": [
         {
-          "path": "components/blocks/charts/chart-area-linear.tsx",
+          "path": "components/registry/n2-primitives/chart-area-linear.tsx",
+          "target": "components/blocks/charts/chart-area-linear.tsx",
           "type": "registry:block"
         }
       ],
@@ -3114,7 +3181,8 @@
       "docs": "Use it for: Multi-metric trend comparison (signups vs churn), Stacked revenue by product line, Cohort comparison over time, Segment breakdown with totals, Visual volume comparisons.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-area-stacked",
       "files": [
         {
-          "path": "components/blocks/charts/chart-area-stacked.tsx",
+          "path": "components/registry/n2-primitives/chart-area-stacked.tsx",
+          "target": "components/blocks/charts/chart-area-stacked.tsx",
           "type": "registry:block"
         }
       ],
@@ -3161,7 +3229,8 @@
       "docs": "Use it for: Stacked percentage share over time (market share), Cohort retention percentages, Channel contribution to total visitors, Resource allocation percentage trends, Normalised multi-series visualisation.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-area-stacked-expand",
       "files": [
         {
-          "path": "components/blocks/charts/chart-area-stacked-expand.tsx",
+          "path": "components/registry/n2-primitives/chart-area-stacked-expand.tsx",
+          "target": "components/blocks/charts/chart-area-stacked-expand.tsx",
           "type": "registry:block"
         }
       ],
@@ -3208,7 +3277,8 @@
       "docs": "Use it for: Threshold-based performance tracking (sprint velocity), Discrete state changes over time, Inventory level changes between events, Price steps in pricing plans over time, Stepwise data where values hold between points.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-area-step",
       "files": [
         {
-          "path": "components/blocks/charts/chart-area-step.tsx",
+          "path": "components/registry/n2-primitives/chart-area-step.tsx",
+          "target": "components/blocks/charts/chart-area-step.tsx",
           "type": "registry:block"
         }
       ],
@@ -3255,7 +3325,8 @@
       "docs": "Use it for: Hover-state-aware ranking displays, Executive dashboards with hover emphasis, Category ranking with visual feedback, Top-N displays with highlight, Active category indication.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-bar-active",
       "files": [
         {
-          "path": "components/blocks/charts/chart-bar-active.tsx",
+          "path": "components/registry/n2-primitives/chart-bar-active.tsx",
+          "target": "components/blocks/charts/chart-bar-active.tsx",
           "type": "registry:block"
         }
       ],
@@ -3302,7 +3373,8 @@
       "docs": "Use it for: Category comparison (sales by region), Ranking visualizations (top 10 products), Vote and survey results, Revenue by department, Basic categorical comparisons.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-bar-default",
       "files": [
         {
-          "path": "components/blocks/charts/chart-bar-default.tsx",
+          "path": "components/registry/n2-primitives/chart-bar-default.tsx",
+          "target": "components/blocks/charts/chart-bar-default.tsx",
           "type": "registry:block"
         }
       ],
@@ -3349,7 +3421,8 @@
       "docs": "Use it for: Horizontal category ranking (long category names), Mobile-friendly bar charts, Dense listings where vertical space is limited, Percentile and rating displays, Label-heavy category comparisons.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-bar-horizontal",
       "files": [
         {
-          "path": "components/blocks/charts/chart-bar-horizontal.tsx",
+          "path": "components/registry/n2-primitives/chart-bar-horizontal.tsx",
+          "target": "components/blocks/charts/chart-bar-horizontal.tsx",
           "type": "registry:block"
         }
       ],
@@ -3396,7 +3469,8 @@
       "docs": "Use it for: Interactive ranking with drill-down, Click-to-filter category bar charts, Analytics dashboards with bar click, Explorable category breakdowns, Segment drill-down from bar visualizations.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-bar-interactive",
       "files": [
         {
-          "path": "components/blocks/charts/chart-bar-interactive.tsx",
+          "path": "components/registry/n2-primitives/chart-bar-interactive.tsx",
+          "target": "components/blocks/charts/chart-bar-interactive.tsx",
           "type": "registry:block"
         }
       ],
@@ -3443,7 +3517,8 @@
       "docs": "Use it for: Bar charts with inline value labels, Presentation dashboards (no hover needed), Static reports with visible values, Executive summaries with explicit numbers, Print-ready dashboards.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-bar-label",
       "files": [
         {
-          "path": "components/blocks/charts/chart-bar-label.tsx",
+          "path": "components/registry/n2-primitives/chart-bar-label.tsx",
+          "target": "components/blocks/charts/chart-bar-label.tsx",
           "type": "registry:block"
         }
       ],
@@ -3490,7 +3565,8 @@
       "docs": "Use it for: Bar charts with custom-styled value labels, Brand-consistent inline labels with mineral colors, Design-polished dashboards, Marketing report charts, Custom label positioning for readability.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-bar-label-custom",
       "files": [
         {
-          "path": "components/blocks/charts/chart-bar-label-custom.tsx",
+          "path": "components/registry/n2-primitives/chart-bar-label-custom.tsx",
+          "target": "components/blocks/charts/chart-bar-label-custom.tsx",
           "type": "registry:block"
         }
       ],
@@ -3537,7 +3613,8 @@
       "docs": "Use it for: Mixed-unit comparisons (bars + values labelled), Dashboards showing both bar and numeric context, Data tables augmented with bar visualisation, Hybrid chart + label presentations, Metric cards with inline bars.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-bar-mixed",
       "files": [
         {
-          "path": "components/blocks/charts/chart-bar-mixed.tsx",
+          "path": "components/registry/n2-primitives/chart-bar-mixed.tsx",
+          "target": "components/blocks/charts/chart-bar-mixed.tsx",
           "type": "registry:block"
         }
       ],
@@ -3584,7 +3661,8 @@
       "docs": "Use it for: Multi-series category comparison (current vs previous), Grouped bar displays with multiple measures, Before/after comparisons by category, Survey results across multiple questions, Department performance comparison.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-bar-multiple",
       "files": [
         {
-          "path": "components/blocks/charts/chart-bar-multiple.tsx",
+          "path": "components/registry/n2-primitives/chart-bar-multiple.tsx",
+          "target": "components/blocks/charts/chart-bar-multiple.tsx",
           "type": "registry:block"
         }
       ],
@@ -3631,7 +3709,8 @@
       "docs": "Use it for: Profit/loss visualization with negative values, Net change displays (gains vs losses), Sentiment analysis (positive vs negative), Account balance changes, Comparison against baseline.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-bar-negative",
       "files": [
         {
-          "path": "components/blocks/charts/chart-bar-negative.tsx",
+          "path": "components/registry/n2-primitives/chart-bar-negative.tsx",
+          "target": "components/blocks/charts/chart-bar-negative.tsx",
           "type": "registry:block"
         }
       ],
@@ -3678,7 +3757,8 @@
       "docs": "Use it for: Stacked category comparison (revenue by product and region), Budget allocation breakdowns, Traffic source stacks, Cohort segmentation visualization, Multi-dimension categorical analysis.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-bar-stacked",
       "files": [
         {
-          "path": "components/blocks/charts/chart-bar-stacked.tsx",
+          "path": "components/registry/n2-primitives/chart-bar-stacked.tsx",
+          "target": "components/blocks/charts/chart-bar-stacked.tsx",
           "type": "registry:block"
         }
       ],
@@ -3725,7 +3805,8 @@
       "docs": "Use it for: Time-series trend visualization, Performance metric tracking over time, Stock and price tracking, User growth dashboards, Basic trend analysis.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-line-default",
       "files": [
         {
-          "path": "components/blocks/charts/chart-line-default.tsx",
+          "path": "components/registry/n2-primitives/chart-line-default.tsx",
+          "target": "components/blocks/charts/chart-line-default.tsx",
           "type": "registry:block"
         }
       ],
@@ -3772,7 +3853,8 @@
       "docs": "Use it for: Line charts with data point markers, Sparse time-series with discrete points, Quarterly and monthly trending with emphasis, Event-based trending (each point significant), Presentation-quality trend charts.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-line-dots",
       "files": [
         {
-          "path": "components/blocks/charts/chart-line-dots.tsx",
+          "path": "components/registry/n2-primitives/chart-line-dots.tsx",
+          "target": "components/blocks/charts/chart-line-dots.tsx",
           "type": "registry:block"
         }
       ],
@@ -3819,7 +3901,8 @@
       "docs": "Use it for: Trend charts with mineral-colored dots, Category-aware line charts with styled points, Brand-consistent visualization, Metric dashboards with colored highlights, Color-coded data point trending.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-line-dots-colors",
       "files": [
         {
-          "path": "components/blocks/charts/chart-line-dots-colors.tsx",
+          "path": "components/registry/n2-primitives/chart-line-dots-colors.tsx",
+          "target": "components/blocks/charts/chart-line-dots-colors.tsx",
           "type": "registry:block"
         }
       ],
@@ -3866,7 +3949,8 @@
       "docs": "Use it for: Custom-styled dot trend charts, Polished presentation dashboards, Brand-consistent trend visualization, Marketing report charts, Styled analytics for external reports.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-line-dots-custom",
       "files": [
         {
-          "path": "components/blocks/charts/chart-line-dots-custom.tsx",
+          "path": "components/registry/n2-primitives/chart-line-dots-custom.tsx",
+          "target": "components/blocks/charts/chart-line-dots-custom.tsx",
           "type": "registry:block"
         }
       ],
@@ -3913,7 +3997,8 @@
       "docs": "Use it for: Interactive trend exploration, Hover-driven date detail, Drill-down line charts, Analytics with click-to-zoom, Executive dashboards with hover interactivity.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-line-interactive",
       "files": [
         {
-          "path": "components/blocks/charts/chart-line-interactive.tsx",
+          "path": "components/registry/n2-primitives/chart-line-interactive.tsx",
+          "target": "components/blocks/charts/chart-line-interactive.tsx",
           "type": "registry:block"
         }
       ],
@@ -3960,7 +4045,8 @@
       "docs": "Use it for: Labelled trend points in line charts, Static reports with visible values, Executive dashboards with explicit numbers, Report-ready trend visualisations, Print-ready line charts.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-line-label",
       "files": [
         {
-          "path": "components/blocks/charts/chart-line-label.tsx",
+          "path": "components/registry/n2-primitives/chart-line-label.tsx",
+          "target": "components/blocks/charts/chart-line-label.tsx",
           "type": "registry:block"
         }
       ],
@@ -4007,7 +4093,8 @@
       "docs": "Use it for: Custom-labelled trend visualizations, Brand-polished dashboards, Marketing analytics with custom labels, Design-forward trend presentations, Executive summary charts.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-line-label-custom",
       "files": [
         {
-          "path": "components/blocks/charts/chart-line-label-custom.tsx",
+          "path": "components/registry/n2-primitives/chart-line-label-custom.tsx",
+          "target": "components/blocks/charts/chart-line-label-custom.tsx",
           "type": "registry:block"
         }
       ],
@@ -4054,7 +4141,8 @@
       "docs": "Use it for: Linear interpolation trends (no smoothing), Point-by-point trajectory visualization, Scientific data with confidence in each point, Engineering metric displays, Data without implied continuity between points.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-line-linear",
       "files": [
         {
-          "path": "components/blocks/charts/chart-line-linear.tsx",
+          "path": "components/registry/n2-primitives/chart-line-linear.tsx",
+          "target": "components/blocks/charts/chart-line-linear.tsx",
           "type": "registry:block"
         }
       ],
@@ -4101,7 +4189,8 @@
       "docs": "Use it for: Multi-series line comparison, Cohort comparison charts (last month vs this month), Regional performance overlay, A/B test result visualization, Segment comparison in analytics.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-line-multiple",
       "files": [
         {
-          "path": "components/blocks/charts/chart-line-multiple.tsx",
+          "path": "components/registry/n2-primitives/chart-line-multiple.tsx",
+          "target": "components/blocks/charts/chart-line-multiple.tsx",
           "type": "registry:block"
         }
       ],
@@ -4148,7 +4237,8 @@
       "docs": "Use it for: Stepwise change visualisation (inventory changes), Binary state over time (on/off, active/inactive), Discrete value transitions, Pricing history step changes, Configuration change timelines.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-line-step",
       "files": [
         {
-          "path": "components/blocks/charts/chart-line-step.tsx",
+          "path": "components/registry/n2-primitives/chart-line-step.tsx",
+          "target": "components/blocks/charts/chart-line-step.tsx",
           "type": "registry:block"
         }
       ],
@@ -4195,7 +4285,8 @@
       "docs": "Use it for: Modern donut chart (pie with center hole), Category proportion with central label space, Progress-style proportion displays, Aesthetic distribution charts, Dashboard distribution with center metric.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-pie-donut",
       "files": [
         {
-          "path": "components/blocks/charts/chart-pie-donut.tsx",
+          "path": "components/registry/n2-primitives/chart-pie-donut.tsx",
+          "target": "components/blocks/charts/chart-pie-donut.tsx",
           "type": "registry:block"
         }
       ],
@@ -4242,7 +4333,8 @@
       "docs": "Use it for: Interactive donut with hover-highlighted segment, Dashboard with click-to-filter segments, Explorable proportion charts, Drill-down distribution visualisations, Active-segment emphasized displays.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-pie-donut-active",
       "files": [
         {
-          "path": "components/blocks/charts/chart-pie-donut-active.tsx",
+          "path": "components/registry/n2-primitives/chart-pie-donut-active.tsx",
+          "target": "components/blocks/charts/chart-pie-donut-active.tsx",
           "type": "registry:block"
         }
       ],
@@ -4289,7 +4381,8 @@
       "docs": "Use it for: Donut with center metric (total), KPI card with supporting distribution, Progress summary with breakdown, Executive dashboards with central number, Metric + context combined visualisation.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-pie-donut-text",
       "files": [
         {
-          "path": "components/blocks/charts/chart-pie-donut-text.tsx",
+          "path": "components/registry/n2-primitives/chart-pie-donut-text.tsx",
+          "target": "components/blocks/charts/chart-pie-donut-text.tsx",
           "type": "registry:block"
         }
       ],
@@ -4336,7 +4429,8 @@
       "docs": "Use it for: Interactive pie with drill-down, Click-to-filter proportion charts, Explorable category breakdowns, Analytics with segment click-through, Filterable distribution visualisations.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-pie-interactive",
       "files": [
         {
-          "path": "components/blocks/charts/chart-pie-interactive.tsx",
+          "path": "components/registry/n2-primitives/chart-pie-interactive.tsx",
+          "target": "components/blocks/charts/chart-pie-interactive.tsx",
           "type": "registry:block"
         }
       ],
@@ -4383,7 +4477,8 @@
       "docs": "Use it for: Pie chart with category labels, Standalone category breakdown, Executive summary proportions, Report-ready pie charts, Print-friendly distribution visualisation.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-pie-label",
       "files": [
         {
-          "path": "components/blocks/charts/chart-pie-label.tsx",
+          "path": "components/registry/n2-primitives/chart-pie-label.tsx",
+          "target": "components/blocks/charts/chart-pie-label.tsx",
           "type": "registry:block"
         }
       ],
@@ -4430,7 +4525,8 @@
       "docs": "Use it for: Custom-styled category-labelled pie, Brand-polished proportion charts, Marketing report pies, Design-forward distribution visualisation, Professional presentation charts.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-pie-label-custom",
       "files": [
         {
-          "path": "components/blocks/charts/chart-pie-label-custom.tsx",
+          "path": "components/registry/n2-primitives/chart-pie-label-custom.tsx",
+          "target": "components/blocks/charts/chart-pie-label-custom.tsx",
           "type": "registry:block"
         }
       ],
@@ -4477,7 +4573,8 @@
       "docs": "Use it for: Labelled pie with full label list, Complex category breakdown with full text, Detailed proportion charts, Multi-category budget displays, Executive report distribution charts.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-pie-label-list",
       "files": [
         {
-          "path": "components/blocks/charts/chart-pie-label-list.tsx",
+          "path": "components/registry/n2-primitives/chart-pie-label-list.tsx",
+          "target": "components/blocks/charts/chart-pie-label-list.tsx",
           "type": "registry:block"
         }
       ],
@@ -4524,7 +4621,8 @@
       "docs": "Use it for: Pie with legend on the side, Multi-category breakdown with legend lookup, Executive summaries with legend, Detailed category displays, Complex distributions with legend.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-pie-legend",
       "files": [
         {
-          "path": "components/blocks/charts/chart-pie-legend.tsx",
+          "path": "components/registry/n2-primitives/chart-pie-legend.tsx",
+          "target": "components/blocks/charts/chart-pie-legend.tsx",
           "type": "registry:block"
         }
       ],
@@ -4571,7 +4669,8 @@
       "docs": "Use it for: Pie chart without separators between slices, Seamless distribution visualisation, Aesthetic-forward dashboards, Design-focused proportion charts, Polished presentation pies.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-pie-separator-none",
       "files": [
         {
-          "path": "components/blocks/charts/chart-pie-separator-none.tsx",
+          "path": "components/registry/n2-primitives/chart-pie-separator-none.tsx",
+          "target": "components/blocks/charts/chart-pie-separator-none.tsx",
           "type": "registry:block"
         }
       ],
@@ -4618,7 +4717,8 @@
       "docs": "Use it for: Simple proportion breakdown (market share), Category distribution visualisation, Budget allocation displays, Survey result breakdowns, Basic share-of-whole dashboards.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-pie-simple",
       "files": [
         {
-          "path": "components/blocks/charts/chart-pie-simple.tsx",
+          "path": "components/registry/n2-primitives/chart-pie-simple.tsx",
+          "target": "components/blocks/charts/chart-pie-simple.tsx",
           "type": "registry:block"
         }
       ],
@@ -4665,7 +4765,8 @@
       "docs": "Use it for: Stacked pie showing nested proportions, Hierarchy-aware distribution (sub-categories), Multi-level breakdown visualisation, Nested proportion charts, Budget displays with sub-allocation.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-pie-stacked",
       "files": [
         {
-          "path": "components/blocks/charts/chart-pie-stacked.tsx",
+          "path": "components/registry/n2-primitives/chart-pie-stacked.tsx",
+          "target": "components/blocks/charts/chart-pie-stacked.tsx",
           "type": "registry:block"
         }
       ],
@@ -4712,7 +4813,8 @@
       "docs": "Use it for: Skill assessment visualization (multi-dimension profile), Product feature comparison, Performance review visualisations, Character and attribute displays, Multi-axis competitive comparisons.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radar-default",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radar-default.tsx",
+          "path": "components/registry/n2-primitives/chart-radar-default.tsx",
+          "target": "components/blocks/charts/chart-radar-default.tsx",
           "type": "registry:block"
         }
       ],
@@ -4759,7 +4861,8 @@
       "docs": "Use it for: Interactive multi-dimension comparison, Radar with hover-emphasis, Skill comparison dashboards, Team performance radar with highlight, Active-axis visualizations.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radar-dots",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radar-dots.tsx",
+          "path": "components/registry/n2-primitives/chart-radar-dots.tsx",
+          "target": "components/blocks/charts/chart-radar-dots.tsx",
           "type": "registry:block"
         }
       ],
@@ -4806,7 +4909,8 @@
       "docs": "Use it for: Circular-grid radar displays, Clean radar with circular axes, Presentation-quality multi-dimensional charts, Executive skill profile radars, Aesthetic multi-axis visualizations.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radar-grid-circle",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radar-grid-circle.tsx",
+          "path": "components/registry/n2-primitives/chart-radar-grid-circle.tsx",
+          "target": "components/blocks/charts/chart-radar-grid-circle.tsx",
           "type": "registry:block"
         }
       ],
@@ -4853,7 +4957,8 @@
       "docs": "Use it for: Filled-circle grid radar, Aesthetic multi-dimensional charts, Design-polished radar visualisations, Professional skill assessment charts, Brand-polished radar displays.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radar-grid-circle-fill",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radar-grid-circle-fill.tsx",
+          "path": "components/registry/n2-primitives/chart-radar-grid-circle-fill.tsx",
+          "target": "components/blocks/charts/chart-radar-grid-circle-fill.tsx",
           "type": "registry:block"
         }
       ],
@@ -4900,7 +5005,8 @@
       "docs": "Use it for: Minimal-grid radar (no background lines), Clean radar without grid noise, Aesthetic-forward multi-dimension charts, Design-focused skill visualisations, Minimalist radar displays.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radar-grid-circle-no-lines",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radar-grid-circle-no-lines.tsx",
+          "path": "components/registry/n2-primitives/chart-radar-grid-circle-no-lines.tsx",
+          "target": "components/blocks/charts/chart-radar-grid-circle-no-lines.tsx",
           "type": "registry:block"
         }
       ],
@@ -4947,7 +5053,8 @@
       "docs": "Use it for: Custom-styled radar grid, Brand-consistent multi-dimensional charts, Design-polished radar visualisations, Bespoke radar displays, Marketing-grade multi-axis charts.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radar-grid-custom",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radar-grid-custom.tsx",
+          "path": "components/registry/n2-primitives/chart-radar-grid-custom.tsx",
+          "target": "components/blocks/charts/chart-radar-grid-custom.tsx",
           "type": "registry:block"
         }
       ],
@@ -4994,7 +5101,8 @@
       "docs": "Use it for: Filled-grid radar displays, Background-highlighted multi-dimensional charts, Presentation-quality radar with grid fill, Design-polished skill visualisations, Aesthetic multi-axis charts with background.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radar-grid-fill",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radar-grid-fill.tsx",
+          "path": "components/registry/n2-primitives/chart-radar-grid-fill.tsx",
+          "target": "components/blocks/charts/chart-radar-grid-fill.tsx",
           "type": "registry:block"
         }
       ],
@@ -5041,7 +5149,8 @@
       "docs": "Use it for: Radar without grid display, Minimalist multi-dimensional charts, Clean radar visualisations, Design-forward skill displays, Aesthetic multi-axis comparisons.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radar-grid-none",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radar-grid-none.tsx",
+          "path": "components/registry/n2-primitives/chart-radar-grid-none.tsx",
+          "target": "components/blocks/charts/chart-radar-grid-none.tsx",
           "type": "registry:block"
         }
       ],
@@ -5088,7 +5197,8 @@
       "docs": "Use it for: Radar with icon-labelled axes, Category-aware skill assessments with icons, Visual multi-dimensional comparisons, Brand-polished radar with icons, Icon-enhanced skill profiles.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radar-icons",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radar-icons.tsx",
+          "path": "components/registry/n2-primitives/chart-radar-icons.tsx",
+          "target": "components/blocks/charts/chart-radar-icons.tsx",
           "type": "registry:block"
         }
       ],
@@ -5135,7 +5245,8 @@
       "docs": "Use it for: Radar with custom axis labels, Domain-specific multi-dimensional charts, Specialised skill assessments, Custom terminology radars, Brand-consistent labelled radars.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radar-label-custom",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radar-label-custom.tsx",
+          "path": "components/registry/n2-primitives/chart-radar-label-custom.tsx",
+          "target": "components/blocks/charts/chart-radar-label-custom.tsx",
           "type": "registry:block"
         }
       ],
@@ -5182,7 +5293,8 @@
       "docs": "Use it for: Radar with comprehensive legend, Multi-entity comparison with legend lookup, Executive summaries with legend, Complex multi-dimensional comparisons, Dashboard radar with legend explanation.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radar-legend",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radar-legend.tsx",
+          "path": "components/registry/n2-primitives/chart-radar-legend.tsx",
+          "target": "components/blocks/charts/chart-radar-legend.tsx",
           "type": "registry:block"
         }
       ],
@@ -5229,7 +5341,8 @@
       "docs": "Use it for: Lines-only radar (no polygon fill), Transparent multi-axis comparison, Overlay-friendly radar charts, Category axis comparison without fill, Clean multi-dimensional displays.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radar-lines-only",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radar-lines-only.tsx",
+          "path": "components/registry/n2-primitives/chart-radar-lines-only.tsx",
+          "target": "components/blocks/charts/chart-radar-lines-only.tsx",
           "type": "registry:block"
         }
       ],
@@ -5276,7 +5389,8 @@
       "docs": "Use it for: Multi-series radar (multiple entities compared), Competitive analysis radars, Before/after multi-dimensional comparison, Team vs team performance radars, Product comparison charts.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radar-multiple",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radar-multiple.tsx",
+          "path": "components/registry/n2-primitives/chart-radar-multiple.tsx",
+          "target": "components/blocks/charts/chart-radar-multiple.tsx",
           "type": "registry:block"
         }
       ],
@@ -5323,7 +5437,8 @@
       "docs": "Use it for: Radius-focused radar variant, Distance-from-center visualisation, Gap-analysis radar charts, Proficiency visualisations, Target vs current state radars.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radar-radius",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radar-radius.tsx",
+          "path": "components/registry/n2-primitives/chart-radar-radius.tsx",
+          "target": "components/blocks/charts/chart-radar-radius.tsx",
           "type": "registry:block"
         }
       ],
@@ -5370,7 +5485,8 @@
       "docs": "Use it for: Grid-backed radial charts, Radial with explicit scale indicators, Engineering and measurement radials, Monitoring dashboard gauges, Scale-aware progress visualisations.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radial-grid",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radial-grid.tsx",
+          "path": "components/registry/n2-primitives/chart-radial-grid.tsx",
+          "target": "components/blocks/charts/chart-radial-grid.tsx",
           "type": "registry:block"
         }
       ],
@@ -5417,7 +5533,8 @@
       "docs": "Use it for: Labelled radial progress charts, Multi-category radial breakdowns, Goal tracking radials with labels, Stacked performance radials, Executive KPI rings with labels.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radial-label",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radial-label.tsx",
+          "path": "components/registry/n2-primitives/chart-radial-label.tsx",
+          "target": "components/blocks/charts/chart-radial-label.tsx",
           "type": "registry:block"
         }
       ],
@@ -5464,7 +5581,8 @@
       "docs": "Use it for: Custom-shaped radial charts, Brand-polished gauge visualisations, Design-forward progress displays, Bespoke KPI rings, Aesthetic-first radial charts.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radial-shape",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radial-shape.tsx",
+          "path": "components/registry/n2-primitives/chart-radial-shape.tsx",
+          "target": "components/blocks/charts/chart-radial-shape.tsx",
           "type": "registry:block"
         }
       ],
@@ -5511,7 +5629,8 @@
       "docs": "Use it for: Simple gauge displays, Percentage completion dashboards, KPI rings, Progress toward goal visualisation, Single-metric radial displays.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radial-simple",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radial-simple.tsx",
+          "path": "components/registry/n2-primitives/chart-radial-simple.tsx",
+          "target": "components/blocks/charts/chart-radial-simple.tsx",
           "type": "registry:block"
         }
       ],
@@ -5558,7 +5677,8 @@
       "docs": "Use it for: Stacked radial charts (multi-metric ring), Multi-goal tracking with stacked progress, Cohort comparison radials, Sub-category breakdowns in rings, Nested KPI visualisations.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radial-stacked",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radial-stacked.tsx",
+          "path": "components/registry/n2-primitives/chart-radial-stacked.tsx",
+          "target": "components/blocks/charts/chart-radial-stacked.tsx",
           "type": "registry:block"
         }
       ],
@@ -5605,7 +5725,8 @@
       "docs": "Use it for: Radial chart with text in center, KPI rings with central value, Progress charts with metric label, Dashboard gauges with numeric display, Donut-style KPI cards.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-radial-text",
       "files": [
         {
-          "path": "components/blocks/charts/chart-radial-text.tsx",
+          "path": "components/registry/n2-primitives/chart-radial-text.tsx",
+          "target": "components/blocks/charts/chart-radial-text.tsx",
           "type": "registry:block"
         }
       ],
@@ -5652,7 +5773,8 @@
       "docs": "Use it for: Rich tooltip with multiple data points, Cross-series tooltip displays, Detailed hover analytics, Executive dashboards with rich hover, Complex multi-metric tooltips.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-tooltip-advanced",
       "files": [
         {
-          "path": "components/blocks/charts/chart-tooltip-advanced.tsx",
+          "path": "components/registry/n2-primitives/chart-tooltip-advanced.tsx",
+          "target": "components/blocks/charts/chart-tooltip-advanced.tsx",
           "type": "registry:block"
         }
       ],
@@ -5699,7 +5821,8 @@
       "docs": "Use it for: Default chart tooltip behaviour, Hover detail for any chart, Baseline tooltip for dashboards, Simple value-on-hover displays, Universal chart hover primitive.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-tooltip-default",
       "files": [
         {
-          "path": "components/blocks/charts/chart-tooltip-default.tsx",
+          "path": "components/registry/n2-primitives/chart-tooltip-default.tsx",
+          "target": "components/blocks/charts/chart-tooltip-default.tsx",
           "type": "registry:block"
         }
       ],
@@ -5746,7 +5869,8 @@
       "docs": "Use it for: Formatted-value tooltip (abbreviated, rounded, unit-appended), Locale-aware number formatting in tooltips, Business-formatted metric displays, Engineering tooltip with unit conversion, Analytics with formatted hover values.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-tooltip-formatter",
       "files": [
         {
-          "path": "components/blocks/charts/chart-tooltip-formatter.tsx",
+          "path": "components/registry/n2-primitives/chart-tooltip-formatter.tsx",
+          "target": "components/blocks/charts/chart-tooltip-formatter.tsx",
           "type": "registry:block"
         }
       ],
@@ -5793,7 +5917,8 @@
       "docs": "Use it for: Chart tooltips with category icons, Visual-rich hover detail, Brand-consistent tooltip displays, Icon-enhanced chart hover, Design-polished tooltip variants.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-tooltip-icons",
       "files": [
         {
-          "path": "components/blocks/charts/chart-tooltip-icons.tsx",
+          "path": "components/registry/n2-primitives/chart-tooltip-icons.tsx",
+          "target": "components/blocks/charts/chart-tooltip-icons.tsx",
           "type": "registry:block"
         }
       ],
@@ -5840,7 +5965,8 @@
       "docs": "Use it for: Chart tooltip with line indicator, Precise-reading tooltip displays, Engineering dashboards with line-pointing, Dense chart hover with alignment guides, Measurement-focused tooltips.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-tooltip-indicator-line",
       "files": [
         {
-          "path": "components/blocks/charts/chart-tooltip-indicator-line.tsx",
+          "path": "components/registry/n2-primitives/chart-tooltip-indicator-line.tsx",
+          "target": "components/blocks/charts/chart-tooltip-indicator-line.tsx",
           "type": "registry:block"
         }
       ],
@@ -5887,7 +6013,8 @@
       "docs": "Use it for: Minimal tooltip without indicator, Clean hover displays, Aesthetic-forward tooltips, Design-focused chart displays, Uncluttered hover experiences.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-tooltip-indicator-none",
       "files": [
         {
-          "path": "components/blocks/charts/chart-tooltip-indicator-none.tsx",
+          "path": "components/registry/n2-primitives/chart-tooltip-indicator-none.tsx",
+          "target": "components/blocks/charts/chart-tooltip-indicator-none.tsx",
           "type": "registry:block"
         }
       ],
@@ -5934,7 +6061,8 @@
       "docs": "Use it for: Custom-label tooltip formatting, Domain-specific tooltip text, Brand-consistent hover labels, Specialised metric tooltips, Localised chart hover displays.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-tooltip-label-custom",
       "files": [
         {
-          "path": "components/blocks/charts/chart-tooltip-label-custom.tsx",
+          "path": "components/registry/n2-primitives/chart-tooltip-label-custom.tsx",
+          "target": "components/blocks/charts/chart-tooltip-label-custom.tsx",
           "type": "registry:block"
         }
       ],
@@ -5981,7 +6109,8 @@
       "docs": "Use it for: Formatted-label tooltip (dates, currencies, percentages), Locale-aware chart tooltips, Domain-formatted tooltip labels, Currency-formatted value displays, Date-formatted time-series tooltips.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-tooltip-label-formatter",
       "files": [
         {
-          "path": "components/blocks/charts/chart-tooltip-label-formatter.tsx",
+          "path": "components/registry/n2-primitives/chart-tooltip-label-formatter.tsx",
+          "target": "components/blocks/charts/chart-tooltip-label-formatter.tsx",
           "type": "registry:block"
         }
       ],
@@ -6028,7 +6157,8 @@
       "docs": "Use it for: Tooltip without label (values only), Minimalist hover detail, Data-focused tooltips, Value-first chart displays, Clean numerical hover.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chart-tooltip-label-none",
       "files": [
         {
-          "path": "components/blocks/charts/chart-tooltip-label-none.tsx",
+          "path": "components/registry/n2-primitives/chart-tooltip-label-none.tsx",
+          "target": "components/blocks/charts/chart-tooltip-label-none.tsx",
           "type": "registry:block"
         }
       ],
@@ -6074,7 +6204,8 @@
       "docs": "Use it for: Mukoko chat message display with sent/received distinction, Comment replies in social feed threads, Customer support conversation history, AI assistant response display, Group chat messages with sender avatar and status.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chat-bubble",
       "files": [
         {
-          "path": "components/ui/chat-bubble.tsx",
+          "path": "components/registry/n2-primitives/chat-bubble.tsx",
+          "target": "components/ui/chat-bubble.tsx",
           "type": "registry:ui"
         }
       ],
@@ -6118,7 +6249,8 @@
       "docs": "Use it for: Chat message composition in Mukoko messaging, Comment composer below posts and articles, Support ticket reply composer, AI prompt entry with attachment support, Reply composer in threaded discussions.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chat-input",
       "files": [
         {
-          "path": "components/ui/chat-input.tsx",
+          "path": "components/registry/n2-primitives/chat-input.tsx",
+          "target": "components/ui/chat-input.tsx",
           "type": "registry:ui"
         }
       ],
@@ -6163,7 +6295,8 @@
       "docs": "Use it for: Full-screen chat pages in Mukoko, Customer support chat interfaces, Team messaging application layouts, AI assistant chat pages with conversation history, Group chat with channels and direct messages.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chat-layout",
       "files": [
         {
-          "path": "components/ui/chat-layout.tsx",
+          "path": "components/registry/n2-primitives/chat-layout.tsx",
+          "target": "components/ui/chat-layout.tsx",
           "type": "registry:ui"
         }
       ],
@@ -6204,7 +6337,8 @@
       "docs": "Use it for: Conversations sidebar in chat layouts, Recent chats list with unread indicators, Customer support inbox display, Message thread navigation with active highlight, AI conversation history browser.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chat-list",
       "files": [
         {
-          "path": "components/ui/chat-list.tsx",
+          "path": "components/registry/n2-primitives/chat-list.tsx",
+          "target": "components/ui/chat-list.tsx",
           "type": "registry:ui"
         }
       ],
@@ -6249,7 +6383,8 @@
       "docs": "Use it for: campfire, circles.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/chat-page",
       "files": [
         {
-          "path": "components/ui/chat-page.tsx",
+          "path": "components/registry/n6-pages/chat-page.tsx",
+          "target": "components/ui/chat-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -6296,7 +6431,8 @@
       "docs": "Use it for: Form consent checkboxes (terms, privacy), Multi-select filter groups, Task completion tracking, Feature flag opt-ins, Batch-select tables with bulk actions.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/checkbox",
       "files": [
         {
-          "path": "components/ui/checkbox.tsx",
+          "path": "components/registry/n2-primitives/checkbox.tsx",
+          "target": "components/ui/checkbox.tsx",
           "type": "registry:ui"
         }
       ],
@@ -6341,7 +6477,8 @@
       "docs": "Use it for: Onboarding setup checklists, Task lists for project management, Shopping lists in grocery and retail apps, Pre-flight checklists in compliance workflows, Personal to-do lists with reorder support.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/checklist",
       "files": [
         {
-          "path": "components/ui/checklist.tsx",
+          "path": "components/registry/n2-primitives/checklist.tsx",
+          "target": "components/ui/checklist.tsx",
           "type": "registry:ui"
         }
       ],
@@ -6385,7 +6522,8 @@
       "docs": "Use it for: nhimbe, bushtrade.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/checkout-page",
       "files": [
         {
-          "path": "components/ui/checkout-page.tsx",
+          "path": "components/registry/n6-pages/checkout-page.tsx",
+          "target": "components/ui/checkout-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -6429,7 +6567,8 @@
       "docs": "Use it for: Protecting calls to third-party APIs that may fail, Guarding payment gateway calls during outages, Preventing cascade failures when a service is degraded, AI service call protection during model outages, Fallback coordination during dependency failures.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/circuit-breaker",
       "files": [
         {
-          "path": "lib/circuit-breaker.ts",
+          "path": "components/registry/n2-primitives/circuit-breaker.ts",
+          "target": "lib/circuit-breaker.ts",
           "type": "registry:lib"
         }
       ],
@@ -6473,7 +6612,8 @@
       "docs": "Use it for: novels.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/co-author-strip",
       "files": [
         {
-          "path": "components/ui/co-author-strip.tsx",
+          "path": "components/registry/n2-primitives/co-author-strip.tsx",
+          "target": "components/ui/co-author-strip.tsx",
           "type": "registry:ui"
         }
       ],
@@ -6516,7 +6656,8 @@
       "docs": "Use it for: Code samples in documentation pages, API response examples in developer docs, Tutorial code snippets with syntax highlighting, Error log display with line numbers, Configuration examples in setup guides.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/code-block",
       "files": [
         {
-          "path": "components/ui/code-block.tsx",
+          "path": "components/registry/n2-primitives/code-block.tsx",
+          "target": "components/ui/code-block.tsx",
           "type": "registry:ui"
         }
       ],
@@ -6560,7 +6701,8 @@
       "docs": "Use it for: Code input fields in developer tools, Configuration editor for YAML/JSON/env files, Script input in automation interfaces, Query editor for analytics and SQL, Template editor with syntax awareness.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/code-editor",
       "files": [
         {
-          "path": "components/ui/code-editor.tsx",
+          "path": "components/registry/n2-primitives/code-editor.tsx",
+          "target": "components/ui/code-editor.tsx",
           "type": "registry:ui"
         }
       ],
@@ -6604,7 +6746,8 @@
       "docs": "Use it for: Multi-language code examples in docs (JS/Python/Go), Framework-specific component usage examples, Before/after code comparison in migration guides, Client SDK examples across platforms, Request/response pair examples.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/code-tabs",
       "files": [
         {
-          "path": "components/ui/code-tabs.tsx",
+          "path": "components/registry/n2-primitives/code-tabs.tsx",
+          "target": "components/ui/code-tabs.tsx",
           "type": "registry:ui"
         }
       ],
@@ -6649,7 +6792,8 @@
       "docs": "Use it for: Expandable filter sections, Show-more/show-less text blocks, Collapsible sidebar groups, Expandable content cards, Progressive disclosure in long forms.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/collapsible",
       "files": [
         {
-          "path": "components/ui/collapsible.tsx",
+          "path": "components/registry/n2-primitives/collapsible.tsx",
+          "target": "components/ui/collapsible.tsx",
           "type": "registry:ui"
         }
       ],
@@ -6691,7 +6835,8 @@
       "docs": "Use it for: Theme customization in settings, Design tool color pickers, Brand color selection in admin interfaces, Calendar event color assignment, Tag color selection.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/color-picker",
       "files": [
         {
-          "path": "components/ui/color-picker.tsx",
+          "path": "components/registry/n2-primitives/color-picker.tsx",
+          "target": "components/ui/color-picker.tsx",
           "type": "registry:ui"
         }
       ],
@@ -6739,7 +6884,8 @@
       "docs": "Use it for: Searchable dropdowns with typeahead, Command palette-style navigation, Tag and label selection with autocomplete, Location picker with search, Country and region selection.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/combobox",
       "files": [
         {
-          "path": "components/ui/combobox.tsx",
+          "path": "components/registry/n2-primitives/combobox.tsx",
+          "target": "components/ui/combobox.tsx",
           "type": "registry:ui"
         }
       ],
@@ -6790,7 +6936,8 @@
       "docs": "Use it for: Command palette for power-user navigation, Global search in enterprise tools, Quick action launcher (Cmd+K), Keyboard-first navigation interface, Search-as-you-type across data types.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/command",
       "files": [
         {
-          "path": "components/ui/command.tsx",
+          "path": "components/registry/n2-primitives/command.tsx",
+          "target": "components/ui/command.tsx",
           "type": "registry:ui"
         }
       ],
@@ -6836,7 +6983,8 @@
       "docs": "Use it for: Global command palette (Cmd+K / Ctrl+K), Power-user quick-action launcher, Cross-app search and navigation, Keyboard-first productivity surface, Unified search across data types.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/command-center",
       "files": [
         {
-          "path": "components/blocks/command-center.tsx",
+          "path": "components/registry/n2-primitives/command-center.tsx",
+          "target": "components/blocks/command-center.tsx",
           "type": "registry:block"
         }
       ],
@@ -6882,7 +7030,8 @@
       "docs": "Use it for: news, novels.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/comment-on-paragraph",
       "files": [
         {
-          "path": "components/ui/comment-on-paragraph.tsx",
+          "path": "components/registry/n2-primitives/comment-on-paragraph.tsx",
+          "target": "components/ui/comment-on-paragraph.tsx",
           "type": "registry:ui"
         }
       ],
@@ -6927,7 +7076,8 @@
       "docs": "Use it for: Comments section below articles and posts, Code review threaded discussions, Product review conversations, Community Q&A with nested responses, Moderated discussion threads.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/comment-thread",
       "files": [
         {
-          "path": "components/ui/comment-thread.tsx",
+          "path": "components/registry/n2-primitives/comment-thread.tsx",
+          "target": "components/ui/comment-thread.tsx",
           "type": "registry:ui"
         }
       ],
@@ -6971,7 +7121,8 @@
       "docs": "Use it for: console.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/console-dashboard-page",
       "files": [
         {
-          "path": "components/ui/console-dashboard-page.tsx",
+          "path": "components/registry/n6-pages/console-dashboard-page.tsx",
+          "target": "components/ui/console-dashboard-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7014,7 +7165,8 @@
       "docs": "Use it for: Directory entries in contact management, Event attendee info cards, Sales CRM contact display, Business card sharing in networking apps, Emergency contact quick-access cards.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/contact-card",
       "files": [
         {
-          "path": "components/ui/contact-card.tsx",
+          "path": "components/registry/n2-primitives/contact-card.tsx",
+          "target": "components/ui/contact-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7057,7 +7209,8 @@
       "docs": "Use it for: news, console.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/content-calendar",
       "files": [
         {
-          "path": "components/ui/content-calendar.tsx",
+          "path": "components/registry/n2-primitives/content-calendar.tsx",
+          "target": "components/ui/content-calendar.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7103,7 +7256,8 @@
       "docs": "Use it for: Right-click contextual actions in admin interfaces, File system operations (rename/delete), Board and kanban card actions, List row contextual actions, Rich-text editor cut/copy/paste menus.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/context-menu",
       "files": [
         {
-          "path": "components/ui/context-menu.tsx",
+          "path": "components/registry/n2-primitives/context-menu.tsx",
+          "target": "components/ui/context-menu.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7148,7 +7302,8 @@
       "docs": "Use it for: all.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/contrast-mode-toggle",
       "files": [
         {
-          "path": "components/ui/contrast-mode-toggle.tsx",
+          "path": "components/registry/n2-primitives/contrast-mode-toggle.tsx",
+          "target": "components/ui/contrast-mode-toggle.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7191,7 +7346,8 @@
       "docs": "Use it for: GDPR and POPIA compliance for EU and SADC markets, Initial visit cookie preference collection, Re-prompting for consent after policy changes, Analytics opt-in for privacy-conscious users, Cross-border data transfer consent.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/cookie-consent",
       "files": [
         {
-          "path": "components/ui/cookie-consent.tsx",
+          "path": "components/registry/n2-primitives/cookie-consent.tsx",
+          "target": "components/ui/cookie-consent.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7233,7 +7389,8 @@
       "docs": "Use it for: Copying API keys and tokens from developer dashboards, Copying share links from social and content pages, Copying code snippets from documentation, Copying wallet addresses in crypto contexts, Copying invite codes and referral links.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/copy-button",
       "files": [
         {
-          "path": "components/ui/copy-button.tsx",
+          "path": "components/registry/n2-primitives/copy-button.tsx",
+          "target": "components/ui/copy-button.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7280,7 +7437,8 @@
       "docs": "Use it for: wallet, bushtrade.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/currency-input",
       "files": [
         {
-          "path": "components/ui/currency-input.tsx",
+          "path": "components/registry/n2-primitives/currency-input.tsx",
+          "target": "components/ui/currency-input.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7323,7 +7481,8 @@
       "docs": "Use it for: circles.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/dao-proposal-card",
       "files": [
         {
-          "path": "components/ui/dao-proposal-card.tsx",
+          "path": "components/registry/n2-primitives/dao-proposal-card.tsx",
+          "target": "components/ui/dao-proposal-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7370,7 +7529,8 @@
       "docs": "Use it for: Admin dashboard home pages, Analytics overview pages, Project status dashboards, KPI monitoring surfaces, Executive summary views.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/dashboard-01",
       "files": [
         {
-          "path": "components/blocks/dashboard-01.tsx",
+          "path": "components/registry/n2-primitives/dashboard-01.tsx",
+          "target": "components/blocks/dashboard-01.tsx",
           "type": "registry:block"
         }
       ],
@@ -7420,7 +7580,8 @@
       "docs": "Use it for: shamwari, console.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/data-explorer-page",
       "files": [
         {
-          "path": "components/ui/data-explorer-page.tsx",
+          "path": "components/registry/n6-pages/data-explorer-page.tsx",
+          "target": "components/ui/data-explorer-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7466,7 +7627,8 @@
       "docs": "Use it for: Admin user management tables, Content management with sorting and filtering, Analytics data exploration, Order and transaction management, Large dataset browsing with pagination.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/data-table",
       "files": [
         {
-          "path": "components/ui/data-table.tsx",
+          "path": "components/registry/n2-primitives/data-table.tsx",
+          "target": "components/ui/data-table.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7516,7 +7678,8 @@
       "docs": "Use it for: all.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/date-label",
       "files": [
         {
-          "path": "components/ui/date-label.tsx",
+          "path": "components/registry/n2-primitives/date-label.tsx",
+          "target": "components/ui/date-label.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7558,7 +7721,8 @@
       "docs": "Use it for: Date of birth input, Appointment booking date selection, Deadline setting in task management, Event date selection, Report filtering by date.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/date-picker",
       "files": [
         {
-          "path": "components/ui/date-picker.tsx",
+          "path": "components/registry/n2-primitives/date-picker.tsx",
+          "target": "components/ui/date-picker.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7608,7 +7772,8 @@
       "docs": "Use it for: Analytics time range selection (last 7 days), Booking date range for travel and accommodation, Report period selection (month/quarter), Leave request start and end date, Campaign active period configuration.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/date-range-picker",
       "files": [
         {
-          "path": "components/ui/date-range-picker.tsx",
+          "path": "components/registry/n2-primitives/date-range-picker.tsx",
+          "target": "components/ui/date-range-picker.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7653,7 +7818,8 @@
       "docs": "Use it for: planner, console.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/dependency-graph",
       "files": [
         {
-          "path": "components/ui/dependency-graph.tsx",
+          "path": "components/registry/n2-primitives/dependency-graph.tsx",
+          "target": "components/ui/dependency-graph.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7692,7 +7858,8 @@
       "docs": "Use it for: console.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/deployment-status-card",
       "files": [
         {
-          "path": "components/ui/deployment-status-card.tsx",
+          "path": "components/registry/n2-primitives/deployment-status-card.tsx",
+          "target": "components/ui/deployment-status-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7736,7 +7903,8 @@
       "docs": "Use it for: Product specification displays, Settings summary views, Profile detail displays, Order detail metadata, Key-value data presentation with semantic markup.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/description-list",
       "files": [
         {
-          "path": "components/ui/description-list.tsx",
+          "path": "components/registry/n2-primitives/description-list.tsx",
+          "target": "components/ui/description-list.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7783,7 +7951,8 @@
       "docs": "Use it for: Forms that block the underlying page, Confirmation and detail modals, Media viewer overlays, Login and signup modal flows, Settings and preferences modal editors.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/dialog",
       "files": [
         {
-          "path": "components/ui/dialog.tsx",
+          "path": "components/registry/n2-primitives/dialog.tsx",
+          "target": "components/ui/dialog.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7832,7 +8001,8 @@
       "docs": "Use it for: Setting RTL text direction for Arabic, Hebrew, Persian, Urdu users, Wrapping locale-specific page sections, Application-level direction provider, Enabling bidi-aware text flow in long-form content, Direction switching in locale settings.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/direction",
       "files": [
         {
-          "path": "components/ui/direction.tsx",
+          "path": "components/registry/n2-primitives/direction.tsx",
+          "target": "components/ui/direction.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7874,7 +8044,8 @@
       "docs": "Use it for: Drag-to-reorder list items (tasks, playlists, kanban cards), Reordering table rows in admin interfaces, Moving panels in customizable dashboards, Reordering form fields in form builders, Tab reordering in multi-tab editors.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/drag-handle",
       "files": [
         {
-          "path": "components/ui/drag-handle.tsx",
+          "path": "components/registry/n2-primitives/drag-handle.tsx",
+          "target": "components/ui/drag-handle.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7921,7 +8092,8 @@
       "docs": "Use it for: Mobile navigation drawer, Details panel sliding from edges, Cart drawer in e-commerce, Notification panel, Filter panel in mobile search.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/drawer",
       "files": [
         {
-          "path": "components/ui/drawer.tsx",
+          "path": "components/registry/n2-primitives/drawer.tsx",
+          "target": "components/ui/drawer.tsx",
           "type": "registry:ui"
         }
       ],
@@ -7962,7 +8134,8 @@
       "docs": "Use it for: transport.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/driver-profile-card",
       "files": [
         {
-          "path": "components/ui/driver-profile-card.tsx",
+          "path": "components/registry/n2-primitives/driver-profile-card.tsx",
+          "target": "components/ui/driver-profile-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8010,7 +8183,8 @@
       "docs": "Use it for: Contextual action menus triggered by button, User profile menu in headers, Actions menu on list items, Sort and filter menus, Settings quick menus.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/dropdown-menu",
       "files": [
         {
-          "path": "components/ui/dropdown-menu.tsx",
+          "path": "components/registry/n2-primitives/dropdown-menu.tsx",
+          "target": "components/ui/dropdown-menu.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8057,7 +8231,8 @@
       "docs": "Use it for: Empty inbox and notification states, No search results found displays, Empty list and table states, Getting-started prompts on fresh accounts, Error fallback states with recovery actions.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/empty",
       "files": [
         {
-          "path": "components/ui/empty.tsx",
+          "path": "components/registry/n2-primitives/empty.tsx",
+          "target": "components/ui/empty.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8101,7 +8276,8 @@
       "docs": "Use it for: Generic empty-state primitive for layer-3 composition, Low-level empty state for unbranded contexts, Placeholder for data-loading states before first result, Foundation for branded empty state variants, Admin panel empty list displays.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/empty-state",
       "files": [
         {
-          "path": "components/blocks/empty-state.tsx",
+          "path": "components/registry/n2-primitives/empty-state.tsx",
+          "target": "components/blocks/empty-state.tsx",
           "type": "registry:block"
         }
       ],
@@ -8148,7 +8324,8 @@
       "docs": "Use it for: REST API endpoint listing in API reference, Webhook endpoint configuration display, GraphQL query explorer endpoint display, Integration API documentation, Server endpoint admin dashboard.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/endpoint-card",
       "files": [
         {
-          "path": "components/ui/endpoint-card.tsx",
+          "path": "components/registry/n2-primitives/endpoint-card.tsx",
+          "target": "components/ui/endpoint-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8192,7 +8369,8 @@
       "docs": "Use it for: Environment variable editor in admin panels, Secret configuration with masked values, Feature flag overrides in development environments, API key management interface, Deployment configuration editor.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/env-editor",
       "files": [
         {
-          "path": "components/ui/env-editor.tsx",
+          "path": "components/registry/n2-primitives/env-editor.tsx",
+          "target": "components/ui/env-editor.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8236,7 +8414,8 @@
       "docs": "Use it for: Error handling, Graceful degradation, Offline support.\nVariants: default, degraded, error.\nIncludes: Y-axis resilience spine, Netflix resilience patterns.\nAccessibility: Error states announced to screen readers, Retry actions keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/error-boundary",
       "files": [
         {
-          "path": "components/error-boundary.tsx",
+          "path": "components/registry/n5-resilience/error-boundary.tsx",
+          "target": "components/error-boundary.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8280,7 +8459,8 @@
       "docs": "Use it for: Error handling, Graceful degradation, Offline support.\nVariants: default, degraded, error.\nIncludes: Y-axis resilience spine, Netflix resilience patterns.\nAccessibility: Error states announced to screen readers, Retry actions keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/error-page",
       "files": [
         {
-          "path": "components/blocks/error-page.tsx",
+          "path": "components/registry/n5-resilience/error-page.tsx",
+          "target": "components/blocks/error-page.tsx",
           "type": "registry:block"
         }
       ],
@@ -8324,7 +8504,8 @@
       "docs": "Use it for: bushtrade.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/escrow-status",
       "files": [
         {
-          "path": "components/ui/escrow-status.tsx",
+          "path": "components/registry/n2-primitives/escrow-status.tsx",
+          "target": "components/ui/escrow-status.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8368,7 +8549,8 @@
       "docs": "Use it for: nhimbe, planner.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/event-block",
       "files": [
         {
-          "path": "components/ui/event-block.tsx",
+          "path": "components/registry/n2-primitives/event-block.tsx",
+          "target": "components/ui/event-block.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8409,7 +8591,8 @@
       "docs": "Use it for: campfire, nhimbe.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/event-rsvp-inline",
       "files": [
         {
-          "path": "components/ui/event-rsvp-inline.tsx",
+          "path": "components/registry/n2-primitives/event-rsvp-inline.tsx",
+          "target": "components/ui/event-rsvp-inline.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8454,7 +8637,8 @@
       "docs": "Use it for: wallet, bushtrade.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/exchange-rate",
       "files": [
         {
-          "path": "components/ui/exchange-rate.tsx",
+          "path": "components/registry/n2-primitives/exchange-rate.tsx",
+          "target": "components/ui/exchange-rate.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8496,7 +8680,8 @@
       "docs": "Use it for: Degraded-mode content delivery (full → cache → placeholder), Multi-source data retrieval with fallbacks, Weather data with primary and backup providers, Payment processing with backup gateway, Translation with fallback language models.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/fallback-chain",
       "files": [
         {
-          "path": "lib/fallback-chain.ts",
+          "path": "components/registry/n2-primitives/fallback-chain.ts",
+          "target": "lib/fallback-chain.ts",
           "type": "registry:lib"
         }
       ],
@@ -8540,7 +8725,8 @@
       "docs": "Use it for: transport.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/fare-calculator",
       "files": [
         {
-          "path": "components/ui/fare-calculator.tsx",
+          "path": "components/registry/n2-primitives/fare-calculator.tsx",
+          "target": "components/ui/fare-calculator.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8582,7 +8768,8 @@
       "docs": "Use it for: console.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/feature-flag-toggle",
       "files": [
         {
-          "path": "components/ui/feature-flag-toggle.tsx",
+          "path": "components/registry/n2-primitives/feature-flag-toggle.tsx",
+          "target": "components/ui/feature-flag-toggle.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8628,7 +8815,8 @@
       "docs": "Use it for: Form field wrapper with label and error, Consistent form layout across registration flows, Settings form fields with descriptions, Profile editing form fields, Admin configuration form fields.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/field",
       "files": [
         {
-          "path": "components/ui/field.tsx",
+          "path": "components/registry/n2-primitives/field.tsx",
+          "target": "components/ui/field.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8676,7 +8864,8 @@
       "docs": "Use it for: Uploaded document preview in forms, Email attachment display, Media library file browser entries, Cloud storage file preview cards, Code review file change indicators.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/file-preview",
       "files": [
         {
-          "path": "components/ui/file-preview.tsx",
+          "path": "components/registry/n2-primitives/file-preview.tsx",
+          "target": "components/ui/file-preview.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8719,7 +8908,8 @@
       "docs": "Use it for: Profile picture upload, Document submission forms (KYC, verification), Media uploads in content creation flows, Bulk import for admin interfaces, Attachment upload in messaging and email.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/file-upload",
       "files": [
         {
-          "path": "components/ui/file-upload.tsx",
+          "path": "components/registry/n2-primitives/file-upload.tsx",
+          "target": "components/ui/file-upload.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8766,7 +8956,8 @@
       "docs": "Use it for: Search result filtering with active indicators, Marketplace listing filters, Inbox and feed filtering, Analytics dashboard filter bar, Content library category filters.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/filter-bar",
       "files": [
         {
-          "path": "components/ui/filter-bar.tsx",
+          "path": "components/registry/n2-primitives/filter-bar.tsx",
+          "target": "components/ui/filter-bar.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8814,7 +9005,8 @@
       "docs": "Use it for: novels, news.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/font-settings-panel",
       "files": [
         {
-          "path": "components/ui/font-settings-panel.tsx",
+          "path": "components/registry/n2-primitives/font-settings-panel.tsx",
+          "target": "components/ui/font-settings-panel.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8864,7 +9056,8 @@
       "docs": "Use it for: Multi-field registration forms, Settings pages with validation, Checkout forms with structured fields, KYC and identity verification forms, Complex business data entry forms.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/form",
       "files": [
         {
-          "path": "components/ui/form.tsx",
+          "path": "components/registry/n2-primitives/form.tsx",
+          "target": "components/ui/form.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8909,7 +9102,8 @@
       "docs": "Use it for: wallet.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/gas-estimator",
       "files": [
         {
-          "path": "components/ui/gas-estimator.tsx",
+          "path": "components/registry/n2-primitives/gas-estimator.tsx",
+          "target": "components/ui/gas-estimator.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8949,7 +9143,8 @@
       "docs": "Use it for: circles.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/group-info-card",
       "files": [
         {
-          "path": "components/ui/group-info-card.tsx",
+          "path": "components/registry/n2-primitives/group-info-card.tsx",
+          "target": "components/ui/group-info-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -8993,7 +9188,8 @@
       "docs": "Use it for: health.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/health-dashboard-page",
       "files": [
         {
-          "path": "components/ui/health-dashboard-page.tsx",
+          "path": "components/registry/n6-pages/health-dashboard-page.tsx",
+          "target": "components/ui/health-dashboard-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9036,7 +9232,8 @@
       "docs": "Use it for: health.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/health-record-summary",
       "files": [
         {
-          "path": "components/ui/health-record-summary.tsx",
+          "path": "components/registry/n2-primitives/health-record-summary.tsx",
+          "target": "components/ui/health-record-summary.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9078,7 +9275,8 @@
       "docs": "Use it for: pulse, circles, bytes.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/horizontal-scroll",
       "files": [
         {
-          "path": "components/ui/horizontal-scroll.tsx",
+          "path": "components/registry/n2-primitives/horizontal-scroll.tsx",
+          "target": "components/ui/horizontal-scroll.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9123,7 +9321,8 @@
       "docs": "Use it for: User profile previews on hover, Link destination previews, Product quick-view cards, Tag and category info previews, Rich-media preview on hover.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/hover-card",
       "files": [
         {
-          "path": "components/ui/hover-card.tsx",
+          "path": "components/registry/n2-primitives/hover-card.tsx",
+          "target": "components/ui/hover-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9165,7 +9364,8 @@
       "docs": "Use it for: pulse, shamwari, campfire, circles, bytes.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/individual-profile-page",
       "files": [
         {
-          "path": "components/ui/individual-profile-page.tsx",
+          "path": "components/registry/n6-pages/individual-profile-page.tsx",
+          "target": "components/ui/individual-profile-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9212,7 +9412,8 @@
       "docs": "Use it for: Social feed endless scrolling, Search results lazy-load, Comments and thread lazy-load, Image gallery progressive loading, Product catalog infinite scroll.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/infinite-scroll",
       "files": [
         {
-          "path": "components/ui/infinite-scroll.tsx",
+          "path": "components/registry/n2-primitives/infinite-scroll.tsx",
+          "target": "components/ui/infinite-scroll.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9255,7 +9456,8 @@
       "docs": "Use it for: nhimbe, wallet, places.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/info-row",
       "files": [
         {
-          "path": "components/ui/info-row.tsx",
+          "path": "components/registry/n2-primitives/info-row.tsx",
+          "target": "components/ui/info-row.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9299,7 +9501,8 @@
       "docs": "Use it for: console.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/infrastructure-page",
       "files": [
         {
-          "path": "components/ui/infrastructure-page.tsx",
+          "path": "components/registry/n6-pages/infrastructure-page.tsx",
+          "target": "components/ui/infrastructure-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9342,7 +9545,8 @@
       "docs": "Use it for: Editable table cells (admin tables), Profile field editing, Task title editing in kanban cards, Settings value editing, Inline note and comment editing.\nVariants: text, textarea, select, number.\nIncludes: Click to activate editing, Escape to revert, Enter to save, Blur to save (configurable), Optimistic save with rollback, Validation per field type.\nAccessibility: Initial display role=button with edit hint, Edit mode exposes role=textbox, Save/cancel announced to screen reader, Keyboard shortcuts labelled, Focus returned to display after save/cancel.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/inline-edit",
       "files": [
         {
-          "path": "components/ui/inline-edit.tsx",
+          "path": "components/registry/n2-primitives/inline-edit.tsx",
+          "target": "components/ui/inline-edit.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9395,7 +9599,8 @@
       "docs": "Use it for: Text input for usernames, emails, and short text, Search bar base input, Profile field editing, Form field for any short text data, Inline editable field foundation.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/input",
       "files": [
         {
-          "path": "components/ui/input.tsx",
+          "path": "components/registry/n2-primitives/input.tsx",
+          "target": "components/ui/input.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9439,7 +9644,8 @@
       "docs": "Use it for: Search input with button suffix, Currency input with unit prefix, Input with inline copy button, URL input with protocol prefix, Input with icon decorations.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/input-group",
       "files": [
         {
-          "path": "components/ui/input-group.tsx",
+          "path": "components/registry/n2-primitives/input-group.tsx",
+          "target": "components/ui/input-group.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9491,7 +9697,8 @@
       "docs": "Use it for: Two-factor authentication code entry, Phone number verification codes, Email verification codes, PIN entry for secure actions, Magic link verification codes.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/input-otp",
       "files": [
         {
-          "path": "components/ui/input-otp.tsx",
+          "path": "components/registry/n2-primitives/input-otp.tsx",
+          "target": "components/ui/input-otp.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9535,7 +9742,8 @@
       "docs": "Use it for: circles, nhimbe.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/invite-link",
       "files": [
         {
-          "path": "components/ui/invite-link.tsx",
+          "path": "components/registry/n2-primitives/invite-link.tsx",
+          "target": "components/ui/invite-link.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9577,7 +9785,8 @@
       "docs": "Use it for: Billing history in account settings, Invoice line display in admin panel, Payment record with downloadable PDF, Subscription billing cycle history, Refund and credit note display.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/invoice-row",
       "files": [
         {
-          "path": "components/ui/invoice-row.tsx",
+          "path": "components/registry/n2-primitives/invoice-row.tsx",
+          "target": "components/ui/invoice-row.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9624,7 +9833,8 @@
       "docs": "Use it for: Settings list items with label and control, Menu list items in dropdowns, Row items in data lists, Flexible list building block, Selection list entries.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/item",
       "files": [
         {
-          "path": "components/ui/item.tsx",
+          "path": "components/registry/n2-primitives/item.tsx",
+          "target": "components/ui/item.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9672,7 +9882,8 @@
       "docs": "Use it for: planner, transport.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/itinerary-timeline",
       "files": [
         {
-          "path": "components/ui/itinerary-timeline.tsx",
+          "path": "components/registry/n2-primitives/itinerary-timeline.tsx",
+          "target": "components/ui/itinerary-timeline.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9717,7 +9928,8 @@
       "docs": "Use it for: jobs.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/job-board-page",
       "files": [
         {
-          "path": "components/ui/job-board-page.tsx",
+          "path": "components/registry/n6-pages/job-board-page.tsx",
+          "target": "components/ui/job-board-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9760,7 +9972,8 @@
       "docs": "Use it for: API response inspection in developer tools, Configuration file previews, Debug data visualization, Schema exploration in admin interfaces, Webhook payload inspection.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/json-viewer",
       "files": [
         {
-          "path": "components/ui/json-viewer.tsx",
+          "path": "components/registry/n2-primitives/json-viewer.tsx",
+          "target": "components/ui/json-viewer.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9804,7 +10017,8 @@
       "docs": "Use it for: Task management boards (Trello-style), Content pipeline visualization, Sales opportunity tracking, Applicant tracking boards, Project status swim lanes.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/kanban-board",
       "files": [
         {
-          "path": "components/ui/kanban-board.tsx",
+          "path": "components/registry/n2-primitives/kanban-board.tsx",
+          "target": "components/ui/kanban-board.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9848,7 +10062,8 @@
       "docs": "Use it for: Showing keyboard shortcuts in command palettes, Help documentation with keystroke references, Tutorial overlays teaching keyboard navigation, Tooltip hints for power-user shortcuts, Accessibility-focused keyboard reference panels.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/kbd",
       "files": [
         {
-          "path": "components/ui/kbd.tsx",
+          "path": "components/registry/n2-primitives/kbd.tsx",
+          "target": "components/ui/kbd.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9891,7 +10106,8 @@
       "docs": "Use it for: nhimbe, news, console.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/kpi-card",
       "files": [
         {
-          "path": "components/ui/kpi-card.tsx",
+          "path": "components/registry/n2-primitives/kpi-card.tsx",
+          "target": "components/ui/kpi-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9933,7 +10149,8 @@
       "docs": "Use it for: Form field labels, Accessible association between label and control, Required-field indicators, Floating and static label patterns, Visually hidden labels for screen-reader-only contexts.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/label",
       "files": [
         {
-          "path": "components/ui/label.tsx",
+          "path": "components/registry/n2-primitives/label.tsx",
+          "target": "components/ui/label.tsx",
           "type": "registry:ui"
         }
       ],
@@ -9975,7 +10192,8 @@
       "docs": "Use it for: all.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/language-switcher",
       "files": [
         {
-          "path": "components/ui/language-switcher.tsx",
+          "path": "components/registry/n2-primitives/language-switcher.tsx",
+          "target": "components/ui/language-switcher.tsx",
           "type": "registry:ui"
         }
       ],
@@ -10019,7 +10237,8 @@
       "docs": "Use it for: Chart-heavy dashboards on mobile (mukoko-weather pattern), Feed pages with multiple heavy sections, Long-form content with embedded media, Image-heavy galleries with staggered loading, Any mobile surface with multiple Canvas/WebGL contexts.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/lazy-section",
       "files": [
         {
-          "path": "components/lazy-section.tsx",
+          "path": "components/registry/n2-primitives/lazy-section.tsx",
+          "target": "components/lazy-section.tsx",
           "type": "registry:ui"
         }
       ],
@@ -10064,7 +10283,8 @@
       "docs": "Use it for: shamwari, lingo.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/learning-page",
       "files": [
         {
-          "path": "components/ui/learning-page.tsx",
+          "path": "components/registry/n6-pages/learning-page.tsx",
+          "target": "components/ui/learning-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -10108,7 +10328,8 @@
       "docs": "Use it for: Gallery and photo viewer in media apps, Product image viewer with zoom, Document page-by-page viewer, Full-screen image detail in marketplace listings, Screenshot walkthroughs in onboarding.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/lightbox",
       "files": [
         {
-          "path": "components/ui/lightbox.tsx",
+          "path": "components/registry/n2-primitives/lightbox.tsx",
+          "target": "components/ui/lightbox.tsx",
           "type": "registry:ui"
         }
       ],
@@ -10152,7 +10373,8 @@
       "docs": "Use it for: nhimbe, places, bushtrade.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/location-picker",
       "files": [
         {
-          "path": "components/ui/location-picker.tsx",
+          "path": "components/registry/n2-primitives/location-picker.tsx",
+          "target": "components/ui/location-picker.tsx",
           "type": "registry:ui"
         }
       ],
@@ -10197,7 +10419,8 @@
       "docs": "Use it for: campfire, places, transport.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/location-share",
       "files": [
         {
-          "path": "components/ui/location-share.tsx",
+          "path": "components/registry/n2-primitives/location-share.tsx",
+          "target": "components/ui/location-share.tsx",
           "type": "registry:ui"
         }
       ],
@@ -10242,7 +10465,8 @@
       "docs": "Use it for: Application log streaming in developer console, Error log investigation with filtering, Audit trail display with severity indicators, Deployment log viewer with auto-scroll, Real-time server log monitoring.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/log-viewer",
       "files": [
         {
-          "path": "components/ui/log-viewer.tsx",
+          "path": "components/registry/n2-primitives/log-viewer.tsx",
+          "target": "components/ui/log-viewer.tsx",
           "type": "registry:ui"
         }
       ],
@@ -10284,7 +10508,8 @@
       "docs": "Use it for: Authentication flow, Login/signup entry point.\nVariants: default, loading.\nAccessibility: Form labels, Keyboard navigation, Error announcements, Focus-visible via L1 global CSS.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/login-01",
       "files": [
         {
-          "path": "components/blocks/login-01.tsx",
+          "path": "components/registry/n6-pages/login-01.tsx",
+          "target": "components/blocks/login-01.tsx",
           "type": "registry:block"
         }
       ],
@@ -10328,7 +10553,8 @@
       "docs": "Use it for: Authentication flow, Login/signup entry point.\nVariants: default, loading.\nAccessibility: Form labels, Keyboard navigation, Error announcements, Focus-visible via L1 global CSS.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/login-02",
       "files": [
         {
-          "path": "components/blocks/login-02.tsx",
+          "path": "components/registry/n6-pages/login-02.tsx",
+          "target": "components/blocks/login-02.tsx",
           "type": "registry:block"
         }
       ],
@@ -10372,7 +10598,8 @@
       "docs": "Use it for: Authentication flow, Login/signup entry point.\nVariants: default, loading.\nAccessibility: Form labels, Keyboard navigation, Error announcements, Focus-visible via L1 global CSS.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/login-03",
       "files": [
         {
-          "path": "components/blocks/login-03.tsx",
+          "path": "components/registry/n6-pages/login-03.tsx",
+          "target": "components/blocks/login-03.tsx",
           "type": "registry:block"
         }
       ],
@@ -10416,7 +10643,8 @@
       "docs": "Use it for: Authentication flow, Login/signup entry point.\nVariants: default, loading.\nAccessibility: Form labels, Keyboard navigation, Error announcements, Focus-visible via L1 global CSS.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/login-04",
       "files": [
         {
-          "path": "components/blocks/login-04.tsx",
+          "path": "components/registry/n6-pages/login-04.tsx",
+          "target": "components/blocks/login-04.tsx",
           "type": "registry:block"
         }
       ],
@@ -10460,7 +10688,8 @@
       "docs": "Use it for: Authentication flow, Login/signup entry point.\nVariants: default, loading.\nAccessibility: Form labels, Keyboard navigation, Error announcements, Focus-visible via L1 global CSS.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/login-05",
       "files": [
         {
-          "path": "components/blocks/login-05.tsx",
+          "path": "components/registry/n6-pages/login-05.tsx",
+          "target": "components/blocks/login-05.tsx",
           "type": "registry:block"
         }
       ],
@@ -10504,7 +10733,8 @@
       "docs": "Use it for: console.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/logs-page",
       "files": [
         {
-          "path": "components/ui/logs-page.tsx",
+          "path": "components/registry/n6-pages/logs-page.tsx",
+          "target": "components/ui/logs-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -10547,7 +10777,8 @@
       "docs": "Use it for: Scheduled maintenance windows, Emergency downtime notifications, Migration and upgrade pages, Temporary service unavailability displays, Whitelisted-only access modes during deployment.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/maintenance-page",
       "files": [
         {
-          "path": "components/ui/maintenance-page.tsx",
+          "path": "components/registry/n2-primitives/maintenance-page.tsx",
+          "target": "components/ui/maintenance-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -10588,7 +10819,8 @@
       "docs": "Use it for: nhimbe, places, bushtrade.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/map-card",
       "files": [
         {
-          "path": "components/ui/map-card.tsx",
+          "path": "components/registry/n2-primitives/map-card.tsx",
+          "target": "components/ui/map-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -10633,7 +10865,8 @@
       "docs": "Use it for: nhimbe, places, bushtrade.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/map-cluster",
       "files": [
         {
-          "path": "components/ui/map-cluster.tsx",
+          "path": "components/registry/n2-primitives/map-cluster.tsx",
+          "target": "components/ui/map-cluster.tsx",
           "type": "registry:ui"
         }
       ],
@@ -10678,7 +10911,8 @@
       "docs": "Use it for: places, transport, bushtrade.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/map-marker",
       "files": [
         {
-          "path": "components/ui/map-marker.tsx",
+          "path": "components/registry/n2-primitives/map-marker.tsx",
+          "target": "components/ui/map-marker.tsx",
           "type": "registry:ui"
         }
       ],
@@ -10723,7 +10957,8 @@
       "docs": "Use it for: planner, places, transport.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/map-page",
       "files": [
         {
-          "path": "components/ui/map-page.tsx",
+          "path": "components/registry/n6-pages/map-page.tsx",
+          "target": "components/ui/map-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -10768,7 +11003,8 @@
       "docs": "Use it for: places, transport.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/map-route",
       "files": [
         {
-          "path": "components/ui/map-route.tsx",
+          "path": "components/registry/n2-primitives/map-route.tsx",
+          "target": "components/ui/map-route.tsx",
           "type": "registry:ui"
         }
       ],
@@ -10811,7 +11047,8 @@
       "docs": "Use it for: nhimbe, places, transport.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/map-view",
       "files": [
         {
-          "path": "components/ui/map-view.tsx",
+          "path": "components/registry/n2-primitives/map-view.tsx",
+          "target": "components/ui/map-view.tsx",
           "type": "registry:ui"
         }
       ],
@@ -10854,7 +11091,8 @@
       "docs": "Use it for: Rendering LLM markdown output with Nyuchi typography, Documentation pages rendered from markdown source, AI-generated articles with themed code blocks, User-composed rich text in chat and comments, Knowledge base articles with consistent styling.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/markdown-renderer",
       "files": [
         {
-          "path": "components/ui/markdown-renderer.tsx",
+          "path": "components/registry/n2-primitives/markdown-renderer.tsx",
+          "target": "components/ui/markdown-renderer.tsx",
           "type": "registry:ui"
         }
       ],
@@ -10895,7 +11133,8 @@
       "docs": "Use it for: nhimbe, places, bushtrade.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/marketplace-page",
       "files": [
         {
-          "path": "components/ui/marketplace-page.tsx",
+          "path": "components/registry/n6-pages/marketplace-page.tsx",
+          "target": "components/ui/marketplace-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -10940,7 +11179,8 @@
       "docs": "Use it for: Pinterest-style content boards, Variable-height photo galleries, Card grids with mixed content sizes, Blog post masonry layouts, User-generated content displays.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/masonry-grid",
       "files": [
         {
-          "path": "components/ui/masonry-grid.tsx",
+          "path": "components/registry/n2-primitives/masonry-grid.tsx",
+          "target": "components/ui/masonry-grid.tsx",
           "type": "registry:ui"
         }
       ],
@@ -10981,7 +11221,8 @@
       "docs": "Use it for: bytes.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/media-filter-strip",
       "files": [
         {
-          "path": "components/ui/media-filter-strip.tsx",
+          "path": "components/registry/n2-primitives/media-filter-strip.tsx",
+          "target": "components/ui/media-filter-strip.tsx",
           "type": "registry:ui"
         }
       ],
@@ -11023,7 +11264,8 @@
       "docs": "Use it for: pulse, bytes, news.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/media-player-page",
       "files": [
         {
-          "path": "components/ui/media-player-page.tsx",
+          "path": "components/registry/n6-pages/media-player-page.tsx",
+          "target": "components/ui/media-player-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -11068,7 +11310,8 @@
       "docs": "Use it for: health.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/medication-reminder",
       "files": [
         {
-          "path": "components/ui/medication-reminder.tsx",
+          "path": "components/registry/n2-primitives/medication-reminder.tsx",
+          "target": "components/ui/medication-reminder.tsx",
           "type": "registry:ui"
         }
       ],
@@ -11113,7 +11356,8 @@
       "docs": "Use it for: Complex site navigation with multiple product areas, E-commerce category exploration menus, Enterprise application section navigation, Content-heavy website navigation, Desktop-class app feature discovery.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mega-menu",
       "files": [
         {
-          "path": "components/ui/mega-menu.tsx",
+          "path": "components/registry/n2-primitives/mega-menu.tsx",
+          "target": "components/ui/mega-menu.tsx",
           "type": "registry:ui"
         }
       ],
@@ -11160,7 +11404,8 @@
       "docs": "Use it for: circles, nhimbe.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/member-list",
       "files": [
         {
-          "path": "components/ui/member-list.tsx",
+          "path": "components/registry/n2-primitives/member-list.tsx",
+          "target": "components/ui/member-list.tsx",
           "type": "registry:ui"
         }
       ],
@@ -11206,7 +11451,8 @@
       "docs": "Use it for: campfire, circles, nhimbe.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/member-row",
       "files": [
         {
-          "path": "components/ui/member-row.tsx",
+          "path": "components/registry/n2-primitives/member-row.tsx",
+          "target": "components/ui/member-row.tsx",
           "type": "registry:ui"
         }
       ],
@@ -11247,7 +11493,8 @@
       "docs": "Use it for: Comment composition with @user mentions, Message input with team member mentions, Task assignment input with user picker, Collaborative document editing mentions, Review and approval request mentions.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mention-input",
       "files": [
         {
-          "path": "components/ui/mention-input.tsx",
+          "path": "components/registry/n2-primitives/mention-input.tsx",
+          "target": "components/ui/mention-input.tsx",
           "type": "registry:ui"
         }
       ],
@@ -11294,7 +11541,8 @@
       "docs": "Use it for: Desktop application menu bar (File/Edit/View/Help), Admin console top menu navigation, Content editor top-level actions, Professional app keyboard-first navigation, Power-user productivity tool navigation.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/menubar",
       "files": [
         {
-          "path": "components/ui/menubar.tsx",
+          "path": "components/registry/n2-primitives/menubar.tsx",
+          "target": "components/ui/menubar.tsx",
           "type": "registry:ui"
         }
       ],
@@ -11340,7 +11588,8 @@
       "docs": "Use it for: Reply threads within chat conversations, Nested replies in forum-style discussions, Email-style threaded message display, Issue comment threads with replies, Collaborative document comment chains.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/message-thread",
       "files": [
         {
-          "path": "components/ui/message-thread.tsx",
+          "path": "components/registry/n2-primitives/message-thread.tsx",
+          "target": "components/ui/message-thread.tsx",
           "type": "registry:ui"
         }
       ],
@@ -11382,7 +11631,8 @@
       "docs": "Use it for: Multi-factor authentication enrollment, Account security setup during onboarding, Re-enrollment after device change, Admin-enforced MFA setup flow, Hardware key registration.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mfa-setup",
       "files": [
         {
-          "path": "components/ui/mfa-setup.tsx",
+          "path": "components/registry/n2-primitives/mfa-setup.tsx",
+          "target": "components/ui/mfa-setup.tsx",
           "type": "registry:ui"
         }
       ],
@@ -11426,7 +11676,8 @@
       "docs": "Use it for: nhimbe, wallet, bushtrade.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mobile-money-selector",
       "files": [
         {
-          "path": "components/ui/mobile-money-selector.tsx",
+          "path": "components/registry/n2-primitives/mobile-money-selector.tsx",
+          "target": "components/ui/mobile-money-selector.tsx",
           "type": "registry:ui"
         }
       ],
@@ -11471,7 +11722,8 @@
       "docs": "Use it for: console.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/moderation-queue-item",
       "files": [
         {
-          "path": "components/ui/moderation-queue-item.tsx",
+          "path": "components/registry/n2-primitives/moderation-queue-item.tsx",
+          "target": "components/ui/moderation-queue-item.tsx",
           "type": "registry:ui"
         }
       ],
@@ -11514,7 +11766,8 @@
       "docs": "Use it for: bytes.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/music-selector",
       "files": [
         {
-          "path": "components/ui/music-selector.tsx",
+          "path": "components/registry/n2-primitives/music-selector.tsx",
+          "target": "components/ui/music-selector.tsx",
           "type": "registry:ui"
         }
       ],
@@ -11558,7 +11811,8 @@
       "docs": "Use it for: Platform monitoring, L8 assurance observability.\nVariants: default.\nIncludes: Z-axis depth observability, Cross-layer blast radius analysis via data-portal backlinks, L9 Fundi integration for auto-healing.\nAccessibility: Non-visual infrastructure — no direct a11y requirements.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-a11y-audit",
       "files": [
         {
-          "path": "lib/mzizi-a11y-audit.ts",
+          "path": "components/registry/n8-assurance/mzizi-a11y-audit.ts",
+          "target": "lib/mzizi-a11y-audit.ts",
           "type": "registry:lib"
         }
       ],
@@ -11597,7 +11851,8 @@
       "docs": "Use it for: Error handling, Graceful degradation, Offline support.\nVariants: default, degraded, error.\nIncludes: Y-axis resilience spine, Netflix resilience patterns.\nAccessibility: Error states announced to screen readers, Retry actions keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-abr-content",
       "files": [
         {
-          "path": "components/ui/mzizi-abr-content.tsx",
+          "path": "components/registry/n5-resilience/mzizi-abr-content.tsx",
+          "target": "components/ui/mzizi-abr-content.tsx",
           "type": "registry:ui"
         }
       ],
@@ -11640,7 +11895,8 @@
       "docs": "Use it for: Platform monitoring, L8 assurance observability.\nVariants: default.\nIncludes: Z-axis depth observability, Cross-layer blast radius analysis via data-portal backlinks, L9 Fundi integration for auto-healing.\nAccessibility: Non-visual infrastructure — no direct a11y requirements.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-alert-engine",
       "files": [
         {
-          "path": "lib/mzizi-alert-engine.ts",
+          "path": "components/registry/n8-assurance/mzizi-alert-engine.ts",
+          "target": "lib/mzizi-alert-engine.ts",
           "type": "registry:lib"
         }
       ],
@@ -11680,7 +11936,8 @@
       "docs": "Use it for: Platform monitoring, L8 assurance observability.\nVariants: default.\nIncludes: Z-axis depth observability, Cross-layer blast radius analysis via data-portal backlinks, L9 Fundi integration for auto-healing.\nAccessibility: Non-visual infrastructure — no direct a11y requirements.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-api-probe",
       "files": [
         {
-          "path": "lib/mzizi-api-probe.ts",
+          "path": "components/registry/n8-assurance/mzizi-api-probe.ts",
+          "target": "lib/mzizi-api-probe.ts",
           "type": "registry:lib"
         }
       ],
@@ -11719,7 +11976,8 @@
       "docs": "Use it for: Access control, Security gate, Verification check.\nVariants: allowed, blocked, loading.\nIncludes: Y-axis safety spine, Renders children when check passes, Branded explanation when blocked, Web3 integration.\nAccessibility: Screen reader announces gate state, Focus management on state change.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-chain-gate",
       "files": [
         {
-          "path": "components/ui/mzizi-chain-gate.tsx",
+          "path": "components/registry/n4-safety/mzizi-chain-gate.tsx",
+          "target": "components/ui/mzizi-chain-gate.tsx",
           "type": "registry:ui"
         }
       ],
@@ -11763,7 +12021,8 @@
       "docs": "Use it for: Error handling, Graceful degradation, Offline support.\nVariants: default, degraded, error.\nIncludes: Y-axis resilience spine, Netflix resilience patterns.\nAccessibility: Error states announced to screen readers, Retry actions keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-chain-resilience",
       "files": [
         {
-          "path": "components/ui/mzizi-chain-resilience.tsx",
+          "path": "components/registry/n5-resilience/mzizi-chain-resilience.tsx",
+          "target": "components/ui/mzizi-chain-resilience.tsx",
           "type": "registry:ui"
         }
       ],
@@ -11806,7 +12065,8 @@
       "docs": "Use it for: Test resilience of any component, Inject random errors at configurable rate, Probe blast radius of failures, Verify error boundaries work.\nVariants: injection, reactive.\nIncludes: Two modes: injection and reactive, Configurable error probability per layer, Blast radius analysis via data-portal, L9 Fundi integration comments.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-chaos",
       "files": [
         {
-          "path": "lib/mzizi-chaos.tsx",
+          "path": "components/registry/n8-assurance/mzizi-chaos.tsx",
+          "target": "lib/mzizi-chaos.tsx",
           "type": "registry:lib"
         }
       ],
@@ -11847,7 +12107,8 @@
       "docs": "Use it for: Platform monitoring, L8 assurance observability.\nVariants: default.\nIncludes: Z-axis depth observability, Cross-layer blast radius analysis via data-portal backlinks, L9 Fundi integration for auto-healing.\nAccessibility: Non-visual infrastructure — no direct a11y requirements.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-conformity-check",
       "files": [
         {
-          "path": "lib/mzizi-conformity-check.ts",
+          "path": "components/registry/n8-assurance/mzizi-conformity-check.ts",
+          "target": "lib/mzizi-conformity-check.ts",
           "type": "registry:lib"
         }
       ],
@@ -11886,7 +12147,8 @@
       "docs": "Use it for: Access control, Security gate, Verification check.\nVariants: allowed, blocked, loading.\nIncludes: Y-axis safety spine, Renders children when check passes, Branded explanation when blocked, Web2 safety gate.\nAccessibility: Screen reader announces gate state, Focus management on state change.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-content-gate",
       "files": [
         {
-          "path": "components/ui/mzizi-content-gate.tsx",
+          "path": "components/registry/n4-safety/mzizi-content-gate.tsx",
+          "target": "components/ui/mzizi-content-gate.tsx",
           "type": "registry:ui"
         }
       ],
@@ -11933,7 +12195,8 @@
       "docs": "Use it for: Error handling, Graceful degradation, Offline support.\nVariants: default, degraded, error.\nIncludes: Y-axis resilience spine, Netflix resilience patterns.\nAccessibility: Error states announced to screen readers, Retry actions keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-crypto-fallback",
       "files": [
         {
-          "path": "components/ui/mzizi-crypto-fallback.tsx",
+          "path": "components/registry/n5-resilience/mzizi-crypto-fallback.tsx",
+          "target": "components/ui/mzizi-crypto-fallback.tsx",
           "type": "registry:ui"
         }
       ],
@@ -11975,7 +12238,8 @@
       "docs": "Use it for: Access control, Security gate, Verification check.\nVariants: allowed, blocked, loading.\nIncludes: Y-axis safety spine, Renders children when check passes, Branded explanation when blocked, Post-quantum cryptography.\nAccessibility: Screen reader announces gate state, Focus management on state change.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-crypto-gate",
       "files": [
         {
-          "path": "components/ui/mzizi-crypto-gate.tsx",
+          "path": "components/registry/n4-safety/mzizi-crypto-gate.tsx",
+          "target": "components/ui/mzizi-crypto-gate.tsx",
           "type": "registry:ui"
         }
       ],
@@ -12019,7 +12283,8 @@
       "docs": "Use it for: Error handling, Graceful degradation, Offline support.\nVariants: default, degraded, error.\nIncludes: Y-axis resilience spine, Netflix resilience patterns.\nAccessibility: Error states announced to screen readers, Retry actions keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-degradation-chain",
       "files": [
         {
-          "path": "components/ui/mzizi-degradation-chain.tsx",
+          "path": "components/registry/n5-resilience/mzizi-degradation-chain.tsx",
+          "target": "components/ui/mzizi-degradation-chain.tsx",
           "type": "registry:ui"
         }
       ],
@@ -12061,7 +12326,8 @@
       "docs": "Use it for: Access control, Security gate, Verification check.\nVariants: allowed, blocked, loading.\nIncludes: Y-axis safety spine, Renders children when check passes, Branded explanation when blocked, Web2 safety gate.\nAccessibility: Screen reader announces gate state, Focus management on state change.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-did-gate",
       "files": [
         {
-          "path": "components/ui/mzizi-did-gate.tsx",
+          "path": "components/registry/n4-safety/mzizi-did-gate.tsx",
+          "target": "components/ui/mzizi-did-gate.tsx",
           "type": "registry:ui"
         }
       ],
@@ -12105,7 +12371,8 @@
       "docs": "Use it for: Error handling, Graceful degradation, Offline support.\nVariants: default, degraded, error.\nIncludes: Y-axis resilience spine, Netflix resilience patterns.\nAccessibility: Error states announced to screen readers, Retry actions keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-error-set",
       "files": [
         {
-          "path": "components/ui/mzizi-error-set.tsx",
+          "path": "components/registry/n5-resilience/mzizi-error-set.tsx",
+          "target": "components/ui/mzizi-error-set.tsx",
           "type": "registry:ui"
         }
       ],
@@ -12153,7 +12420,8 @@
       "docs": "Use it for: Catch and deduplicate errors, Enrich with component backlinks, Calculate blast radius, Report to Fundi for healing.\nIncludes: Structured error collection, Deduplication, Blast radius via data-portal attributes, L9 Fundi reporter integration, Severity classification.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-error-tracker",
       "files": [
         {
-          "path": "lib/mzizi-error-tracker.ts",
+          "path": "components/registry/n8-assurance/mzizi-error-tracker.ts",
+          "target": "lib/mzizi-error-tracker.ts",
           "type": "registry:lib"
         }
       ],
@@ -12190,7 +12458,8 @@
       "docs": "Use it for: Access control, Security gate, Verification check.\nVariants: allowed, blocked, loading.\nIncludes: Y-axis safety spine, Renders children when check passes, Branded explanation when blocked, Web2 safety gate.\nAccessibility: Screen reader announces gate state, Focus management on state change.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-feature-gate",
       "files": [
         {
-          "path": "components/ui/mzizi-feature-gate.tsx",
+          "path": "components/registry/n4-safety/mzizi-feature-gate.tsx",
+          "target": "components/ui/mzizi-feature-gate.tsx",
           "type": "registry:ui"
         }
       ],
@@ -12234,7 +12503,8 @@
       "docs": "Use it for: Access control, Security gate, Verification check.\nVariants: allowed, blocked, loading.\nIncludes: Y-axis safety spine, Renders children when check passes, Branded explanation when blocked, Web2 safety gate.\nAccessibility: Screen reader announces gate state, Focus management on state change.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-geo-gate",
       "files": [
         {
-          "path": "components/ui/mzizi-geo-gate.tsx",
+          "path": "components/registry/n4-safety/mzizi-geo-gate.tsx",
+          "target": "components/ui/mzizi-geo-gate.tsx",
           "type": "registry:ui"
         }
       ],
@@ -12279,7 +12549,8 @@
       "docs": "Use it for: Platform monitoring, L8 assurance observability.\nVariants: default.\nIncludes: Z-axis depth observability, Cross-layer blast radius analysis via data-portal backlinks, L9 Fundi integration for auto-healing.\nAccessibility: Non-visual infrastructure — no direct a11y requirements.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-incident-manager",
       "files": [
         {
-          "path": "lib/mzizi-incident-manager.ts",
+          "path": "components/registry/n8-assurance/mzizi-incident-manager.ts",
+          "target": "lib/mzizi-incident-manager.ts",
           "type": "registry:lib"
         }
       ],
@@ -12318,7 +12589,8 @@
       "docs": "Use it for: Error handling, Graceful degradation, Offline support.\nVariants: default, degraded, error.\nIncludes: Y-axis resilience spine, Netflix resilience patterns.\nAccessibility: Error states announced to screen readers, Retry actions keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-load-shedder",
       "files": [
         {
-          "path": "components/ui/mzizi-load-shedder.tsx",
+          "path": "components/registry/n5-resilience/mzizi-load-shedder.tsx",
+          "target": "components/ui/mzizi-load-shedder.tsx",
           "type": "registry:ui"
         }
       ],
@@ -12360,7 +12632,8 @@
       "docs": "Use it for: Access control, Security gate, Verification check.\nVariants: allowed, blocked, loading.\nIncludes: Y-axis safety spine, Renders children when check passes, Branded explanation when blocked, Web2 safety gate.\nAccessibility: Screen reader announces gate state, Focus management on state change.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-moderation-gate",
       "files": [
         {
-          "path": "components/ui/mzizi-moderation-gate.tsx",
+          "path": "components/registry/n4-safety/mzizi-moderation-gate.tsx",
+          "target": "components/ui/mzizi-moderation-gate.tsx",
           "type": "registry:ui"
         }
       ],
@@ -12404,7 +12677,8 @@
       "docs": "Use it for: Access control, Security gate, Verification check.\nVariants: allowed, blocked, loading.\nIncludes: Y-axis safety spine, Renders children when check passes, Branded explanation when blocked, Local-first offline support.\nAccessibility: Screen reader announces gate state, Focus management on state change.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-offline-gate",
       "files": [
         {
-          "path": "components/ui/mzizi-offline-gate.tsx",
+          "path": "components/registry/n4-safety/mzizi-offline-gate.tsx",
+          "target": "components/ui/mzizi-offline-gate.tsx",
           "type": "registry:ui"
         }
       ],
@@ -12449,7 +12723,8 @@
       "docs": "Use it for: Ship synthetic probe results to a collector, Give mzizi-rum / mzizi-error-tracker / mzizi-alert-engine a sink for their callbacks, Let other agents subscribe to Mzizi assurance events over a standard protocol, Emit assurance telemetry from a Cloudflare Worker, where the OTel JS SDK does not run.\nIncludes: OTLP/HTTP JSON traces - no @opentelemetry/* dependency, Maps the N8 ProbeResult contract to a run span plus one child span per step, Honours OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, Never throws and never changes the caller's verdict, Inert with no endpoint configured - no default collector is invented.\nAccessibility: Non-visual infrastructure - no direct a11y requirements.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-otel",
       "files": [
         {
-          "path": "lib/mzizi-otel.ts",
+          "path": "components/registry/n8-assurance/mzizi-otel.ts",
+          "target": "lib/mzizi-otel.ts",
           "type": "registry:lib"
         }
       ],
@@ -12492,7 +12767,8 @@
       "docs": "Use it for: Platform monitoring, L8 assurance observability.\nVariants: default.\nIncludes: Z-axis depth observability, Cross-layer blast radius analysis via data-portal backlinks, L9 Fundi integration for auto-healing.\nAccessibility: Non-visual infrastructure — no direct a11y requirements.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-perf-probe",
       "files": [
         {
-          "path": "lib/mzizi-perf-probe.ts",
+          "path": "components/registry/n8-assurance/mzizi-perf-probe.ts",
+          "target": "lib/mzizi-perf-probe.ts",
           "type": "registry:lib"
         }
       ],
@@ -12531,7 +12807,8 @@
       "docs": "Use it for: Gate features behind verification tier, Block posting for unverified users, Require government ID for selling, Restrict moderation to trusted users.\nIncludes: Renders children when check passes, Branded upgrade CTA when blocked, 5 verification tiers, Maps to system.verification_tier.\nAccessibility: aria-live announces gate state, Focus moves to CTA when blocked, Screen reader explains what is required.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-permission-gate",
       "files": [
         {
-          "path": "components/ui/mzizi-permission-gate.tsx",
+          "path": "components/registry/n4-safety/mzizi-permission-gate.tsx",
+          "target": "components/ui/mzizi-permission-gate.tsx",
           "type": "registry:ui"
         }
       ],
@@ -12576,7 +12853,8 @@
       "docs": "Use it for: Platform monitoring, L8 assurance observability.\nVariants: default.\nIncludes: Z-axis depth observability, Cross-layer blast radius analysis via data-portal backlinks, L9 Fundi integration for auto-healing.\nAccessibility: Non-visual infrastructure — no direct a11y requirements.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-platform-health",
       "files": [
         {
-          "path": "components/ui/mzizi-platform-health.tsx",
+          "path": "components/registry/n8-assurance/mzizi-platform-health.tsx",
+          "target": "components/ui/mzizi-platform-health.tsx",
           "type": "registry:ui"
         }
       ],
@@ -12615,7 +12893,8 @@
       "docs": "Use it for: Error handling, Graceful degradation, Offline support.\nVariants: default, degraded, error.\nIncludes: Y-axis resilience spine, Netflix resilience patterns.\nAccessibility: Error states announced to screen readers, Retry actions keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-prefetch-boundary",
       "files": [
         {
-          "path": "components/ui/mzizi-prefetch-boundary.tsx",
+          "path": "components/registry/n5-resilience/mzizi-prefetch-boundary.tsx",
+          "target": "components/ui/mzizi-prefetch-boundary.tsx",
           "type": "registry:ui"
         }
       ],
@@ -12657,7 +12936,8 @@
       "docs": "Use it for: Access control, Security gate, Verification check.\nVariants: allowed, blocked, loading.\nIncludes: Y-axis safety spine, Renders children when check passes, Branded explanation when blocked, Web2 safety gate.\nAccessibility: Screen reader announces gate state, Focus management on state change.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-rate-gate",
       "files": [
         {
-          "path": "components/ui/mzizi-rate-gate.tsx",
+          "path": "components/registry/n4-safety/mzizi-rate-gate.tsx",
+          "target": "components/ui/mzizi-rate-gate.tsx",
           "type": "registry:ui"
         }
       ],
@@ -12702,7 +12982,8 @@
       "docs": "Use it for: Platform monitoring, L8 assurance observability.\nVariants: default.\nIncludes: Z-axis depth observability, Cross-layer blast radius analysis via data-portal backlinks, L9 Fundi integration for auto-healing.\nAccessibility: Non-visual infrastructure — no direct a11y requirements.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-rum",
       "files": [
         {
-          "path": "lib/mzizi-rum.ts",
+          "path": "components/registry/n8-assurance/mzizi-rum.ts",
+          "target": "lib/mzizi-rum.ts",
           "type": "registry:lib"
         }
       ],
@@ -12741,7 +13022,8 @@
       "docs": "Use it for: Wrap every page section in resilience, Isolate failures to individual sections, Report section health to global monitor, Lazy mount heavy sections.\nVariants: default, lazy, critical.\nIncludes: Error boundary integration, Loading skeleton, Health reporting (healthy/degraded/error/loading), Optional lazy mounting, data-slot attribute, data-portal backlink.\nAccessibility: aria-busy during loading, Error state announced to screen reader, Retry button keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-section",
       "files": [
         {
-          "path": "components/ui/mzizi-section.tsx",
+          "path": "components/registry/n5-resilience/mzizi-section.tsx",
+          "target": "components/ui/mzizi-section.tsx",
           "type": "registry:ui"
         }
       ],
@@ -12794,7 +13076,8 @@
       "docs": "Use it for: Loading states for feeds, Initial page-load placeholders, Data-fetching fallbacks in dashboards, Infinite-scroll loading indicators, Search-results loading state.\nVariants: card-list, feed-item, profile-block, chart-placeholder, row-item.\nIncludes: Respects prefers-reduced-motion (no shimmer when reduced), Matches final component shape to prevent layout shift, Configurable item count for list skeletons, Mineral accent subtle even in loading state, Harness integration for observability.\nAccessibility: aria-busy=true on parent container, aria-live=polite for updates when loading completes, Screen reader silent during shimmer (decorative), Non-interactive — no focus traps.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-skeleton-set",
       "files": [
         {
-          "path": "components/ui/mzizi-skeleton-set.tsx",
+          "path": "components/registry/n5-resilience/mzizi-skeleton-set.tsx",
+          "target": "components/ui/mzizi-skeleton-set.tsx",
           "type": "registry:ui"
         }
       ],
@@ -12848,7 +13131,8 @@
       "docs": "Use it for: Error handling, Graceful degradation, Offline support.\nVariants: default, degraded, error.\nIncludes: Y-axis resilience spine, Netflix resilience patterns.\nAccessibility: Error states announced to screen readers, Retry actions keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-sync-status",
       "files": [
         {
-          "path": "components/ui/mzizi-sync-status.tsx",
+          "path": "components/registry/n5-resilience/mzizi-sync-status.tsx",
+          "target": "components/ui/mzizi-sync-status.tsx",
           "type": "registry:ui"
         }
       ],
@@ -12891,7 +13175,8 @@
       "docs": "Use it for: Platform monitoring, L8 assurance observability.\nVariants: default.\nIncludes: Z-axis depth observability, Cross-layer blast radius analysis via data-portal backlinks, L9 Fundi integration for auto-healing.\nAccessibility: Non-visual infrastructure — no direct a11y requirements.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-synthetic-probe",
       "files": [
         {
-          "path": "lib/mzizi-synthetic-probe.ts",
+          "path": "components/registry/n8-assurance/mzizi-synthetic-probe.ts",
+          "target": "lib/mzizi-synthetic-probe.ts",
           "type": "registry:lib"
         }
       ],
@@ -12930,7 +13215,8 @@
       "docs": "Use it for: Access control, Security gate, Verification check.\nVariants: allowed, blocked, loading.\nIncludes: Y-axis safety spine, Renders children when check passes, Branded explanation when blocked, Web2 safety gate.\nAccessibility: Screen reader announces gate state, Focus management on state change.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-trust-gate",
       "files": [
         {
-          "path": "components/ui/mzizi-trust-gate.tsx",
+          "path": "components/registry/n4-safety/mzizi-trust-gate.tsx",
+          "target": "components/ui/mzizi-trust-gate.tsx",
           "type": "registry:ui"
         }
       ],
@@ -12977,7 +13263,8 @@
       "docs": "Use it for: Access control, Security gate, Verification check.\nVariants: allowed, blocked, loading.\nIncludes: Y-axis safety spine, Renders children when check passes, Branded explanation when blocked, Web3 integration.\nAccessibility: Screen reader announces gate state, Focus management on state change.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-wallet-gate",
       "files": [
         {
-          "path": "components/ui/mzizi-wallet-gate.tsx",
+          "path": "components/registry/n4-safety/mzizi-wallet-gate.tsx",
+          "target": "components/ui/mzizi-wallet-gate.tsx",
           "type": "registry:ui"
         }
       ],
@@ -13021,7 +13308,8 @@
       "docs": "Use it for: Simple dropdown forms (country, language), Mobile-optimized form fields, Accessibility-preferred select in form contexts, Admin panels with native form control, Progressive-enhancement form fallbacks.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/native-select",
       "files": [
         {
-          "path": "components/ui/native-select.tsx",
+          "path": "components/registry/n2-primitives/native-select.tsx",
+          "target": "components/ui/native-select.tsx",
           "type": "registry:ui"
         }
       ],
@@ -13069,7 +13357,8 @@
       "docs": "Use it for: Primary site navigation with hover flyouts, Dropdown-enabled header menus, Multi-level category navigation, Documentation site top navigation, Marketing site navigation with submenus.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/navigation-menu",
       "files": [
         {
-          "path": "components/ui/navigation-menu.tsx",
+          "path": "components/registry/n2-primitives/navigation-menu.tsx",
+          "target": "components/ui/navigation-menu.tsx",
           "type": "registry:ui"
         }
       ],
@@ -13114,7 +13403,8 @@
       "docs": "Use it for: nhimbe, places, transport.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nearby-list",
       "files": [
         {
-          "path": "components/ui/nearby-list.tsx",
+          "path": "components/registry/n2-primitives/nearby-list.tsx",
+          "target": "components/ui/nearby-list.tsx",
           "type": "registry:ui"
         }
       ],
@@ -13160,7 +13450,8 @@
       "docs": "Use it for: novels, nhimbe, wallet.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nft-card",
       "files": [
         {
-          "path": "components/ui/nft-card.tsx",
+          "path": "components/registry/n2-primitives/nft-card.tsx",
+          "target": "components/ui/nft-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -13206,7 +13497,8 @@
       "docs": "Use it for: wallet.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/node-status-card",
       "files": [
         {
-          "path": "components/ui/node-status-card.tsx",
+          "path": "components/registry/n2-primitives/node-status-card.tsx",
+          "target": "components/ui/node-status-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -13251,7 +13543,8 @@
       "docs": "Use it for: Notes app card list, Quick notes in dashboard widgets, Meeting notes summary display, Bookmark preview cards, Article snippet previews in feeds.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/note-card",
       "files": [
         {
-          "path": "components/ui/note-card.tsx",
+          "path": "components/registry/n2-primitives/note-card.tsx",
+          "target": "components/ui/note-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -13292,7 +13585,8 @@
       "docs": "Use it for: campfire, novels, planner.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/note-editor",
       "files": [
         {
-          "path": "components/ui/note-editor.tsx",
+          "path": "components/registry/n2-primitives/note-editor.tsx",
+          "target": "components/ui/note-editor.tsx",
           "type": "registry:ui"
         }
       ],
@@ -13338,7 +13632,8 @@
       "docs": "Use it for: App header notification icon with counter, Mobile header notification access, Unread count display with popover, Primary notification entry point, Quick-glance notification summary.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/notification-bell",
       "files": [
         {
-          "path": "components/ui/notification-bell.tsx",
+          "path": "components/registry/n2-primitives/notification-bell.tsx",
+          "target": "components/ui/notification-bell.tsx",
           "type": "registry:ui"
         }
       ],
@@ -13388,7 +13683,8 @@
       "docs": "Use it for: Full notification center page or drawer, Inbox-style notification management, Mentions and replies separation, Notification preferences and filters, Archived notification browsing.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/notification-center",
       "files": [
         {
-          "path": "components/blocks/notification-center.tsx",
+          "path": "components/registry/n2-primitives/notification-center.tsx",
+          "target": "components/blocks/notification-center.tsx",
           "type": "registry:block"
         }
       ],
@@ -13439,7 +13735,8 @@
       "docs": "Use it for: Full-screen notification management, Notification drawer with filters, Grouped conversations view, Archived notification browsing, Bulk mark-as-read and delete actions.\nVariants: drawer, full-page, modal.\nIncludes: Filter by all/unread/mentions/mine, Search within notifications, Date-grouped lists (today/yesterday/this week), Bulk selection with actions, Conversation threading.\nAccessibility: role=region with aria-label, Filter tabs with role=tablist, Notification items in role=feed, Keyboard-navigable with j/k shortcuts, Screen reader announces count changes.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/notification-center-full",
       "files": [
         {
-          "path": "components/ui/notification-center-full.tsx",
+          "path": "components/registry/n2-primitives/notification-center-full.tsx",
+          "target": "components/ui/notification-center-full.tsx",
           "type": "registry:ui"
         }
       ],
@@ -13489,7 +13786,8 @@
       "docs": "Use it for: Notification drawer content, Grouped notification display (today, yesterday, last week), Mark-as-read and bulk action lists, Activity log in admin interfaces, System event listings.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/notification-list",
       "files": [
         {
-          "path": "components/ui/notification-list.tsx",
+          "path": "components/registry/n2-primitives/notification-list.tsx",
+          "target": "components/ui/notification-list.tsx",
           "type": "registry:ui"
         }
       ],
@@ -13533,7 +13831,8 @@
       "docs": "Use it for: novels.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/novel-cover",
       "files": [
         {
-          "path": "components/ui/novel-cover.tsx",
+          "path": "components/registry/n2-primitives/novel-cover.tsx",
+          "target": "components/ui/novel-cover.tsx",
           "type": "registry:ui"
         }
       ],
@@ -13577,7 +13876,8 @@
       "docs": "Use it for: Quantity input in shopping carts, Price and currency amount entry, Age input in profile forms, Pagination size selector, Numeric settings (max retries, timeout).\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/number-input",
       "files": [
         {
-          "path": "components/ui/number-input.tsx",
+          "path": "components/registry/n2-primitives/number-input.tsx",
+          "target": "components/ui/number-input.tsx",
           "type": "registry:ui"
         }
       ],
@@ -13625,7 +13925,8 @@
       "docs": "Use it for: Design token infrastructure, All layers consume L1.\nVariants: default.\nIncludes: Y-axis vertical spine, CSS custom properties, Multi-platform generators.\nAccessibility: Defines focus ring tokens, Touch target minimums, Contrast-safe pairings.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-a11y",
       "files": [
         {
-          "path": "lib/a11y/index.tsx",
+          "path": "components/registry/n1-tokens/nyuchi-a11y.tsx",
+          "target": "lib/a11y/index.tsx",
           "type": "registry:lib"
         }
       ],
@@ -13668,7 +13969,8 @@
       "docs": "Use it for: pulse, campfire, bytes, circles, novels.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-action-sheet",
       "files": [
         {
-          "path": "components/ui/nyuchi-action-sheet.tsx",
+          "path": "components/registry/n3-brand/nyuchi-action-sheet.tsx",
+          "target": "components/ui/nyuchi-action-sheet.tsx",
           "type": "registry:ui"
         }
       ],
@@ -13718,7 +14020,8 @@
       "docs": "Use it for: Documentation, AI context generation, Changelog display.\nVariants: default.\nIncludes: Layer 10 documentation infrastructure, Reads from documentation_pages + ai_instructions tables.\nAccessibility: Semantic HTML, Keyboard navigation, Screen reader compatible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-ai-context",
       "files": [
         {
-          "path": "lib/nyuchi-ai-context.ts",
+          "path": "components/registry/n10-documentation/nyuchi-ai-context.ts",
+          "target": "lib/nyuchi-ai-context.ts",
           "type": "registry:lib"
         }
       ],
@@ -13759,7 +14062,8 @@
       "docs": "Use it for: wallet, campfire, circles, transport, bushtrade.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-alert-banner",
       "files": [
         {
-          "path": "components/ui/nyuchi-alert-banner.tsx",
+          "path": "components/registry/n3-brand/nyuchi-alert-banner.tsx",
+          "target": "components/ui/nyuchi-alert-banner.tsx",
           "type": "registry:ui"
         }
       ],
@@ -13808,7 +14112,8 @@
       "docs": "Use it for: jobs.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-application-tracker",
       "files": [
         {
-          "path": "components/ui/nyuchi-application-tracker.tsx",
+          "path": "components/registry/n3-brand/nyuchi-application-tracker.tsx",
+          "target": "components/ui/nyuchi-application-tracker.tsx",
           "type": "registry:ui"
         }
       ],
@@ -13853,7 +14158,8 @@
       "docs": "Use it for: News article feeds in Mukoko News, Pulse aggregation article listings, Content discovery feeds with journalist attribution, Feature article grids with source credibility, Cross-source news aggregation displays.\nVariants: default, compact, hero.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-article-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-article-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-article-card.tsx",
+          "target": "components/ui/nyuchi-article-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -13906,7 +14212,8 @@
       "docs": "Use it for: Authenticate a user inside Claude / Claude Code via an MCP, Register a new account inline before subscribing, First step of an inline UCP checkout flow.\nVariants: login, register.\nIncludes: Inline sign-in AND registration — never a browser tab, Mode toggle between login and register, SSO / passwordless provider buttons, Drives the MCP inline-auth handoff (OAuth 2.1 / DCR / elicitation), Dynamic mineral accent via --brand-accent, Pending + error states managed internally.\nAccessibility: Focus-visible ring on all interactive elements, 48px minimum touch targets, aria-modal dialog with aria-label, role=alert for error messaging, autoComplete + inputMode on inputs, prefers-reduced-motion honoured via the harness.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-auth-card",
       "files": [
         {
-          "path": "agentic/nyuchi-auth-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-auth-card.tsx",
+          "target": "agentic/nyuchi-auth-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -13957,7 +14264,8 @@
       "docs": "Use it for: pulse, shamwari, campfire, circles, bytes.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-auth-layout",
       "files": [
         {
-          "path": "components/ui/nyuchi-auth-layout.tsx",
+          "path": "components/registry/n6-pages/nyuchi-auth-layout.tsx",
+          "target": "components/ui/nyuchi-auth-layout.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14004,7 +14312,8 @@
       "docs": "Use it for: +N going social proof on event cards (nhimbe), Attendee stack on listings, Member preview on circles / calendars.\nVariants: sm, md.\nIncludes: Overlapping ring-separated avatar stack (-space-x-2), Image or initials fallback per person, +N overflow bubble past max, Optional trailing total + label (13px muted), Server-safe presentational atom — no harness, no client directive, sm / md size scale.\nAccessibility: Decorative avatars marked aria-hidden, Group carries an accessible summary label (e.g. 128 going), Initials fallback when no image, Trailing count label mirrors the aria summary.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-avatar-stack",
       "files": [
         {
-          "path": "components/ui/nyuchi-avatar-stack.tsx",
+          "path": "components/registry/n3-brand/nyuchi-avatar-stack.tsx",
+          "target": "components/ui/nyuchi-avatar-stack.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14052,7 +14361,8 @@
       "docs": "Use it for: Profile achievement showcase, Ubuntu badge grid on user profiles, Leaderboard side-panel with top badges, Achievement notifications when badges earned, Badge galleries in community pages.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-badge-display",
       "files": [
         {
-          "path": "components/ui/nyuchi-badge-display.tsx",
+          "path": "components/registry/n3-brand/nyuchi-badge-display.tsx",
+          "target": "components/ui/nyuchi-badge-display.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14102,7 +14412,8 @@
       "docs": "Use it for: Wallet home screen hero, Mini wallet widget, Payment confirmation balance check, Transaction receipt header.\nVariants: full, compact, mini.\nIncludes: MIT currency formatting, Fiat conversion display, Quick action buttons (Send, Receive, Swap), Harness integration, Maps to wallet.balance table.\nAccessibility: aria-live for balance updates, Focus-visible on action buttons, 48px touch targets.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-balance-display",
       "files": [
         {
-          "path": "components/ui/nyuchi-balance-display.tsx",
+          "path": "components/registry/n3-brand/nyuchi-balance-display.tsx",
+          "target": "components/ui/nyuchi-balance-display.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14155,7 +14466,8 @@
       "docs": "Use it for: Mobile primary navigation across all Nyuchi apps, Bottom-tab navigation with center FAB, Mobile-first app shells, Tablet bottom navigation, Thumb-friendly nav with primary create action.\nVariants: default.\nIncludes: App shell infrastructure, Cross-layer wiring (L7→L8→L9), data-slot + data-portal DOM attributes, Harness integration.\nAccessibility: Focus-visible ring on interactive elements, ARIA attributes.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-bottom-nav",
       "files": [
         {
-          "path": "components/ui/nyuchi-bottom-nav.tsx",
+          "path": "components/registry/n7-shell/nyuchi-bottom-nav.tsx",
+          "target": "components/ui/nyuchi-bottom-nav.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14204,7 +14516,8 @@
       "docs": "Use it for: nhimbe, planner, jobs, health.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-calendar",
       "files": [
         {
-          "path": "components/ui/nyuchi-calendar.tsx",
+          "path": "components/registry/n3-brand/nyuchi-calendar.tsx",
+          "target": "components/ui/nyuchi-calendar.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14255,7 +14568,8 @@
       "docs": "Use it for: Documentation, AI context generation, Changelog display.\nVariants: default.\nIncludes: Layer 10 documentation infrastructure, Reads from documentation_pages + ai_instructions tables.\nAccessibility: Semantic HTML, Keyboard navigation, Screen reader compatible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-changelog-renderer",
       "files": [
         {
-          "path": "components/ui/nyuchi-changelog-renderer.tsx",
+          "path": "components/registry/n10-documentation/nyuchi-changelog-renderer.tsx",
+          "target": "components/ui/nyuchi-changelog-renderer.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14296,7 +14610,8 @@
       "docs": "Use it for: Global search (Cmd+K / Ctrl+K), Navigate to any page, Switch between mini-apps, Run quick actions.\nIncludes: Fuzzy search across mini-apps, Recent items, Categorized results, Keyboard navigation, Action shortcuts.\nAccessibility: role=dialog, aria-label, Keyboard trap while open, Escape to close, Arrow keys for navigation.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-command-palette",
       "files": [
         {
-          "path": "components/ui/nyuchi-command-palette.tsx",
+          "path": "components/registry/n7-shell/nyuchi-command-palette.tsx",
+          "target": "components/ui/nyuchi-command-palette.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14340,7 +14655,8 @@
       "docs": "Use it for: planner, transport.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-commute-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-commute-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-commute-card.tsx",
+          "target": "components/ui/nyuchi-commute-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14385,7 +14701,8 @@
       "docs": "Use it for: pulse, shamwari, campfire, circles, bytes.\nVariants: default.\nIncludes: App shell infrastructure, Cross-layer wiring (L7→L8→L9), data-slot + data-portal DOM attributes, Harness integration.\nAccessibility: Focus-visible ring on interactive elements, ARIA role, ARIA attributes.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-connectivity-bar",
       "files": [
         {
-          "path": "components/ui/nyuchi-connectivity-bar.tsx",
+          "path": "components/registry/n7-shell/nyuchi-connectivity-bar.tsx",
+          "target": "components/ui/nyuchi-connectivity-bar.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14430,7 +14747,8 @@
       "docs": "Use it for: pulse, campfire, bytes, circles, novels.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-content-composer",
       "files": [
         {
-          "path": "components/ui/nyuchi-content-composer.tsx",
+          "path": "components/registry/n3-brand/nyuchi-content-composer.tsx",
+          "target": "components/ui/nyuchi-content-composer.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14480,7 +14798,8 @@
       "docs": "Use it for: campfire, circles.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-conversation-row",
       "files": [
         {
-          "path": "components/ui/nyuchi-conversation-row.tsx",
+          "path": "components/registry/n3-brand/nyuchi-conversation-row.tsx",
+          "target": "components/ui/nyuchi-conversation-row.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14526,7 +14845,8 @@
       "docs": "Use it for: pulse, jobs, campfire, bytes, circles.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-cover-header",
       "files": [
         {
-          "path": "components/ui/nyuchi-cover-header.tsx",
+          "path": "components/registry/n3-brand/nyuchi-cover-header.tsx",
+          "target": "components/ui/nyuchi-cover-header.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14571,7 +14891,8 @@
       "docs": "Use it for: Event detail page header (nhimbe), Any detail page that tints itself from a cover mineral, Campaign / landing hero that seeds a wash context.\nVariants: image, gradient.\nIncludes: 4.2.0 cover-wash signature — seeds --event-primary + --wash on the root, Full-bleed image or gradient cover with legibility scrim, Accent from prop or mineral, --brand-accent neutral default, Inline meta row (date / location / host) + CTA slot via children, Harness-wired reduced-motion entry + observability.\nAccessibility: Decorative cover image + scrim marked aria-hidden, CTA slot keeps its own focus semantics, Reduced-motion respected via harness, Serif title over a legibility scrim for contrast.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-cover-wash-header",
       "files": [
         {
-          "path": "components/ui/nyuchi-cover-wash-header.tsx",
+          "path": "components/registry/n3-brand/nyuchi-cover-wash-header.tsx",
+          "target": "components/ui/nyuchi-cover-wash-header.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14620,7 +14941,8 @@
       "docs": "Use it for: Event creation in Nhimbe, Product creation in Bush Trade, News article authoring in Mukoko News, Place submission in Mukoko Places, Any create/edit flow across the super app.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-create-listing",
       "files": [
         {
-          "path": "components/ui/nyuchi-create-listing.tsx",
+          "path": "components/registry/n3-brand/nyuchi-create-listing.tsx",
+          "target": "components/ui/nyuchi-create-listing.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14675,7 +14997,8 @@
       "docs": "Use it for: campfire, bytes, circles, novels, nhimbe.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-create-page",
       "files": [
         {
-          "path": "components/ui/nyuchi-create-page.tsx",
+          "path": "components/registry/n6-pages/nyuchi-create-page.tsx",
+          "target": "components/ui/nyuchi-create-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14726,7 +15049,8 @@
       "docs": "Use it for: Professional credential display in Nyuchi Medical, Qualification showcases on profiles, Verified practitioner directories, Credential verification workflows, Regulatory compliance displays.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-credential-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-credential-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-credential-card.tsx",
+          "target": "components/ui/nyuchi-credential-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14776,7 +15100,8 @@
       "docs": "Use it for: Full app shell for Nyuchi ecosystem apps, Standard dashboard composition with header, sidebar, bottom nav, Responsive app layout across mobile and desktop, Primary app page structure, Base layout for admin, analytics, and dashboard apps.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-dashboard-layout",
       "files": [
         {
-          "path": "components/ui/nyuchi-dashboard-layout.tsx",
+          "path": "components/registry/n6-pages/nyuchi-dashboard-layout.tsx",
+          "target": "components/ui/nyuchi-dashboard-layout.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14830,7 +15155,8 @@
       "docs": "Use it for: Design token infrastructure, All layers consume L1.\nVariants: default.\nIncludes: Y-axis vertical spine, CSS custom properties, Multi-platform generators.\nAccessibility: Defines focus ring tokens, Touch target minimums, Contrast-safe pairings.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-data",
       "files": [
         {
-          "path": "lib/data/index.tsx",
+          "path": "components/registry/n1-tokens/nyuchi-data.tsx",
+          "target": "lib/data/index.tsx",
           "type": "registry:lib"
         }
       ],
@@ -14876,7 +15202,8 @@
       "docs": "Use it for: pulse, shamwari, campfire, circles, bytes.\nVariants: default.\nIncludes: App shell infrastructure, Cross-layer wiring (L7→L8→L9), data-slot + data-portal DOM attributes, Harness integration.\nAccessibility: Focus-visible ring on interactive elements.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-deep-link-handler",
       "files": [
         {
-          "path": "components/ui/nyuchi-deep-link-handler.tsx",
+          "path": "components/registry/n7-shell/nyuchi-deep-link-handler.tsx",
+          "target": "components/ui/nyuchi-deep-link-handler.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14919,7 +15246,8 @@
       "docs": "Use it for: Event detail pages in Nhimbe, Article detail pages in Mukoko News, Product detail pages in Bush Trade, Place detail pages in Mukoko Places, Universal detail page composition across verticals.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-detail-layout",
       "files": [
         {
-          "path": "components/ui/nyuchi-detail-layout.tsx",
+          "path": "components/registry/n6-pages/nyuchi-detail-layout.tsx",
+          "target": "components/ui/nyuchi-detail-layout.tsx",
           "type": "registry:ui"
         }
       ],
@@ -14972,7 +15300,8 @@
       "docs": "Use it for: pulse, bytes, circles, novels, nhimbe.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-detail-page",
       "files": [
         {
-          "path": "components/ui/nyuchi-detail-page.tsx",
+          "path": "components/registry/n6-pages/nyuchi-detail-page.tsx",
+          "target": "components/ui/nyuchi-detail-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -15025,7 +15354,8 @@
       "docs": "Use it for: Documentation, AI context generation, Changelog display.\nVariants: default.\nIncludes: N10 documentation infrastructure, Deno edge-function runtime, Reads documentation + ai_instructions content over PostgREST.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-docs-api",
       "files": [
         {
-          "path": "lib/nyuchi-docs-api.ts",
+          "path": "components/registry/n10-documentation/nyuchi-docs-api.ts",
+          "target": "lib/nyuchi-docs-api.ts",
           "type": "registry:lib"
         }
       ],
@@ -15063,7 +15393,8 @@
       "docs": "Use it for: Render documentation pages from DB, Sidebar navigation with search, Markdown content rendering, Version-aware documentation.\nIncludes: Reads from documentation_pages table, Category-based navigation, Search across all docs, Responsive sidebar layout.\nAccessibility: role=main on content area, aria-label on navigation, Focus-visible on sidebar links, Search input has aria-label.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-docs-engine",
       "files": [
         {
-          "path": "components/ui/nyuchi-docs-engine.tsx",
+          "path": "components/registry/n10-documentation/nyuchi-docs-engine.tsx",
+          "target": "components/ui/nyuchi-docs-engine.tsx",
           "type": "registry:ui"
         }
       ],
@@ -15106,7 +15437,8 @@
       "docs": "Use it for: Design token infrastructure, All layers consume L1.\nVariants: default.\nIncludes: Y-axis vertical spine, CSS custom properties, Multi-platform generators.\nAccessibility: Defines focus ring tokens, Touch target minimums, Contrast-safe pairings.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-dx",
       "files": [
         {
-          "path": "lib/dx/index.ts",
+          "path": "components/registry/n1-tokens/nyuchi-dx.ts",
+          "target": "lib/dx/index.ts",
           "type": "registry:lib"
         }
       ],
@@ -15149,7 +15481,8 @@
       "docs": "Use it for: pulse, shamwari, campfire, circles, bytes.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-empty-screen",
       "files": [
         {
-          "path": "components/ui/nyuchi-empty-screen.tsx",
+          "path": "components/registry/n6-pages/nyuchi-empty-screen.tsx",
+          "target": "components/ui/nyuchi-empty-screen.tsx",
           "type": "registry:ui"
         }
       ],
@@ -15196,7 +15529,8 @@
       "docs": "Use it for: pulse, campfire, circles, bytes, novels.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-empty-state",
       "files": [
         {
-          "path": "components/ui/nyuchi-empty-state.tsx",
+          "path": "components/registry/n3-brand/nyuchi-empty-state.tsx",
+          "target": "components/ui/nyuchi-empty-state.tsx",
           "type": "registry:ui"
         }
       ],
@@ -15244,7 +15578,8 @@
       "docs": "Use it for: pulse, shamwari, campfire, circles, bytes.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-error-screen",
       "files": [
         {
-          "path": "components/ui/nyuchi-error-screen.tsx",
+          "path": "components/registry/n6-pages/nyuchi-error-screen.tsx",
+          "target": "components/ui/nyuchi-error-screen.tsx",
           "type": "registry:ui"
         }
       ],
@@ -15292,7 +15627,8 @@
       "docs": "Use it for: Merchant requires a choice mid-checkout (delivery slot, add-on), Disambiguate before the agent resumes the automated flow.\nVariants: default.\nIncludes: UCP ECP \"requires escalation\" mini-card, Generic agent-needs-a-choice surface, Per-option label + description, async-safe pending state, Dynamic mineral accent via --brand-accent.\nAccessibility: role=group with aria-label, 48px minimum touch target per option, focus-visible ring on each option, prefers-reduced-motion honoured via the harness.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-escalation-card",
       "files": [
         {
-          "path": "agentic/nyuchi-escalation-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-escalation-card.tsx",
+          "target": "agentic/nyuchi-escalation-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -15339,7 +15675,8 @@
       "docs": "Use it for: Event listings in Nhimbe (meetups, gatherings, ceremonies), Upcoming shows and performances, Calendar agenda items with location, RSVP-driven community events, Ticketed events with date and price.\nVariants: default, compact, hero, agenda-row.\nIncludes: Date and time display with locale formatting, Location with map link, RSVP button slot, Mineral accent per event category, Harness integration (log, motion, LiveRegion), animStyle with prefersReduced.\nAccessibility: role=article, aria-label with event title and date, Focus-visible ring, 48px minimum touch target, Screen reader announces title, date, location, RSVP count, Time elements use datetime attribute for assistive tech.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-event-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-event-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-event-card.tsx",
+          "target": "components/ui/nyuchi-event-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -15394,7 +15731,8 @@
       "docs": "Use it for: Homepage hero spotlight, Editorial feature promotion, Curated recommendations in Mukoko feed, Sponsored placements (clearly marked), Onboarding first-use discovery surfaces.\nVariants: hero, spotlight, banner, split.\nIncludes: Larger mineral accent than standard listing card, Full-bleed media support, Optional category badge, Meta row with stats (views, reactions), Harness integration (log, motion, LiveRegion), animStyle with prefersReduced.\nAccessibility: role=article with aria-label, Focus-visible ring on entire card, 48px minimum touch target, Screen reader announces featured status and title, Media has descriptive alt text.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-featured-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-featured-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-featured-card.tsx",
+          "target": "components/ui/nyuchi-featured-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -15448,7 +15786,8 @@
       "docs": "Use it for: pulse, bytes, circles, novels, nhimbe.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-feed-page",
       "files": [
         {
-          "path": "components/ui/nyuchi-feed-page.tsx",
+          "path": "components/registry/n6-pages/nyuchi-feed-page.tsx",
+          "target": "components/ui/nyuchi-feed-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -15503,7 +15842,8 @@
       "docs": "Use it for: App footer across all Nyuchi ecosystem apps, Standardized copyright and links surface, Mineral-colored ecosystem identity strip, Legal and utility links container, Bottom-of-page branding.\nVariants: default.\nIncludes: App shell infrastructure, Cross-layer wiring (L7→L8→L9), data-slot + data-portal DOM attributes, Harness integration.\nAccessibility: Focus-visible ring on interactive elements, ARIA role, ARIA attributes.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-footer",
       "files": [
         {
-          "path": "components/ui/nyuchi-footer.tsx",
+          "path": "components/registry/n7-shell/nyuchi-footer.tsx",
+          "target": "components/ui/nyuchi-footer.tsx",
           "type": "registry:ui"
         }
       ],
@@ -15551,7 +15891,8 @@
       "docs": "Use it for: weather.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-forecast-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-forecast-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-forecast-card.tsx",
+          "target": "components/ui/nyuchi-forecast-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -15595,7 +15936,8 @@
       "docs": "Use it for: Client-side healing decisions, Wrap app in FundiProvider, Auto-heal or escalate to human, Server-side healing via edge function.\nIncludes: Decision engine with 6 rules, Dual client/server architecture, GitHub issue integration, Healing plan creation, Human-in-the-loop via GitHub.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-fundi",
       "files": [
         {
-          "path": "lib/nyuchi-fundi.tsx",
+          "path": "components/registry/n9-fundi/nyuchi-fundi.tsx",
+          "target": "lib/nyuchi-fundi.tsx",
           "type": "registry:lib"
         }
       ],
@@ -15632,7 +15974,8 @@
       "docs": "Use it for: Self-healing, GitHub issue tracking, Healing plan generation.\nVariants: default.\nIncludes: Outside actor — operates via GitHub Issues, Human-in-the-loop healing workflow, DB persistence via fundi_issues table.\nAccessibility: Non-visual infrastructure — no direct a11y requirements.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-fundi-learning",
       "files": [
         {
-          "path": "lib/nyuchi-fundi-learning.ts",
+          "path": "components/registry/n9-fundi/nyuchi-fundi-learning.ts",
+          "target": "lib/nyuchi-fundi-learning.ts",
           "type": "registry:lib"
         }
       ],
@@ -15672,7 +16015,8 @@
       "docs": "Use it for: Bridge L8 failures to GitHub, Create structured GitHub issues, Trigger fundi-webhook edge function, Rate limit to prevent spam.\nIncludes: Structured issue body with portal links, fundi: label system, Cooldown rate limiting (5 min default), Two modes: direct GitHub API or edge function, Blast radius in issue body.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-fundi-reporter",
       "files": [
         {
-          "path": "lib/nyuchi-fundi-reporter.ts",
+          "path": "components/registry/n9-fundi/nyuchi-fundi-reporter.ts",
+          "target": "lib/nyuchi-fundi-reporter.ts",
           "type": "registry:lib"
         }
       ],
@@ -15709,7 +16053,8 @@
       "docs": "Use it for: planner, lingo, wallet, transport, weather.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-gauge-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-gauge-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-gauge-card.tsx",
+          "target": "components/ui/nyuchi-gauge-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -15759,7 +16104,8 @@
       "docs": "Use it for: pulse, shamwari, campfire, circles, bytes.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-grid",
       "files": [
         {
-          "path": "components/ui/nyuchi-grid.tsx",
+          "path": "components/registry/n6-pages/nyuchi-grid.tsx",
+          "target": "components/ui/nyuchi-grid.tsx",
           "type": "registry:ui"
         }
       ],
@@ -15806,7 +16152,8 @@
       "docs": "Use it for: campfire, circles, nhimbe, lingo, bushtrade.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-group-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-group-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-group-card.tsx",
+          "target": "components/ui/nyuchi-group-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -15855,7 +16202,8 @@
       "docs": "Use it for: cn() classname composition across all layers, Shared utility functions for formatting, Tailwind class merging helpers, Common type predicates and guards, Universal helpers imported everywhere.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-harness",
       "files": [
         {
-          "path": "lib/harness/index.tsx",
+          "path": "components/registry/n3-brand/nyuchi-harness.tsx",
+          "target": "lib/harness/index.tsx",
           "type": "registry:lib"
         }
       ],
@@ -15898,7 +16246,8 @@
       "docs": "Use it for: Design token infrastructure, All layers consume L1.\nVariants: default.\nIncludes: Y-axis vertical spine, CSS custom properties, Multi-platform generators.\nAccessibility: Defines focus ring tokens, Touch target minimums, Contrast-safe pairings.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-harness-prewire",
       "files": [
         {
-          "path": "lib/harness/index.tsx",
+          "path": "components/registry/n1-tokens/nyuchi-harness-prewire.tsx",
+          "target": "lib/harness/index.tsx",
           "type": "registry:lib"
         }
       ],
@@ -15946,7 +16295,8 @@
       "docs": "Use it for: App header across all Nyuchi ecosystem apps, Desktop nav with responsive mobile pill actions, Primary brand identity header, Shared navigation bar with per-app accent colour, Sticky header with brand-aware controls.\nVariants: default.\nIncludes: App shell infrastructure, Cross-layer wiring (L7→L8→L9), data-slot + data-portal DOM attributes, Harness integration.\nAccessibility: Focus-visible ring on interactive elements, ARIA attributes.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-header",
       "files": [
         {
-          "path": "components/ui/nyuchi-header.tsx",
+          "path": "components/registry/n7-shell/nyuchi-header.tsx",
+          "target": "components/ui/nyuchi-header.tsx",
           "type": "registry:ui"
         }
       ],
@@ -15994,7 +16344,8 @@
       "docs": "Use it for: health.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-health-dashboard",
       "files": [
         {
-          "path": "components/ui/nyuchi-health-dashboard.tsx",
+          "path": "components/registry/n3-brand/nyuchi-health-dashboard.tsx",
+          "target": "components/ui/nyuchi-health-dashboard.tsx",
           "type": "registry:ui"
         }
       ],
@@ -16042,7 +16393,8 @@
       "docs": "Use it for: jobs, wallet, transport, bushtrade, weather.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-hero-stat",
       "files": [
         {
-          "path": "components/ui/nyuchi-hero-stat.tsx",
+          "path": "components/registry/n3-brand/nyuchi-hero-stat.tsx",
+          "target": "components/ui/nyuchi-hero-stat.tsx",
           "type": "registry:ui"
         }
       ],
@@ -16092,7 +16444,8 @@
       "docs": "Use it for: Central icon registry for all components, Semantic icon naming (icon-success vs CheckCircle), Custom brand icons (MukokoLogo, MineralStrip), Size system: xs(16), sm(20), md(24), lg(32), xl(40).\nSizes: xs, sm, md, lg, xl.\nIncludes: 120+ Lucide re-exports, Semantic aliases, Icon component with name prop, MukokoLogo brand mark, MineralStrip color bar, Tree-shaking optimized.\nAccessibility: aria-hidden on decorative icons, role=img with aria-label on meaningful icons.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-icons",
       "files": [
         {
-          "path": "lib/nyuchi-icons/index.tsx",
+          "path": "components/registry/n1-tokens/nyuchi-icons.tsx",
+          "target": "lib/nyuchi-icons/index.tsx",
           "type": "registry:lib"
         }
       ],
@@ -16141,7 +16494,8 @@
       "docs": "Use it for: pulse, jobs.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes, I18N via Intl formatters.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-job-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-job-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-job-card.tsx",
+          "target": "components/ui/nyuchi-job-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -16189,7 +16543,8 @@
       "docs": "Use it for: Design token infrastructure, All layers consume L1.\nVariants: default.\nIncludes: Y-axis vertical spine, CSS custom properties, Multi-platform generators.\nAccessibility: Defines focus ring tokens, Touch target minimums, Contrast-safe pairings.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-layout",
       "files": [
         {
-          "path": "lib/layout/index.tsx",
+          "path": "components/registry/n1-tokens/nyuchi-layout.tsx",
+          "target": "lib/layout/index.tsx",
           "type": "registry:lib"
         }
       ],
@@ -16232,7 +16587,8 @@
       "docs": "Use it for: Community Ubuntu point leaderboards, Competition and challenge rankings, Top contributor displays, Weekly and monthly leaderboards, Group and circle ranking views.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-leaderboard-row",
       "files": [
         {
-          "path": "components/ui/nyuchi-leaderboard-row.tsx",
+          "path": "components/registry/n3-brand/nyuchi-leaderboard-row.tsx",
+          "target": "components/ui/nyuchi-leaderboard-row.tsx",
           "type": "registry:ui"
         }
       ],
@@ -16281,7 +16637,8 @@
       "docs": "Use it for: lingo.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-lesson-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-lesson-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-lesson-card.tsx",
+          "target": "components/ui/nyuchi-lesson-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -16328,7 +16685,8 @@
       "docs": "Use it for: Event listings (Nhimbe), Product listings (BushTrade), News articles (News), Place listings (Places), Job listings (Jobs).\nVariants: row, compact, hero.\nIncludes: Mineral-colored category accent, Harness integration (log, motion, LiveRegion), animStyle with prefersReduced, Verified badge slot, Mini-app aware mineral accent.\nAccessibility: role=article, aria-label with title, Focus-visible ring, 48px minimum touch target, Screen reader announces category and title.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-listing-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-listing-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-listing-card.tsx",
+          "target": "components/ui/nyuchi-listing-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -16384,7 +16742,8 @@
       "docs": "Use it for: Design token infrastructure, All layers consume L1.\nVariants: default.\nIncludes: Y-axis vertical spine, CSS custom properties, Multi-platform generators.\nAccessibility: Defines focus ring tokens, Touch target minimums, Contrast-safe pairings.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-locale",
       "files": [
         {
-          "path": "lib/locale/index.tsx",
+          "path": "components/registry/n1-tokens/nyuchi-locale.tsx",
+          "target": "lib/locale/index.tsx",
           "type": "registry:lib"
         }
       ],
@@ -16429,7 +16788,8 @@
       "docs": "Use it for: pulse, campfire, circles, bytes, novels.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-media",
       "files": [
         {
-          "path": "components/ui/nyuchi-media.tsx",
+          "path": "components/registry/n3-brand/nyuchi-media.tsx",
+          "target": "components/ui/nyuchi-media.tsx",
           "type": "registry:ui"
         }
       ],
@@ -16480,7 +16840,8 @@
       "docs": "Use it for: shamwari, campfire, circles.\nVariants: default, compact, hero.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-message-bubble",
       "files": [
         {
-          "path": "components/ui/nyuchi-message-bubble.tsx",
+          "path": "components/registry/n3-brand/nyuchi-message-bubble.tsx",
+          "target": "components/ui/nyuchi-message-bubble.tsx",
           "type": "registry:ui"
         }
       ],
@@ -16529,7 +16890,8 @@
       "docs": "Use it for: Event detail When / Where rows (nhimbe), Place card location line (Places), Listing date anchor across the super app.\nVariants: icon, date.\nIncludes: 4.2.0 date/location signature pattern, Server-safe — no client directive, renders in RSC, 13px muted metadata / 16px bold primary, Brand-accent chip tint (--brand-accent), color-mix surface, Icon-chip or month-over-day date-chip modes.\nAccessibility: Decorative chip marked aria-hidden, Truncating single-line primary/secondary, Semantic top-to-bottom reading order.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-meta-tile",
       "files": [
         {
-          "path": "components/ui/nyuchi-meta-tile.tsx",
+          "path": "components/registry/n3-brand/nyuchi-meta-tile.tsx",
+          "target": "components/ui/nyuchi-meta-tile.tsx",
           "type": "registry:ui"
         }
       ],
@@ -16573,7 +16935,8 @@
       "docs": "Use it for: pulse, shamwari, campfire, circles, bytes.\nVariants: default.\nIncludes: App shell infrastructure, Cross-layer wiring (L7→L8→L9), data-slot + data-portal DOM attributes, Harness integration.\nAccessibility: Focus-visible ring on interactive elements, ARIA role, ARIA attributes.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-mini-app-runtime",
       "files": [
         {
-          "path": "components/ui/nyuchi-mini-app-runtime.tsx",
+          "path": "components/registry/n7-shell/nyuchi-mini-app-runtime.tsx",
+          "target": "components/ui/nyuchi-mini-app-runtime.tsx",
           "type": "registry:ui"
         }
       ],
@@ -16618,7 +16981,8 @@
       "docs": "Use it for: Ubuntu gamification quest displays, Community contribution challenges, Onboarding mission tracking, Achievement-driven user engagement, Structured challenge surfaces.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-mission-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-mission-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-mission-card.tsx",
+          "target": "components/ui/nyuchi-mission-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -16669,7 +17033,8 @@
       "docs": "Use it for: Design token infrastructure, All layers consume L1.\nVariants: default.\nIncludes: Y-axis vertical spine, CSS custom properties, Multi-platform generators.\nAccessibility: Defines focus ring tokens, Touch target minimums, Contrast-safe pairings.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-motion",
       "files": [
         {
-          "path": "lib/motion/index.tsx",
+          "path": "components/registry/n1-tokens/nyuchi-motion.tsx",
+          "target": "lib/motion/index.tsx",
           "type": "registry:lib"
         }
       ],
@@ -16712,7 +17077,8 @@
       "docs": "Use it for: pulse, shamwari, campfire, circles, bytes.\nVariants: default.\nIncludes: App shell infrastructure, Cross-layer wiring (L7→L8→L9), data-slot + data-portal DOM attributes, Harness integration.\nAccessibility: Focus-visible ring on interactive elements, ARIA role, ARIA attributes.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-notification-center",
       "files": [
         {
-          "path": "components/ui/nyuchi-notification-center.tsx",
+          "path": "components/registry/n7-shell/nyuchi-notification-center.tsx",
+          "target": "components/ui/nyuchi-notification-center.tsx",
           "type": "registry:ui"
         }
       ],
@@ -16757,7 +17123,8 @@
       "docs": "Use it for: pulse, campfire, circles, nhimbe, wallet.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-notification-item",
       "files": [
         {
-          "path": "components/ui/nyuchi-notification-item.tsx",
+          "path": "components/registry/n3-brand/nyuchi-notification-item.tsx",
+          "target": "components/ui/nyuchi-notification-item.tsx",
           "type": "registry:ui"
         }
       ],
@@ -16806,7 +17173,8 @@
       "docs": "Use it for: Bush Trade marketplace product cards, Commerce listing grids, Deal and offer displays, Seller marketplace listings, Inquiry-driven commerce interfaces.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes, I18N via Intl formatters.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-offer-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-offer-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-offer-card.tsx",
+          "target": "components/ui/nyuchi-offer-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -16857,7 +17225,8 @@
       "docs": "Use it for: pulse, campfire, circles, nhimbe, wallet.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-onboarding-step",
       "files": [
         {
-          "path": "components/ui/nyuchi-onboarding-step.tsx",
+          "path": "components/registry/n3-brand/nyuchi-onboarding-step.tsx",
+          "target": "components/ui/nyuchi-onboarding-step.tsx",
           "type": "registry:ui"
         }
       ],
@@ -16906,7 +17275,8 @@
       "docs": "Use it for: pulse, shamwari, campfire, circles, bytes.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-page",
       "files": [
         {
-          "path": "components/ui/nyuchi-page.tsx",
+          "path": "components/registry/n6-pages/nyuchi-page.tsx",
+          "target": "components/ui/nyuchi-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -16954,7 +17324,8 @@
       "docs": "Use it for: Authorize the $1/mo fundi-tester charge inside an AI client, Final step of an inline UCP checkout, Confirm a one-time purchase via an AP2 mandate.\nVariants: default.\nIncludes: Inline AP2 payment authorization — no checkout tab, Payment-handler (rail) selection: card / bank / mobile money, Shows the AP2 mandate chain (intent/cart) for transparency, No card details leave the wallet — signs a Payment Mandate, Dynamic mineral accent via --brand-accent.\nAccessibility: radio fieldset/legend for payment handler choice, 48px minimum touch targets, focus-visible ring on all controls, role=alert for errors, prefers-reduced-motion honoured via the harness.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-payment-mandate-card",
       "files": [
         {
-          "path": "agentic/nyuchi-payment-mandate-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-payment-mandate-card.tsx",
+          "target": "agentic/nyuchi-payment-mandate-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -17002,7 +17373,8 @@
       "docs": "Use it for: novels, nhimbe, wallet, transport, bushtrade.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes, I18N via Intl formatters.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-payment-summary",
       "files": [
         {
-          "path": "components/ui/nyuchi-payment-summary.tsx",
+          "path": "components/registry/n3-brand/nyuchi-payment-summary.tsx",
+          "target": "components/ui/nyuchi-payment-summary.tsx",
           "type": "registry:ui"
         }
       ],
@@ -17052,7 +17424,8 @@
       "docs": "Use it for: pulse, campfire, bytes, news.\nVariants: default.\nIncludes: App shell infrastructure, Cross-layer wiring (L7→L8→L9), data-slot + data-portal DOM attributes, Harness integration.\nAccessibility: Focus-visible ring on interactive elements, ARIA role, ARIA attributes.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-persistent-player",
       "files": [
         {
-          "path": "components/ui/nyuchi-persistent-player.tsx",
+          "path": "components/registry/n7-shell/nyuchi-persistent-player.tsx",
+          "target": "components/ui/nyuchi-persistent-player.tsx",
           "type": "registry:ui"
         }
       ],
@@ -17096,7 +17469,8 @@
       "docs": "Use it for: lingo.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-phrase-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-phrase-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-phrase-card.tsx",
+          "target": "components/ui/nyuchi-phrase-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -17141,7 +17515,8 @@
       "docs": "Use it for: Mukoko Places location listings, Shamwari hospitality suggestions, Nearby places discovery, Verified business directories, Location-based search results.\nVariants: default, compact, hero.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-place-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-place-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-place-card.tsx",
+          "target": "components/ui/nyuchi-place-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -17194,7 +17569,8 @@
       "docs": "Use it for: Design token infrastructure, All layers consume L1.\nVariants: default.\nIncludes: Y-axis vertical spine, CSS custom properties, Multi-platform generators.\nAccessibility: Defines focus ring tokens, Touch target minimums, Contrast-safe pairings.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-platform",
       "files": [
         {
-          "path": "lib/platform/index.tsx",
+          "path": "components/registry/n1-tokens/nyuchi-platform.tsx",
+          "target": "lib/platform/index.tsx",
           "type": "registry:lib"
         }
       ],
@@ -17239,7 +17615,8 @@
       "docs": "Use it for: BushTrade marketplace product listings, Cart item display in checkout flows, Wishlist entries, Recommended products panels, Search results in commerce contexts.\nVariants: default, compact, grid, list-row.\nIncludes: Price display with locale currency formatting, Rating with star count, Availability badge (in-stock, low-stock, out-of-stock), Add-to-cart action slot, Mineral accent for category or merchant, Harness integration (log, motion, LiveRegion), animStyle with prefersReduced.\nAccessibility: role=article with aria-label including price, Focus-visible ring, 48px minimum touch target on add-to-cart, Screen reader announces title, price, availability, rating, Currency formatted via Intl.NumberFormat for locale.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-product-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-product-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-product-card.tsx",
+          "target": "components/ui/nyuchi-product-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -17293,7 +17670,8 @@
       "docs": "Use it for: Show the agent's product search results inline, Let the user pick which product to view/buy.\nVariants: default.\nIncludes: Compact top 3–5 UCP search results, Per-result price label + description, Selecting a result hands the id back to the agent, Empty-state messaging.\nAccessibility: list semantics (ul/li), 48px minimum touch target per result, focus-visible ring on each row, truncation with title preserved.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-product-results",
       "files": [
         {
-          "path": "agentic/nyuchi-product-results.tsx",
+          "path": "components/registry/n3-brand/nyuchi-product-results.tsx",
+          "target": "agentic/nyuchi-product-results.tsx",
           "type": "registry:ui"
         }
       ],
@@ -17338,7 +17716,8 @@
       "docs": "Use it for: Standardized profile header across all Mukoko apps, User profile primary identity block, Trust-signal display on profiles, Consistent identity presentation across ecosystem, Profile-first surfaces throughout Nyuchi.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-profile-block",
       "files": [
         {
-          "path": "components/ui/nyuchi-profile-block.tsx",
+          "path": "components/registry/n3-brand/nyuchi-profile-block.tsx",
+          "target": "components/ui/nyuchi-profile-block.tsx",
           "type": "registry:ui"
         }
       ],
@@ -17392,7 +17771,8 @@
       "docs": "Use it for: Full user profile page header, Cover image with profile overlay, Full-bleed identity presentation, Social profile page heroes, Profile page top section.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-profile-header",
       "files": [
         {
-          "path": "components/ui/nyuchi-profile-header.tsx",
+          "path": "components/registry/n3-brand/nyuchi-profile-header.tsx",
+          "target": "components/ui/nyuchi-profile-header.tsx",
           "type": "registry:ui"
         }
       ],
@@ -17439,7 +17819,8 @@
       "docs": "Use it for: Full user profile pages, Social feed profile destinations, Community member profile views, Creator and author profile pages, Service provider profile pages.\nVariants: default, compact, hero.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-profile-page",
       "files": [
         {
-          "path": "components/blocks/profile-page.tsx",
+          "path": "components/registry/n3-brand/nyuchi-profile-page.tsx",
+          "target": "components/blocks/profile-page.tsx",
           "type": "registry:block"
         }
       ],
@@ -17494,7 +17875,8 @@
       "docs": "Use it for: pulse, campfire, bytes, circles, novels.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-profile-page-layout",
       "files": [
         {
-          "path": "components/ui/nyuchi-profile-page-layout.tsx",
+          "path": "components/registry/n6-pages/nyuchi-profile-page-layout.tsx",
+          "target": "components/ui/nyuchi-profile-page-layout.tsx",
           "type": "registry:ui"
         }
       ],
@@ -17547,7 +17929,8 @@
       "docs": "Use it for: Profile settings pages, Account preferences, Notification settings, Privacy and security settings, User preference management.\nVariants: default, compact, hero.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-profile-settings",
       "files": [
         {
-          "path": "components/blocks/profile-settings.tsx",
+          "path": "components/registry/n3-brand/nyuchi-profile-settings.tsx",
+          "target": "components/blocks/profile-settings.tsx",
           "type": "registry:block"
         }
       ],
@@ -17605,7 +17988,8 @@
       "docs": "Use it for: Event programme and schedule displays, Conference agenda timelines, Workshop session listings, Multi-day event schedules, Time-slot-based event programmes.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-programme-item",
       "files": [
         {
-          "path": "components/ui/nyuchi-programme-item.tsx",
+          "path": "components/registry/n3-brand/nyuchi-programme-item.tsx",
+          "target": "components/ui/nyuchi-programme-item.tsx",
           "type": "registry:ui"
         }
       ],
@@ -17653,7 +18037,8 @@
       "docs": "Use it for: pulse, places, bushtrade, health.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-provider-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-provider-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-provider-card.tsx",
+          "target": "components/ui/nyuchi-provider-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -17702,7 +18087,8 @@
       "docs": "Use it for: Event registration / ticketing panel (nhimbe), Paid RSVP tier selection, Any quantity + tier purchase sidebar.\nVariants: default.\nIncludes: Selectable ticket-tier list with radio semantics, USD Intl.NumberFormat price formatting, Free for 0, Clamped quantity stepper (Minus/Plus, 48px pills), One saturated accent CTA with running total + loading spinner, Harness live-region announcements, --brand-accent neutral default.\nAccessibility: Tier rows are radios (role=radio, aria-checked) in a radiogroup, Quantity steppers are 48px targets with aria-labels, Live region announces tier + quantity changes, Sold-out tiers disabled and labelled Sold out, Visible focus-visible ring on every control.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-registration-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-registration-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-registration-card.tsx",
+          "target": "components/ui/nyuchi-registration-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -17750,7 +18136,8 @@
       "docs": "Use it for: Design token infrastructure, All layers consume L1.\nVariants: default.\nIncludes: Y-axis vertical spine, CSS custom properties, Multi-platform generators.\nAccessibility: Defines focus ring tokens, Touch target minimums, Contrast-safe pairings.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-resilience",
       "files": [
         {
-          "path": "lib/resilience/index.tsx",
+          "path": "components/registry/n1-tokens/nyuchi-resilience.tsx",
+          "target": "lib/resilience/index.tsx",
           "type": "registry:lib"
         }
       ],
@@ -17803,7 +18190,8 @@
       "docs": "Use it for: novels, nhimbe, places, bushtrade, health.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-review-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-review-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-review-card.tsx",
+          "target": "components/ui/nyuchi-review-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -17854,7 +18242,8 @@
       "docs": "Use it for: App Router root layout wrapper, Provider composition (theme, sidebar, harness), L8 assurance initialization, Font loading and global styles.\nIncludes: Composes ThemeProvider, SidebarProvider, Harness, LiveRegion portal for screen readers, Service worker registration, L8 RUM + error tracker initialization, Fundi reporter for critical errors.\nAccessibility: SkipNav link for keyboard users, lang attribute from locale, dir attribute for RTL support.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-root-layout",
       "files": [
         {
-          "path": "components/ui/nyuchi-root-layout.tsx",
+          "path": "components/registry/n7-shell/nyuchi-root-layout.tsx",
+          "target": "components/ui/nyuchi-root-layout.tsx",
           "type": "registry:ui"
         }
       ],
@@ -17896,7 +18285,8 @@
       "docs": "Use it for: pulse, shamwari, campfire, circles, bytes.\nVariants: default.\nIncludes: App shell infrastructure, Cross-layer wiring (L7→L8→L9), data-slot + data-portal DOM attributes, Harness integration.\nAccessibility: Focus-visible ring on interactive elements, ARIA role, ARIA attributes.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-route-guard",
       "files": [
         {
-          "path": "components/ui/nyuchi-route-guard.tsx",
+          "path": "components/registry/n7-shell/nyuchi-route-guard.tsx",
+          "target": "components/ui/nyuchi-route-guard.tsx",
           "type": "registry:ui"
         }
       ],
@@ -17941,7 +18331,8 @@
       "docs": "Use it for: transport.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes, I18N via Intl formatters.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-route-planner",
       "files": [
         {
-          "path": "components/ui/nyuchi-route-planner.tsx",
+          "path": "components/registry/n3-brand/nyuchi-route-planner.tsx",
+          "target": "components/ui/nyuchi-route-planner.tsx",
           "type": "registry:ui"
         }
       ],
@@ -17990,7 +18381,8 @@
       "docs": "Use it for: circles, nhimbe, planner.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes, I18N via Intl formatters.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-rsvp-button",
       "files": [
         {
-          "path": "components/ui/nyuchi-rsvp-button.tsx",
+          "path": "components/registry/n3-brand/nyuchi-rsvp-button.tsx",
+          "target": "components/ui/nyuchi-rsvp-button.tsx",
           "type": "registry:ui"
         }
       ],
@@ -18037,7 +18429,8 @@
       "docs": "Use it for: pulse, campfire, circles, novels, nhimbe.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-search-view",
       "files": [
         {
-          "path": "components/ui/nyuchi-search-view.tsx",
+          "path": "components/registry/n3-brand/nyuchi-search-view.tsx",
+          "target": "components/ui/nyuchi-search-view.tsx",
           "type": "registry:ui"
         }
       ],
@@ -18090,7 +18483,8 @@
       "docs": "Use it for: pulse, shamwari, campfire, circles, bytes.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-seo",
       "files": [
         {
-          "path": "lib/nyuchi-seo.ts",
+          "path": "components/registry/n11-discovery/nyuchi-seo.ts",
+          "target": "lib/nyuchi-seo.ts",
           "type": "registry:lib"
         }
       ],
@@ -18137,7 +18531,8 @@
       "docs": "Use it for: pulse, campfire, nhimbe, planner, wallet.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-settings-page",
       "files": [
         {
-          "path": "components/ui/nyuchi-settings-page.tsx",
+          "path": "components/registry/n6-pages/nyuchi-settings-page.tsx",
+          "target": "components/ui/nyuchi-settings-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -18189,7 +18584,8 @@
       "docs": "Use it for: pulse, campfire, bytes, circles, novels.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-share-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-share-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-share-card.tsx",
+          "target": "components/ui/nyuchi-share-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -18241,7 +18637,8 @@
       "docs": "Use it for: Desktop sidebar across all Nyuchi ecosystem apps, Section-based navigation with mineral accent strip, Standardized left-side app navigation, Multi-section workspace navigation, Brand-consistent desktop navigation.\nVariants: default.\nIncludes: App shell infrastructure, Cross-layer wiring (L7→L8→L9), data-slot + data-portal DOM attributes, Harness integration.\nAccessibility: Focus-visible ring on interactive elements, ARIA role, ARIA attributes.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-sidebar",
       "files": [
         {
-          "path": "components/ui/nyuchi-sidebar.tsx",
+          "path": "components/registry/n7-shell/nyuchi-sidebar.tsx",
+          "target": "components/ui/nyuchi-sidebar.tsx",
           "type": "registry:ui"
         }
       ],
@@ -18292,7 +18689,8 @@
       "docs": "Use it for: nhimbe, console, bushtrade.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-sidebar-nav",
       "files": [
         {
-          "path": "components/ui/nyuchi-sidebar-nav.tsx",
+          "path": "components/registry/n3-brand/nyuchi-sidebar-nav.tsx",
+          "target": "components/ui/nyuchi-sidebar-nav.tsx",
           "type": "registry:ui"
         }
       ],
@@ -18336,7 +18734,8 @@
       "docs": "Use it for: News source credibility indicators, Article source attribution, Media organization trust badges, Verified source displays, Source transparency in news feeds.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-source-badge",
       "files": [
         {
-          "path": "components/ui/nyuchi-source-badge.tsx",
+          "path": "components/registry/n3-brand/nyuchi-source-badge.tsx",
+          "target": "components/ui/nyuchi-source-badge.tsx",
           "type": "registry:ui"
         }
       ],
@@ -18385,7 +18784,8 @@
       "docs": "Use it for: pulse, shamwari, campfire, circles, bytes.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-splash-screen",
       "files": [
         {
-          "path": "components/ui/nyuchi-splash-screen.tsx",
+          "path": "components/registry/n6-pages/nyuchi-splash-screen.tsx",
+          "target": "components/ui/nyuchi-splash-screen.tsx",
           "type": "registry:ui"
         }
       ],
@@ -18434,7 +18834,8 @@
       "docs": "Use it for: pulse, nhimbe, planner, wallet, bushtrade.\nVariants: default, compact, hero.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-stats-row",
       "files": [
         {
-          "path": "components/ui/nyuchi-stats-row.tsx",
+          "path": "components/registry/n3-brand/nyuchi-stats-row.tsx",
+          "target": "components/ui/nyuchi-stats-row.tsx",
           "type": "registry:ui"
         }
       ],
@@ -18485,7 +18886,8 @@
       "docs": "Use it for: events, wallet, transport, bushtrade, nhimbe.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-success-screen",
       "files": [
         {
-          "path": "components/ui/nyuchi-success-screen.tsx",
+          "path": "components/registry/n3-brand/nyuchi-success-screen.tsx",
+          "target": "components/ui/nyuchi-success-screen.tsx",
           "type": "registry:ui"
         }
       ],
@@ -18530,7 +18932,8 @@
       "docs": "Use it for: planner, jobs, places, transport, weather.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-suitability-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-suitability-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-suitability-card.tsx",
+          "target": "components/ui/nyuchi-suitability-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -18578,7 +18981,8 @@
       "docs": "Use it for: Root theme provider for every Nyuchi app, Design token distribution via CSS custom properties, Light/dark/high-contrast theme switching, Per-brand accent color overrides, System preference and user override management.\nVariants: default.\nIncludes: App shell infrastructure, Cross-layer wiring (L7→L8→L9), data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-theme-provider",
       "files": [
         {
-          "path": "components/ui/nyuchi-theme-provider.tsx",
+          "path": "components/registry/n7-shell/nyuchi-theme-provider.tsx",
+          "target": "components/ui/nyuchi-theme-provider.tsx",
           "type": "registry:ui"
         }
       ],
@@ -18623,7 +19027,8 @@
       "docs": "Use it for: Event tickets in My Events, Check-in flow displays, Digital wallet ticket views, QR code entry credentials, Ticket transfer and gift flows.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-ticket-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-ticket-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-ticket-card.tsx",
+          "target": "components/ui/nyuchi-ticket-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -18673,7 +19078,8 @@
       "docs": "Use it for: Scoped discover timelines (nhimbe /events, /search), Circle Events tab, Signed-in home Your events, Planner day-grouped schedule.\nVariants: default.\nIncludes: 4.2.0 date-rail signature pattern, Day-grouped with weekday/day/month rail, Harness integration — reduced-motion staggered entry + observability, Full 1px borders, 13px muted metadata, 16px title (4.2.0 density), Avatar stack + right thumbnail per row, Mineral event dot per row.\nAccessibility: Decorative dots/avatars marked aria-hidden, Rows are focusable links with visible focus ring, Reduced-motion respected via harness, Truncating single-line title/host/location.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-timeline",
       "files": [
         {
-          "path": "components/ui/nyuchi-timeline.tsx",
+          "path": "components/registry/n3-brand/nyuchi-timeline.tsx",
+          "target": "components/ui/nyuchi-timeline.tsx",
           "type": "registry:ui"
         }
       ],
@@ -18722,7 +19128,8 @@
       "docs": "Use it for: pulse, shamwari, campfire, circles, bytes.\nVariants: default.\nIncludes: App shell infrastructure, Cross-layer wiring (L7→L8→L9), data-slot + data-portal DOM attributes, Harness integration.\nAccessibility: Focus-visible ring on interactive elements, ARIA role, ARIA attributes.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-toast-provider",
       "files": [
         {
-          "path": "components/ui/nyuchi-toast-provider.tsx",
+          "path": "components/registry/n7-shell/nyuchi-toast-provider.tsx",
+          "target": "components/ui/nyuchi-toast-provider.tsx",
           "type": "registry:ui"
         }
       ],
@@ -19142,7 +19549,8 @@
       "description": "Mzizi design tokens for ArkTS / HarmonyOS. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties — seven African Minerals + seven Heritage tones, both themes. Colour constants, spacing, radius and typography for HarmonyOS. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md §8.4.1).",
       "files": [
         {
-          "path": "lib/tokens/nyuchi-tokens-arkts.ets",
+          "path": "components/registry/n1-tokens/nyuchi-tokens-arkts.ets",
+          "target": "lib/tokens/nyuchi-tokens-arkts.ets",
           "type": "registry:lib"
         }
       ],
@@ -19165,7 +19573,8 @@
       "description": "Mzizi design tokens for Kotlin / Jetpack Compose. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties — seven African Minerals + seven Heritage tones, both themes. Color objects, spacing Dp values, radius and typography constants for Android. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md §8.4.1).",
       "files": [
         {
-          "path": "lib/tokens/nyuchi-tokens-kotlin.kt",
+          "path": "components/registry/n1-tokens/nyuchi-tokens-kotlin.kt",
+          "target": "lib/tokens/nyuchi-tokens-kotlin.kt",
           "type": "registry:lib"
         }
       ],
@@ -19188,7 +19597,8 @@
       "description": "Mzizi design tokens for Python. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties — seven African Minerals + seven Heritage tones, both themes. Frozen dataclasses of colour values for analytics pipelines, data visualisation (matplotlib, plotly, altair), report generation and ML tooling. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md §8.4.1).",
       "files": [
         {
-          "path": "lib/tokens/nyuchi-tokens-python.py",
+          "path": "components/registry/n1-tokens/nyuchi-tokens-python.py",
+          "target": "lib/tokens/nyuchi-tokens-python.py",
           "type": "registry:lib"
         }
       ],
@@ -19211,7 +19621,8 @@
       "description": "Mzizi design tokens for React Native. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties — seven African Minerals + seven Heritage tones, both themes. A StyleSheet-ready token object for React Native. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md §8.4.1).",
       "files": [
         {
-          "path": "lib/tokens/nyuchi-tokens-react-native.ts",
+          "path": "components/registry/n1-tokens/nyuchi-tokens-react-native.ts",
+          "target": "lib/tokens/nyuchi-tokens-react-native.ts",
           "type": "registry:lib"
         }
       ],
@@ -19234,7 +19645,8 @@
       "description": "Mzizi design tokens for Rust. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties — seven African Minerals + seven Heritage tones, both themes, as `const` values plus `Palette`, `Spacing`, `Radius` and `Fonts`. This is what the Dioxus half of the registry consumes, via the `mzizi-tokens` crate. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md §8.4.1).",
       "files": [
         {
-          "path": "src/tokens/nyuchi_tokens.rs",
+          "path": "components/registry/n1-tokens/nyuchi-tokens-rust.rs",
+          "target": "src/tokens/nyuchi_tokens.rs",
           "type": "registry:lib"
         }
       ],
@@ -19257,7 +19669,8 @@
       "description": "Mzizi design tokens for Swift / SwiftUI. Generated by `pnpm tokens:sync` from the same source that emits the web CSS custom properties — seven African Minerals + seven Heritage tones, both themes. Color extensions, spacing, radius and typography constants for iOS, macOS, watchOS and tvOS. Never hand-edited: adding a target means adding an emitter, never re-authoring the palette (CLAUDE.md §8.4.1).",
       "files": [
         {
-          "path": "lib/tokens/nyuchi-tokens-swift.swift",
+          "path": "components/registry/n1-tokens/nyuchi-tokens-swift.swift",
+          "target": "lib/tokens/nyuchi-tokens-swift.swift",
           "type": "registry:lib"
         }
       ],
@@ -19281,7 +19694,8 @@
       "docs": "Use it for: Design token provider for all Nyuchi apps, CSS custom properties for colors, spacing, radii, motion, Multi-platform export: Swift, Kotlin, ArkTS, Rust, Python, Brand overrides per mini-app.\nVariants: light, dark, high-contrast.\nIncludes: Five African Minerals palette with light/dark pairs, Four-level AAA surface system, 8 semantic token categories, Brand override per mini-app, Multi-platform generators.\nAccessibility: AAA contrast on all text-surface combinations, prefers-contrast: more support, prefers-reduced-motion: respects motion tokens.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-tokens-typescript",
       "files": [
         {
-          "path": "lib/tokens/index.ts",
+          "path": "components/registry/n1-tokens/nyuchi-tokens-typescript.ts",
+          "target": "lib/tokens/index.ts",
           "type": "registry:lib"
         }
       ],
@@ -19330,7 +19744,8 @@
       "docs": "Use it for: nhimbe, wallet, bushtrade.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-transaction-row",
       "files": [
         {
-          "path": "components/ui/nyuchi-transaction-row.tsx",
+          "path": "components/registry/n3-brand/nyuchi-transaction-row.tsx",
+          "target": "components/ui/nyuchi-transaction-row.tsx",
           "type": "registry:ui"
         }
       ],
@@ -19376,7 +19791,8 @@
       "docs": "Use it for: Full trust score breakdown on profiles, Trust audit screens in admin, Three-signal trust visualization, Trust detail views, Verification tier displays with context.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-trust-meter",
       "files": [
         {
-          "path": "components/ui/nyuchi-trust-meter.tsx",
+          "path": "components/registry/n3-brand/nyuchi-trust-meter.tsx",
+          "target": "components/ui/nyuchi-trust-meter.tsx",
           "type": "registry:ui"
         }
       ],
@@ -19428,7 +19844,8 @@
       "docs": "Use it for: pulse, shamwari, campfire, circles, bytes.\nVariants: default.\nIncludes: App shell infrastructure, Cross-layer wiring (L7→L8→L9), data-slot + data-portal DOM attributes, Harness integration.\nAccessibility: Focus-visible ring on interactive elements, ARIA role, ARIA attributes.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-update-prompt",
       "files": [
         {
-          "path": "components/ui/nyuchi-update-prompt.tsx",
+          "path": "components/registry/n7-shell/nyuchi-update-prompt.tsx",
+          "target": "components/ui/nyuchi-update-prompt.tsx",
           "type": "registry:ui"
         }
       ],
@@ -19473,7 +19890,8 @@
       "docs": "Use it for: Team member listings, Community member displays, User mention results, Friend and follower lists, Contact and directory cards.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-user-card",
       "files": [
         {
-          "path": "components/ui/nyuchi-user-card.tsx",
+          "path": "components/registry/n3-brand/nyuchi-user-card.tsx",
+          "target": "components/ui/nyuchi-user-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -19520,7 +19938,8 @@
       "docs": "Use it for: App header user menu in all Nyuchi apps, Profile dropdown with account links, Sign-out access point, User preferences shortcut menu, Avatar-triggered action menu.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute, aria-label for screen readers.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-user-menu",
       "files": [
         {
-          "path": "components/ui/nyuchi-user-menu.tsx",
+          "path": "components/registry/n3-brand/nyuchi-user-menu.tsx",
+          "target": "components/ui/nyuchi-user-menu.tsx",
           "type": "registry:ui"
         }
       ],
@@ -19572,7 +19991,8 @@
       "docs": "Use it for: Profile header verification display, Inline name verification, Listing card trust indicator, Search result trust signal.\nVariants: community (terracotta), otp (cobalt), government (gold), licensed (tanzanite), suspended (dimmed), ancestral (memorial).\nSizes: sm, md, lg.\nIncludes: Three-axis trust model: Status × Tier → Score, Mineral-colored per tier, Tooltip with tier explanation, Maps to system.verification_tier.\nAccessibility: aria-label describes verification tier, Tooltip accessible via focus, Screen reader announces trust level.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-verified-badge",
       "files": [
         {
-          "path": "components/ui/nyuchi-verified-badge.tsx",
+          "path": "components/registry/n3-brand/nyuchi-verified-badge.tsx",
+          "target": "components/ui/nyuchi-verified-badge.tsx",
           "type": "registry:ui"
         }
       ],
@@ -19629,7 +20049,8 @@
       "docs": "Use it for: Structured logging across all layers, Performance measurement in critical paths, Error tracking with context enrichment, Distributed trace context propagation, Metric collection for dashboards.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/observability",
       "files": [
         {
-          "path": "lib/observability.ts",
+          "path": "components/registry/n2-primitives/observability.ts",
+          "target": "lib/observability.ts",
           "type": "registry:lib"
         }
       ],
@@ -19670,7 +20091,8 @@
       "docs": "Use it for: Error handling, Graceful degradation, Offline support.\nVariants: default, degraded, error.\nIncludes: Y-axis resilience spine, Netflix resilience patterns.\nAccessibility: Error states announced to screen readers, Retry actions keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/offline-banner",
       "files": [
         {
-          "path": "components/ui/offline-banner.tsx",
+          "path": "components/registry/n5-resilience/offline-banner.tsx",
+          "target": "components/ui/offline-banner.tsx",
           "type": "registry:ui"
         }
       ],
@@ -19715,7 +20137,8 @@
       "docs": "Use it for: First-time user onboarding, Multi-step profile setup, Interest and preference selection, Account creation completion, Guided app introduction flows.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/onboarding-flow",
       "files": [
         {
-          "path": "components/blocks/onboarding-flow.tsx",
+          "path": "components/registry/n6-pages/onboarding-flow.tsx",
+          "target": "components/blocks/onboarding-flow.tsx",
           "type": "registry:block"
         }
       ],
@@ -19770,7 +20193,8 @@
       "docs": "Use it for: Feature discovery overlays for new features, Post-login product tours, Help tour on user request, Update-triggered feature walkthroughs, In-app tutorial sequences.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/onboarding-tour",
       "files": [
         {
-          "path": "components/ui/onboarding-tour.tsx",
+          "path": "components/registry/n6-pages/onboarding-tour.tsx",
+          "target": "components/ui/onboarding-tour.tsx",
           "type": "registry:ui"
         }
       ],
@@ -19819,7 +20243,8 @@
       "docs": "Use it for: Checkout total calculation display, Order confirmation summary, Pre-payment review step, Shopping cart totals with tax breakdown, Subscription upgrade cost comparison.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/order-summary",
       "files": [
         {
-          "path": "components/ui/order-summary.tsx",
+          "path": "components/registry/n2-primitives/order-summary.tsx",
+          "target": "components/ui/order-summary.tsx",
           "type": "registry:ui"
         }
       ],
@@ -19861,7 +20286,8 @@
       "docs": "Use it for: nhimbe, events, places, jobs, bushtrade.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/org-profile-page",
       "files": [
         {
-          "path": "components/ui/org-profile-page.tsx",
+          "path": "components/registry/n6-pages/org-profile-page.tsx",
+          "target": "components/ui/org-profile-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -19908,7 +20334,8 @@
       "docs": "Use it for: Page header with title and breadcrumbs, Section banner with actions, Detail-page title with metadata, Admin page standard header, Content page title and action area.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/page-header",
       "files": [
         {
-          "path": "components/ui/page-header.tsx",
+          "path": "components/registry/n2-primitives/page-header.tsx",
+          "target": "components/ui/page-header.tsx",
           "type": "registry:ui"
         }
       ],
@@ -19953,7 +20380,8 @@
       "docs": "Use it for: Long result list pagination (search, marketplace), Admin table page navigation, Article archive pagination, Comment thread pagination, Infinite-scroll alternative with explicit controls.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/pagination",
       "files": [
         {
-          "path": "components/ui/pagination.tsx",
+          "path": "components/registry/n2-primitives/pagination.tsx",
+          "target": "components/ui/pagination.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20000,7 +20428,8 @@
       "docs": "Use it for: Account creation password validation, Password change forms with strength feedback, Password policy enforcement displays, Educational feedback during password creation, Real-time requirement checklist validation.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/password-strength",
       "files": [
         {
-          "path": "components/ui/password-strength.tsx",
+          "path": "components/registry/n2-primitives/password-strength.tsx",
+          "target": "components/ui/password-strength.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20044,7 +20473,8 @@
       "docs": "Use it for: Saved cards in checkout flow, Payment method management in account, Default payment selection, Mobile money display (EcoCash, OneMoney), Wallet balance with alternative payment options.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/payment-method-card",
       "files": [
         {
-          "path": "components/ui/payment-method-card.tsx",
+          "path": "components/registry/n2-primitives/payment-method-card.tsx",
+          "target": "components/ui/payment-method-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20088,7 +20518,8 @@
       "docs": "Use it for: nhimbe, wallet, bushtrade.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/payment-page",
       "files": [
         {
-          "path": "components/ui/payment-page.tsx",
+          "path": "components/registry/n6-pages/payment-page.tsx",
+          "target": "components/ui/payment-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20133,7 +20564,8 @@
       "docs": "Use it for: wallet.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/payment-pin-pad",
       "files": [
         {
-          "path": "components/ui/payment-pin-pad.tsx",
+          "path": "components/registry/n2-primitives/payment-pin-pad.tsx",
+          "target": "components/ui/payment-pin-pad.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20178,7 +20610,8 @@
       "docs": "Use it for: User role indicator in admin panels, Permission scope display on API keys, Team member role visualization, Verified status badges, Access tier indicators.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/permission-badge",
       "files": [
         {
-          "path": "components/ui/permission-badge.tsx",
+          "path": "components/registry/n2-primitives/permission-badge.tsx",
+          "target": "components/ui/permission-badge.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20222,7 +20655,8 @@
       "docs": "Use it for: Registration forms with African country codes, Mobile money setup (EcoCash, OneMoney), SMS verification workflows, WhatsApp business contact entry, Emergency contact information.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/phone-input",
       "files": [
         {
-          "path": "components/ui/phone-input.tsx",
+          "path": "components/registry/n2-primitives/phone-input.tsx",
+          "target": "components/ui/phone-input.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20266,7 +20700,8 @@
       "docs": "Use it for: campfire, circles.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/pinned-message",
       "files": [
         {
-          "path": "components/ui/pinned-message.tsx",
+          "path": "components/registry/n2-primitives/pinned-message.tsx",
+          "target": "components/ui/pinned-message.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20310,7 +20745,8 @@
       "docs": "Use it for: wallet.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/pod-storage-meter",
       "files": [
         {
-          "path": "components/ui/pod-storage-meter.tsx",
+          "path": "components/registry/n2-primitives/pod-storage-meter.tsx",
+          "target": "components/ui/pod-storage-meter.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20353,7 +20789,8 @@
       "docs": "Use it for: campfire, circles.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/poll",
       "files": [
         {
-          "path": "components/ui/poll.tsx",
+          "path": "components/registry/n2-primitives/poll.tsx",
+          "target": "components/ui/poll.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20400,7 +20837,8 @@
       "docs": "Use it for: Contextual help and info popovers, Form field assistance and examples, Quick-edit fields in tables, Mini-detail views without full navigation, Inline-action confirmations.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/popover",
       "files": [
         {
-          "path": "components/ui/popover.tsx",
+          "path": "components/registry/n2-primitives/popover.tsx",
+          "target": "components/ui/popover.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20442,7 +20880,8 @@
       "docs": "Use it for: Product price in marketplace listings, Discount price with strikethrough original, Subscription tier pricing display, Multi-currency price with conversion, Promotional pricing with countdown.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/price-display",
       "files": [
         {
-          "path": "components/ui/price-display.tsx",
+          "path": "components/registry/n2-primitives/price-display.tsx",
+          "target": "components/ui/price-display.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20483,7 +20922,8 @@
       "docs": "Use it for: Subscription tier comparison on pricing pages, Plan upgrade interfaces, Feature-gated pricing presentation, Highlighted recommended plan in lineup, Promotional pricing cards with countdown.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/pricing-card",
       "files": [
         {
-          "path": "components/ui/pricing-card.tsx",
+          "path": "components/registry/n2-primitives/pricing-card.tsx",
+          "target": "components/ui/pricing-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20533,7 +20973,8 @@
       "docs": "Use it for: planner.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/priority-selector",
       "files": [
         {
-          "path": "components/ui/priority-selector.tsx",
+          "path": "components/registry/n2-primitives/priority-selector.tsx",
+          "target": "components/ui/priority-selector.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20579,7 +21020,8 @@
       "docs": "Use it for: Upload progress feedback, Task completion indicators, Onboarding progress bars, Profile completeness indicators, Multi-step form progress.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/progress",
       "files": [
         {
-          "path": "components/ui/progress.tsx",
+          "path": "components/registry/n2-primitives/progress.tsx",
+          "target": "components/ui/progress.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20623,7 +21065,8 @@
       "docs": "Use it for: Main prompt input for AI chat experiences, Voice-to-text transcription input with send control, Multi-modal prompts with file attachment support, Command palette prompts for AI-powered search, Form-embedded AI assistance for long text fields.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/prompt-input",
       "files": [
         {
-          "path": "components/ui/prompt-input.tsx",
+          "path": "components/registry/n2-primitives/prompt-input.tsx",
+          "target": "components/ui/prompt-input.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20668,7 +21111,8 @@
       "docs": "Use it for: Profile detail displays with copy actions, Transaction detail views, API key and token display with copy, Configuration value displays, Structured data presentation.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/property-list",
       "files": [
         {
-          "path": "components/ui/property-list.tsx",
+          "path": "components/registry/n2-primitives/property-list.tsx",
+          "target": "components/ui/property-list.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20712,7 +21156,8 @@
       "docs": "Use it for: Mobile feed refresh in Mukoko social streams, Inbox-style notification refresh, Newsfeed and activity stream reloading, Email and message list pull-refresh, Cart and order status refresh in BushTrade.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/pull-to-refresh",
       "files": [
         {
-          "path": "components/ui/pull-to-refresh.tsx",
+          "path": "components/registry/n2-primitives/pull-to-refresh.tsx",
+          "target": "components/ui/pull-to-refresh.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20756,7 +21201,8 @@
       "docs": "Use it for: nhimbe, console, wallet.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/quick-action-grid",
       "files": [
         {
-          "path": "components/ui/quick-action-grid.tsx",
+          "path": "components/registry/n2-primitives/quick-action-grid.tsx",
+          "target": "components/ui/quick-action-grid.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20799,7 +21245,8 @@
       "docs": "Use it for: Gender selection in registration forms, Subscription tier selection, Payment method selection (mobile money vs card), Mutually exclusive settings options, Survey and form single-choice questions.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/radio-group",
       "files": [
         {
-          "path": "components/ui/radio-group.tsx",
+          "path": "components/registry/n2-primitives/radio-group.tsx",
+          "target": "components/ui/radio-group.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20844,7 +21291,8 @@
       "docs": "Use it for: Protecting API quotas (Tomorrow.io, Anthropic, government registries), User-side rate limiting to prevent abuse, Preventing thundering herd on popular endpoints, Burst-allowing limits for legitimate spikes, Quota tracking for multi-tenant services.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/rate-limiter",
       "files": [
         {
-          "path": "lib/rate-limiter.ts",
+          "path": "components/registry/n2-primitives/rate-limiter.ts",
+          "target": "lib/rate-limiter.ts",
           "type": "registry:lib"
         }
       ],
@@ -20887,7 +21335,8 @@
       "docs": "Use it for: Product reviews in BushTrade commerce, Service quality ratings, Learning content difficulty rating, Restaurant and place reviews in Bundu, User feedback collection on features.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/rating",
       "files": [
         {
-          "path": "components/ui/rating.tsx",
+          "path": "components/registry/n2-primitives/rating.tsx",
+          "target": "components/ui/rating.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20931,7 +21380,8 @@
       "docs": "Use it for: Emoji reactions on chat messages, Content reactions on social posts, Quick sentiment feedback on articles, Engagement signals in community discussions, Approval reactions on proposals and decisions.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/reaction-picker",
       "files": [
         {
-          "path": "components/ui/reaction-picker.tsx",
+          "path": "components/registry/n2-primitives/reaction-picker.tsx",
+          "target": "components/ui/reaction-picker.tsx",
           "type": "registry:ui"
         }
       ],
@@ -20975,7 +21425,8 @@
       "docs": "Use it for: campfire.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/read-receipts",
       "files": [
         {
-          "path": "components/ui/read-receipts.tsx",
+          "path": "components/registry/n2-primitives/read-receipts.tsx",
+          "target": "components/ui/read-receipts.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21019,7 +21470,8 @@
       "docs": "Use it for: novels.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/reading-progress",
       "files": [
         {
-          "path": "components/ui/reading-progress.tsx",
+          "path": "components/registry/n2-primitives/reading-progress.tsx",
+          "target": "components/ui/reading-progress.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21062,7 +21514,8 @@
       "docs": "Use it for: campfire, bytes.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/recording-controls",
       "files": [
         {
-          "path": "components/ui/recording-controls.tsx",
+          "path": "components/registry/n2-primitives/recording-controls.tsx",
+          "target": "components/ui/recording-controls.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21106,7 +21559,8 @@
       "docs": "Use it for: nhimbe, planner, health.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/recurrence-picker",
       "files": [
         {
-          "path": "components/ui/recurrence-picker.tsx",
+          "path": "components/registry/n2-primitives/recurrence-picker.tsx",
+          "target": "components/ui/recurrence-picker.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21153,7 +21607,8 @@
       "docs": "Use it for: planner, health.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/reminder-card",
       "files": [
         {
-          "path": "components/ui/reminder-card.tsx",
+          "path": "components/registry/n2-primitives/reminder-card.tsx",
+          "target": "components/ui/reminder-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21196,7 +21651,8 @@
       "docs": "Use it for: shamwari, console, health.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/report-page",
       "files": [
         {
-          "path": "components/ui/report-page.tsx",
+          "path": "components/registry/n6-pages/report-page.tsx",
+          "target": "components/ui/report-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21244,7 +21700,8 @@
       "docs": "Use it for: Split-pane code editor layouts, Dashboard with resizable sidebar, Document editor with resizable outline, Chat with resizable conversation list, Settings pages with collapsible detail pane.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/resizable",
       "files": [
         {
-          "path": "components/ui/resizable.tsx",
+          "path": "components/registry/n2-primitives/resizable.tsx",
+          "target": "components/ui/resizable.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21288,7 +21745,8 @@
       "docs": "Use it for: Transient network failure recovery, Retrying flaky third-party API calls, Database query retry on deadlock, Upload retry with exponential backoff, Idempotent operation retry after timeout.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/retry",
       "files": [
         {
-          "path": "lib/retry.ts",
+          "path": "components/registry/n2-primitives/retry.ts",
+          "target": "lib/retry.ts",
           "type": "registry:lib"
         }
       ],
@@ -21333,7 +21791,8 @@
       "docs": "Use it for: bytes, novels, console.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/revenue-dashboard-widget",
       "files": [
         {
-          "path": "components/ui/revenue-dashboard-widget.tsx",
+          "path": "components/registry/n2-primitives/revenue-dashboard-widget.tsx",
+          "target": "components/ui/revenue-dashboard-widget.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21376,7 +21835,8 @@
       "docs": "Use it for: Customer testimonial display on landing pages, Product review cards in marketplaces, Service provider reviews in platforms, Book and content reviews, App store-style rating testimonials.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/review-card",
       "files": [
         {
-          "path": "components/ui/review-card.tsx",
+          "path": "components/registry/n2-primitives/review-card.tsx",
+          "target": "components/ui/review-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21421,7 +21881,8 @@
       "docs": "Use it for: Blog post composition in content creation, Message body formatting in chat, Comment composition with formatting, Article editing in admin interfaces, Product description authoring.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/rich-text-editor",
       "files": [
         {
-          "path": "components/ui/rich-text-editor.tsx",
+          "path": "components/registry/n2-primitives/rich-text-editor.tsx",
+          "target": "components/ui/rich-text-editor.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21468,7 +21929,8 @@
       "docs": "Use it for: Role assignment in team management, Permission upgrade/downgrade workflows, Admin role delegation interface, RBAC configuration in organization settings, Invite-time role specification.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/role-selector",
       "files": [
         {
-          "path": "components/ui/role-selector.tsx",
+          "path": "components/registry/n2-primitives/role-selector.tsx",
+          "target": "components/ui/role-selector.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21512,7 +21974,8 @@
       "docs": "Use it for: transport.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/route-card",
       "files": [
         {
-          "path": "components/ui/route-card.tsx",
+          "path": "components/registry/n2-primitives/route-card.tsx",
+          "target": "components/ui/route-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21555,7 +22018,8 @@
       "docs": "Use it for: Pre-launch RTL readiness validation, Continuous RTL monitoring across deployed apps, Pull request RTL regression detection, Locale expansion readiness gates, Bidi text rendering validation.\nVariants: full-scan, diff-scan, component-specific.\nIncludes: Logical property usage check (start/end vs left/right), Bidi text rendering validation, Icon mirroring rule enforcement, Text alignment consistency check, Regression detection from baseline.\nAccessibility: Output structured as machine-readable report, Findings include severity and component reference, Report format supports CI integration, Results exposed via get_conformity_report(), Remediation guidance per finding.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/rtl-conformity-check",
       "files": [
         {
-          "path": "components/ui/rtl-conformity-check.tsx",
+          "path": "components/registry/n8-assurance/rtl-conformity-check.tsx",
+          "target": "components/ui/rtl-conformity-check.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21605,7 +22069,8 @@
       "docs": "Use it for: API response schema documentation, Database table schema exploration, GraphQL type browser, JSON data structure explorer, OpenAPI specification viewer.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/schema-viewer",
       "files": [
         {
-          "path": "components/ui/schema-viewer.tsx",
+          "path": "components/registry/n2-primitives/schema-viewer.tsx",
+          "target": "components/ui/schema-viewer.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21652,7 +22117,8 @@
       "docs": "Use it for: Scrollable content within fixed-height containers, Custom-styled scrollbars across browsers, Contained data grids, Long lists within cards, Chat message history panes.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/scroll-area",
       "files": [
         {
-          "path": "components/ui/scroll-area.tsx",
+          "path": "components/registry/n2-primitives/scroll-area.tsx",
+          "target": "components/ui/scroll-area.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21696,7 +22162,8 @@
       "docs": "Use it for: Site-wide header search, Dashboard search with keyboard shortcut, Quick-find interface with clear button, App search with command palette integration, Marketplace product search.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/search-bar",
       "files": [
         {
-          "path": "components/ui/search-bar.tsx",
+          "path": "components/registry/n2-primitives/search-bar.tsx",
+          "target": "components/ui/search-bar.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21745,7 +22212,8 @@
       "docs": "Use it for: Standard search results page with filters, Marketplace result listings, Content library search results, Knowledge base search output, Document and media search results.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/search-results",
       "files": [
         {
-          "path": "components/blocks/search-results.tsx",
+          "path": "components/registry/n2-primitives/search-results.tsx",
+          "target": "components/blocks/search-results.tsx",
           "type": "registry:block"
         }
       ],
@@ -21796,7 +22264,8 @@
       "docs": "Use it for: Error handling, Graceful degradation, Offline support.\nVariants: default, degraded, error.\nIncludes: Y-axis resilience spine, Netflix resilience patterns.\nAccessibility: Error states announced to screen readers, Retry actions keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/section-error-boundary",
       "files": [
         {
-          "path": "components/section-error-boundary.tsx",
+          "path": "components/registry/n5-resilience/section-error-boundary.tsx",
+          "target": "components/section-error-boundary.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21842,7 +22311,8 @@
       "docs": "Use it for: Section dividers in settings pages, Group headers in dashboards, Content section titles with actions, Card group headers with actions, Long-form content section breaks.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/section-header",
       "files": [
         {
-          "path": "components/ui/section-header.tsx",
+          "path": "components/registry/n2-primitives/section-header.tsx",
+          "target": "components/ui/section-header.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21885,7 +22355,8 @@
       "docs": "Use it for: View mode switcher (grid/list/calendar), Time range picker (day/week/month/year), Binary preference toggle with two labels, Segment selection in settings, Filter mode selection.\nVariants: default, compact, icon-only, icon-with-label.\nIncludes: Pill-shaped connected group per brand identity, Keyboard navigation (arrow keys), Single-select behavior, Mineral accent on active segment, Harness integration (log, motion, LiveRegion).\nAccessibility: role=radiogroup with aria-label, Each segment role=radio, Arrow keys move selection, 48px minimum touch target, Selected state announced.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/segmented-control",
       "files": [
         {
-          "path": "components/ui/segmented-control.tsx",
+          "path": "components/registry/n2-primitives/segmented-control.tsx",
+          "target": "components/ui/segmented-control.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21939,7 +22410,8 @@
       "docs": "Use it for: Country selector in address forms, Category filter in listing pages, Language and timezone settings, Plan and tier selection, Form field with limited options.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/select",
       "files": [
         {
-          "path": "components/ui/select.tsx",
+          "path": "components/registry/n2-primitives/select.tsx",
+          "target": "components/ui/select.tsx",
           "type": "registry:ui"
         }
       ],
@@ -21985,7 +22457,8 @@
       "docs": "Use it for: campfire, wallet.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/send-money-flow",
       "files": [
         {
-          "path": "components/ui/send-money-flow.tsx",
+          "path": "components/registry/n2-primitives/send-money-flow.tsx",
+          "target": "components/ui/send-money-flow.tsx",
           "type": "registry:ui"
         }
       ],
@@ -22033,7 +22506,8 @@
       "docs": "Use it for: Section dividers in long content, Visual breaks in lists, Settings page section dividers, Sidebar navigation group separation, Card content dividers.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/separator",
       "files": [
         {
-          "path": "components/ui/separator.tsx",
+          "path": "components/registry/n2-primitives/separator.tsx",
+          "target": "components/ui/separator.tsx",
           "type": "registry:ui"
         }
       ],
@@ -22075,7 +22549,8 @@
       "docs": "Use it for: console.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/service-health-card",
       "files": [
         {
-          "path": "components/ui/service-health-card.tsx",
+          "path": "components/registry/n2-primitives/service-health-card.tsx",
+          "target": "components/ui/service-health-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -22114,7 +22589,8 @@
       "docs": "Use it for: Active sessions display in account security, Device management with revoke capability, Login history with location and device, Suspicious session detection interface, Sign-out-all-devices confirmation.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/session-list",
       "files": [
         {
-          "path": "components/ui/session-list.tsx",
+          "path": "components/registry/n2-primitives/session-list.tsx",
+          "target": "components/ui/session-list.tsx",
           "type": "registry:ui"
         }
       ],
@@ -22158,7 +22634,8 @@
       "docs": "Use it for: Standard settings page layout, Account preferences pages, Admin configuration surfaces, Multi-section preference management, User profile edit pages.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/settings-layout",
       "files": [
         {
-          "path": "components/ui/settings-layout.tsx",
+          "path": "components/registry/n2-primitives/settings-layout.tsx",
+          "target": "components/ui/settings-layout.tsx",
           "type": "registry:ui"
         }
       ],
@@ -22199,7 +22676,8 @@
       "docs": "Use it for: planner, news, transport.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/severity-badge",
       "files": [
         {
-          "path": "components/ui/severity-badge.tsx",
+          "path": "components/registry/n2-primitives/severity-badge.tsx",
+          "target": "components/ui/severity-badge.tsx",
           "type": "registry:ui"
         }
       ],
@@ -22244,7 +22722,8 @@
       "docs": "Use it for: Social share sheets with copy and native share, Article share dialogs, Event and invite share dialogs, QR code share overlays, Deep-link share composers.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/share-dialog",
       "files": [
         {
-          "path": "components/ui/share-dialog.tsx",
+          "path": "components/registry/n2-primitives/share-dialog.tsx",
+          "target": "components/ui/share-dialog.tsx",
           "type": "registry:ui"
         }
       ],
@@ -22297,7 +22776,8 @@
       "docs": "Use it for: Side panels for extended forms, Filter panels in desktop search, Detail drawers from list rows, Settings panels on desktop layouts, Secondary content overlays.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sheet",
       "files": [
         {
-          "path": "components/ui/sheet.tsx",
+          "path": "components/registry/n2-primitives/sheet.tsx",
+          "target": "components/ui/sheet.tsx",
           "type": "registry:ui"
         }
       ],
@@ -22348,7 +22828,8 @@
       "docs": "Use it for: Customizable sidebar shell for any app, Design-portal sidebar foundation, Base for all sidebar variants, Composable sidebar parts (header, content, footer), Theme-aware sidebar with collapse support.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar",
       "files": [
         {
-          "path": "components/ui/sidebar.tsx",
+          "path": "components/registry/n2-primitives/sidebar.tsx",
+          "target": "components/ui/sidebar.tsx",
           "type": "registry:ui"
         }
       ],
@@ -22403,7 +22884,8 @@
       "docs": "Use it for: Simple apps with icon-and-label navigation, Small-team admin interfaces, Basic dashboard layouts, Starter pattern for new sidebar implementations, Minimal navigation requirements.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar-01",
       "files": [
         {
-          "path": "components/blocks/sidebar-01.tsx",
+          "path": "components/registry/n2-primitives/sidebar-01.tsx",
+          "target": "components/blocks/sidebar-01.tsx",
           "type": "registry:block"
         }
       ],
@@ -22454,7 +22936,8 @@
       "docs": "Use it for: Apps with grouped navigation sections, Multi-area dashboards with section collapsing, Large feature sets organized by domain, Settings pages with grouped categories, Admin consoles with many tools.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar-02",
       "files": [
         {
-          "path": "components/blocks/sidebar-02.tsx",
+          "path": "components/registry/n2-primitives/sidebar-02.tsx",
+          "target": "components/blocks/sidebar-02.tsx",
           "type": "registry:block"
         }
       ],
@@ -22505,7 +22988,8 @@
       "docs": "Use it for: Content-heavy apps needing search-first navigation, File browsers and document systems, Knowledge bases and wikis, Apps with many navigation items, Search-driven workflows.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar-03",
       "files": [
         {
-          "path": "components/blocks/sidebar-03.tsx",
+          "path": "components/registry/n2-primitives/sidebar-03.tsx",
+          "target": "components/blocks/sidebar-03.tsx",
           "type": "registry:block"
         }
       ],
@@ -22556,7 +23040,8 @@
       "docs": "Use it for: Apps where user identity is core to navigation, Team workspaces with avatar-first sidebars, Social and community apps, Account-centric admin interfaces, Multi-profile apps with active-user context.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar-04",
       "files": [
         {
-          "path": "components/blocks/sidebar-04.tsx",
+          "path": "components/registry/n2-primitives/sidebar-04.tsx",
+          "target": "components/blocks/sidebar-04.tsx",
           "type": "registry:block"
         }
       ],
@@ -22607,7 +23092,8 @@
       "docs": "Use it for: Deep hierarchical navigation, Admin consoles with nested modules, Documentation with nested page trees, File browsers with folder nesting, Apps with parent/child resource relationships.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar-05",
       "files": [
         {
-          "path": "components/blocks/sidebar-05.tsx",
+          "path": "components/registry/n2-primitives/sidebar-05.tsx",
+          "target": "components/blocks/sidebar-05.tsx",
           "type": "registry:block"
         }
       ],
@@ -22658,7 +23144,8 @@
       "docs": "Use it for: Space-constrained layouts, Icon-first power-user interfaces, Tool-centric apps (design, dev tools), Collapsed states of full sidebars, Tablet and compact desktop modes.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar-06",
       "files": [
         {
-          "path": "components/blocks/sidebar-06.tsx",
+          "path": "components/registry/n2-primitives/sidebar-06.tsx",
+          "target": "components/blocks/sidebar-06.tsx",
           "type": "registry:block"
         }
       ],
@@ -22709,7 +23196,8 @@
       "docs": "Use it for: Apps with unread counts and activity indicators, Inbox-style navigation with queue counts, Task management with priority badges, Chat apps with channel notification counts, Moderation queues with severity indicators.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar-07",
       "files": [
         {
-          "path": "components/blocks/sidebar-07.tsx",
+          "path": "components/registry/n2-primitives/sidebar-07.tsx",
+          "target": "components/blocks/sidebar-07.tsx",
           "type": "registry:block"
         }
       ],
@@ -22760,7 +23248,8 @@
       "docs": "Use it for: Apps with branding header and user footer, Marketing-aware admin consoles, Logo-prominent navigation, Apps with version info in footer, Workspace apps with team info in header.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar-08",
       "files": [
         {
-          "path": "components/blocks/sidebar-08.tsx",
+          "path": "components/registry/n2-primitives/sidebar-08.tsx",
+          "target": "components/blocks/sidebar-08.tsx",
           "type": "registry:block"
         }
       ],
@@ -22811,7 +23300,8 @@
       "docs": "Use it for: Apps with categorical feature groups, Multi-product suites organized by category, Admin consoles with grouped menu items, Tool directories with feature groupings, Navigation structured by functional area.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar-09",
       "files": [
         {
-          "path": "components/blocks/sidebar-09.tsx",
+          "path": "components/registry/n2-primitives/sidebar-09.tsx",
+          "target": "components/blocks/sidebar-09.tsx",
           "type": "registry:block"
         }
       ],
@@ -22862,7 +23352,8 @@
       "docs": "Use it for: Floating-design apps (iOS-style detached panels), Content-focused apps where nav floats above content, Apps with visual separation from page edge, Modern aesthetic design systems, Landing-page-style navigation.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar-10",
       "files": [
         {
-          "path": "components/blocks/sidebar-10.tsx",
+          "path": "components/registry/n2-primitives/sidebar-10.tsx",
+          "target": "components/blocks/sidebar-10.tsx",
           "type": "registry:block"
         }
       ],
@@ -22913,7 +23404,8 @@
       "docs": "Use it for: Complex apps with many nested sections, Admin consoles with expandable tool groups, Documentation with collapsible topic groups, Navigation needing progressive disclosure, Space-efficient deep navigation.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar-11",
       "files": [
         {
-          "path": "components/blocks/sidebar-11.tsx",
+          "path": "components/registry/n2-primitives/sidebar-11.tsx",
+          "target": "components/blocks/sidebar-11.tsx",
           "type": "registry:block"
         }
       ],
@@ -22963,7 +23455,8 @@
       "docs": "Use it for: Deep navigation where current location context matters, Admin consoles with nested resource paths, File browsers showing folder trail, Documentation with section path awareness, Apps where users navigate deeply.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar-12",
       "files": [
         {
-          "path": "components/blocks/sidebar-12.tsx",
+          "path": "components/registry/n2-primitives/sidebar-12.tsx",
+          "target": "components/blocks/sidebar-12.tsx",
           "type": "registry:block"
         }
       ],
@@ -23014,7 +23507,8 @@
       "docs": "Use it for: Apps where quick actions are important, Admin consoles with common-task shortcuts, Sales and CRM apps with frequent actions, Productivity tools with one-click operations, Workflow apps with common next-steps.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar-13",
       "files": [
         {
-          "path": "components/blocks/sidebar-13.tsx",
+          "path": "components/registry/n2-primitives/sidebar-13.tsx",
+          "target": "components/blocks/sidebar-13.tsx",
           "type": "registry:block"
         }
       ],
@@ -23065,7 +23559,8 @@
       "docs": "Use it for: Apps where theme switching is a first-class action, Reading apps with light/dark/sepia modes, Apps with density and size preferences, Apps built for extended usage sessions, Apps with accessibility mode switching.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar-14",
       "files": [
         {
-          "path": "components/blocks/sidebar-14.tsx",
+          "path": "components/registry/n2-primitives/sidebar-14.tsx",
+          "target": "components/blocks/sidebar-14.tsx",
           "type": "registry:block"
         }
       ],
@@ -23116,7 +23611,8 @@
       "docs": "Use it for: Multi-tenant apps (team or organisation switching), Enterprise admin consoles with multiple workspaces, Apps where users belong to multiple contexts, Agency and consulting tools with client switching, Platform apps with brand or project switching.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar-15",
       "files": [
         {
-          "path": "components/blocks/sidebar-15.tsx",
+          "path": "components/registry/n2-primitives/sidebar-15.tsx",
+          "target": "components/blocks/sidebar-15.tsx",
           "type": "registry:block"
         }
       ],
@@ -23167,7 +23663,8 @@
       "docs": "Use it for: Enterprise apps needing every sidebar feature, Apps inheriting from shadcn/ui full sidebar reference, Complex multi-tenant multi-feature consoles, Production-ready sidebar with all patterns enabled, Feature-complete navigation for mature products.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar-16",
       "files": [
         {
-          "path": "components/blocks/sidebar-16.tsx",
+          "path": "components/registry/n2-primitives/sidebar-16.tsx",
+          "target": "components/blocks/sidebar-16.tsx",
           "type": "registry:block"
         }
       ],
@@ -23217,7 +23714,8 @@
       "docs": "Use it for: Authentication flow, Login/signup entry point.\nVariants: default, loading.\nAccessibility: Form labels, Keyboard navigation, Error announcements, Focus-visible via L1 global CSS.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/signup-01",
       "files": [
         {
-          "path": "components/blocks/signup-01.tsx",
+          "path": "components/registry/n6-pages/signup-01.tsx",
+          "target": "components/blocks/signup-01.tsx",
           "type": "registry:block"
         }
       ],
@@ -23261,7 +23759,8 @@
       "docs": "Use it for: Authentication flow, Login/signup entry point.\nVariants: default, loading.\nAccessibility: Form labels, Keyboard navigation, Error announcements, Focus-visible via L1 global CSS.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/signup-02",
       "files": [
         {
-          "path": "components/blocks/signup-02.tsx",
+          "path": "components/registry/n6-pages/signup-02.tsx",
+          "target": "components/blocks/signup-02.tsx",
           "type": "registry:block"
         }
       ],
@@ -23305,7 +23804,8 @@
       "docs": "Use it for: Authentication flow, Login/signup entry point.\nVariants: default, loading.\nAccessibility: Form labels, Keyboard navigation, Error announcements, Focus-visible via L1 global CSS.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/signup-03",
       "files": [
         {
-          "path": "components/blocks/signup-03.tsx",
+          "path": "components/registry/n6-pages/signup-03.tsx",
+          "target": "components/blocks/signup-03.tsx",
           "type": "registry:block"
         }
       ],
@@ -23349,7 +23849,8 @@
       "docs": "Use it for: Authentication flow, Login/signup entry point.\nVariants: default, loading.\nAccessibility: Form labels, Keyboard navigation, Error announcements, Focus-visible via L1 global CSS.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/signup-04",
       "files": [
         {
-          "path": "components/blocks/signup-04.tsx",
+          "path": "components/registry/n6-pages/signup-04.tsx",
+          "target": "components/blocks/signup-04.tsx",
           "type": "registry:block"
         }
       ],
@@ -23393,7 +23894,8 @@
       "docs": "Use it for: Authentication flow, Login/signup entry point.\nVariants: default, loading.\nAccessibility: Form labels, Keyboard navigation, Error announcements, Focus-visible via L1 global CSS.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/signup-05",
       "files": [
         {
-          "path": "components/blocks/signup-05.tsx",
+          "path": "components/registry/n6-pages/signup-05.tsx",
+          "target": "components/blocks/signup-05.tsx",
           "type": "registry:block"
         }
       ],
@@ -23438,7 +23940,8 @@
       "docs": "Use it for: Content placeholder during fetch, Table row placeholders during pagination, Card grid loading states, Feed placeholders during initial load, Preventing layout shift during data loading.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/skeleton",
       "files": [
         {
-          "path": "components/ui/skeleton.tsx",
+          "path": "components/registry/n2-primitives/skeleton.tsx",
+          "target": "components/ui/skeleton.tsx",
           "type": "registry:ui"
         }
       ],
@@ -23482,7 +23985,8 @@
       "docs": "Use it for: Price range filter in search, Brightness and volume adjustments, Image editor parameter controls, Rating scale inputs, Numeric range selection in analytics filters.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/slider",
       "files": [
         {
-          "path": "components/ui/slider.tsx",
+          "path": "components/registry/n2-primitives/slider.tsx",
+          "target": "components/ui/slider.tsx",
           "type": "registry:ui"
         }
       ],
@@ -23526,7 +24030,8 @@
       "docs": "Use it for: pulse, campfire, circles, bytes.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/social-feed-page",
       "files": [
         {
-          "path": "components/ui/social-feed-page.tsx",
+          "path": "components/registry/n6-pages/social-feed-page.tsx",
+          "target": "components/ui/social-feed-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -23576,7 +24081,8 @@
       "docs": "Use it for: Fast, stackable toast notifications, Form submission success feedback, Quick error notifications, Background action confirmations, Promise-based async feedback (loading/success/error).\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sonner",
       "files": [
         {
-          "path": "components/ui/sonner.tsx",
+          "path": "components/registry/n2-primitives/sonner.tsx",
+          "target": "components/ui/sonner.tsx",
           "type": "registry:ui"
         }
       ],
@@ -23621,7 +24127,8 @@
       "docs": "Use it for: Citing source documents in AI responses, Displaying provenance for AI-generated facts, Academic research assistant citation display, Legal and medical AI with authoritative sources, Link-backed answers in knowledge base search.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/source-citation",
       "files": [
         {
-          "path": "components/ui/source-citation.tsx",
+          "path": "components/registry/n2-primitives/source-citation.tsx",
+          "target": "components/ui/source-citation.tsx",
           "type": "registry:ui"
         }
       ],
@@ -23665,7 +24172,8 @@
       "docs": "Use it for: Button loading states, Page-level loading indicators, Inline content loading placeholders, Async operation progress indicators, Refresh and reload feedback.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/spinner",
       "files": [
         {
-          "path": "components/ui/spinner.tsx",
+          "path": "components/registry/n2-primitives/spinner.tsx",
+          "target": "components/ui/spinner.tsx",
           "type": "registry:ui"
         }
       ],
@@ -23709,7 +24217,8 @@
       "docs": "Use it for: campfire, wallet.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/split-bill",
       "files": [
         {
-          "path": "components/ui/split-bill.tsx",
+          "path": "components/registry/n2-primitives/split-bill.tsx",
+          "target": "components/ui/split-bill.tsx",
           "type": "registry:ui"
         }
       ],
@@ -23753,7 +24262,8 @@
       "docs": "Use it for: Master-detail layouts (email, chat), File browser with preview pane, Documentation browser with content pane, Admin console with detail drawer, Split-screen workflows on desktop.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/split-view",
       "files": [
         {
-          "path": "components/ui/split-view.tsx",
+          "path": "components/registry/n2-primitives/split-view.tsx",
+          "target": "components/ui/split-view.tsx",
           "type": "registry:ui"
         }
       ],
@@ -23794,7 +24304,8 @@
       "docs": "Use it for: KPI dashboards with primary metrics, Revenue and growth indicators, User count and engagement metrics, Service health score displays, Analytics summary cards with trend.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/stats-card",
       "files": [
         {
-          "path": "components/ui/stats-card.tsx",
+          "path": "components/registry/n2-primitives/stats-card.tsx",
+          "target": "components/ui/stats-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -23839,7 +24350,8 @@
       "docs": "Use it for: pulse, shamwari, campfire.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/status-dot",
       "files": [
         {
-          "path": "components/ui/status-dot.tsx",
+          "path": "components/registry/n2-primitives/status-dot.tsx",
+          "target": "components/ui/status-dot.tsx",
           "type": "registry:ui"
         }
       ],
@@ -23881,7 +24393,8 @@
       "docs": "Use it for: User presence indicators (online/offline/away), Service health status dots, Live broadcast and streaming indicators, Server and API endpoint status displays, Build and deployment status.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/status-indicator",
       "files": [
         {
-          "path": "components/ui/status-indicator.tsx",
+          "path": "components/registry/n2-primitives/status-indicator.tsx",
+          "target": "components/ui/status-indicator.tsx",
           "type": "registry:ui"
         }
       ],
@@ -23924,7 +24437,8 @@
       "docs": "Use it for: nhimbe, events, wallet.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/step-progress",
       "files": [
         {
-          "path": "components/ui/step-progress.tsx",
+          "path": "components/registry/n2-primitives/step-progress.tsx",
+          "target": "components/ui/step-progress.tsx",
           "type": "registry:ui"
         }
       ],
@@ -23966,7 +24480,8 @@
       "docs": "Use it for: Multi-step onboarding wizards, Checkout flow step navigation, Form-filling multi-page progress, Tutorial step progression, Application process step tracking.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/stepper",
       "files": [
         {
-          "path": "components/ui/stepper.tsx",
+          "path": "components/registry/n2-primitives/stepper.tsx",
+          "target": "components/ui/stepper.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24011,7 +24526,8 @@
       "docs": "Use it for: Sticky page headers on scroll, Persistent action bars on long pages, Sticky filter bars in search results, Sticky primary CTA on mobile detail pages, Persistent context bars in editors.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sticky-bar",
       "files": [
         {
-          "path": "components/ui/sticky-bar.tsx",
+          "path": "components/registry/n2-primitives/sticky-bar.tsx",
+          "target": "components/ui/sticky-bar.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24052,7 +24568,8 @@
       "docs": "Use it for: transport.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/stop-card",
       "files": [
         {
-          "path": "components/ui/stop-card.tsx",
+          "path": "components/registry/n2-primitives/stop-card.tsx",
+          "target": "components/ui/stop-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24093,7 +24610,8 @@
       "docs": "Use it for: pulse, bytes.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/story-creator",
       "files": [
         {
-          "path": "components/ui/story-creator.tsx",
+          "path": "components/registry/n2-primitives/story-creator.tsx",
+          "target": "components/ui/story-creator.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24137,7 +24655,8 @@
       "docs": "Use it for: Real-time display of streaming LLM responses, Progressive rendering of AI-generated content, Loading-feel text animations during API waits, Narrative storytelling interfaces with pacing, Educational content with controlled reveal.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/streaming-text",
       "files": [
         {
-          "path": "components/ui/streaming-text.tsx",
+          "path": "components/registry/n2-primitives/streaming-text.tsx",
+          "target": "components/ui/streaming-text.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24178,7 +24697,8 @@
       "docs": "Use it for: Active subscription display in account settings, Plan management interface, Upgrade/downgrade flow, Usage and billing preview, Cancellation and renewal controls.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/subscription-card",
       "files": [
         {
-          "path": "components/ui/subscription-card.tsx",
+          "path": "components/registry/n2-primitives/subscription-card.tsx",
+          "target": "components/ui/subscription-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24222,7 +24742,8 @@
       "docs": "Use it for: Access control, Security gate, Verification check.\nVariants: allowed, blocked, loading.\nIncludes: Y-axis safety spine, Renders children when check passes, Branded explanation when blocked, Web2 safety gate.\nAccessibility: Screen reader announces gate state, Focus management on state change.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/subscription-gate",
       "files": [
         {
-          "path": "components/ui/subscription-gate.tsx",
+          "path": "components/registry/n4-safety/subscription-gate.tsx",
+          "target": "components/ui/subscription-gate.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24270,7 +24791,8 @@
       "docs": "Use it for: Quick-start prompts for new AI chat sessions, Context-aware follow-up suggestions, Onboarding guided prompts for first-time users, Discovery surface for AI capabilities, Category-filtered prompt libraries.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/suggested-prompts",
       "files": [
         {
-          "path": "components/ui/suggested-prompts.tsx",
+          "path": "components/registry/n2-primitives/suggested-prompts.tsx",
+          "target": "components/ui/suggested-prompts.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24315,7 +24837,8 @@
       "docs": "Use it for: Dark mode toggle, Notification opt-in switches, Feature flag enable/disable, Privacy setting toggles, Binary preference settings.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/switch",
       "files": [
         {
-          "path": "components/ui/switch.tsx",
+          "path": "components/registry/n2-primitives/switch.tsx",
+          "target": "components/ui/switch.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24360,7 +24883,8 @@
       "docs": "Use it for: health.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/symptom-checker",
       "files": [
         {
-          "path": "components/ui/symptom-checker.tsx",
+          "path": "components/registry/n2-primitives/symptom-checker.tsx",
+          "target": "components/ui/symptom-checker.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24404,7 +24928,8 @@
       "docs": "Use it for: Tabular data display (orders, users, products), Settings tables with key-value rows, Reference tables (pricing, specifications), Report tables with grouped rows, Simple data listings without heavy interactivity.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/table",
       "files": [
         {
-          "path": "components/ui/table.tsx",
+          "path": "components/registry/n2-primitives/table.tsx",
+          "target": "components/ui/table.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24450,7 +24975,8 @@
       "docs": "Use it for: Settings pages with section switching, Dashboard view selection, Product detail pages (overview/reviews/specs), Admin panels with multi-area layouts, Code editor with file tabs.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/tabs",
       "files": [
         {
-          "path": "components/ui/tabs.tsx",
+          "path": "components/registry/n2-primitives/tabs.tsx",
+          "target": "components/ui/tabs.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24495,7 +25021,8 @@
       "docs": "Use it for: Tag selection for articles and posts, Skill and interest selection in profiles, Recipient entry in messaging (To: field), Filter multi-select as pills, Category assignment in content management.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/tag-input",
       "files": [
         {
-          "path": "components/ui/tag-input.tsx",
+          "path": "components/registry/n2-primitives/tag-input.tsx",
+          "target": "components/ui/tag-input.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24540,7 +25067,8 @@
       "docs": "Use it for: planner.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/task-board",
       "files": [
         {
-          "path": "components/ui/task-board.tsx",
+          "path": "components/registry/n2-primitives/task-board.tsx",
+          "target": "components/ui/task-board.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24586,7 +25114,8 @@
       "docs": "Use it for: nhimbe, console, bushtrade.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/team-management-page",
       "files": [
         {
-          "path": "components/ui/team-management-page.tsx",
+          "path": "components/registry/n6-pages/team-management-page.tsx",
+          "target": "components/ui/team-management-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24631,7 +25160,8 @@
       "docs": "Use it for: health.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/telemedicine-widget",
       "files": [
         {
-          "path": "components/ui/telemedicine-widget.tsx",
+          "path": "components/registry/n2-primitives/telemedicine-widget.tsx",
+          "target": "components/ui/telemedicine-widget.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24675,7 +25205,8 @@
       "docs": "Use it for: all.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/text-size-adjuster",
       "files": [
         {
-          "path": "components/ui/text-size-adjuster.tsx",
+          "path": "components/registry/n2-primitives/text-size-adjuster.tsx",
+          "target": "components/ui/text-size-adjuster.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24719,7 +25250,8 @@
       "docs": "Use it for: Comment composition, Long-form feedback and review entry, Bug report and support ticket body, Article summary and description fields, Multi-line settings (bio, about).\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/textarea",
       "files": [
         {
-          "path": "components/ui/textarea.tsx",
+          "path": "components/registry/n2-primitives/textarea.tsx",
+          "target": "components/ui/textarea.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24763,7 +25295,8 @@
       "docs": "Use it for: Appointment and meeting time selection, Alarm and reminder time entry, Event start and end time pickers, Scheduled task time configuration, Business hours setting.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/time-picker",
       "files": [
         {
-          "path": "components/ui/time-picker.tsx",
+          "path": "components/registry/n2-primitives/time-picker.tsx",
+          "target": "components/ui/time-picker.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24813,7 +25346,8 @@
       "docs": "Use it for: planner, news, wallet.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/time-series-chart",
       "files": [
         {
-          "path": "components/ui/time-series-chart.tsx",
+          "path": "components/registry/n2-primitives/time-series-chart.tsx",
+          "target": "components/ui/time-series-chart.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24858,7 +25392,8 @@
       "docs": "Use it for: Booking platforms with available slots, Medical and telemedicine appointment booking, Conference room reservation, Consultation scheduling, Service provider availability selection.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/time-slot-picker",
       "files": [
         {
-          "path": "components/ui/time-slot-picker.tsx",
+          "path": "components/registry/n2-primitives/time-slot-picker.tsx",
+          "target": "components/ui/time-slot-picker.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24900,7 +25435,8 @@
       "docs": "Use it for: planner.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/time-tracker",
       "files": [
         {
-          "path": "components/ui/time-tracker.tsx",
+          "path": "components/registry/n2-primitives/time-tracker.tsx",
+          "target": "components/ui/time-tracker.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24940,7 +25476,8 @@
       "docs": "Use it for: Project history and milestones, Order status tracking, User activity over time, Version history visualization, Event sequence displays.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/timeline",
       "files": [
         {
-          "path": "components/ui/timeline.tsx",
+          "path": "components/registry/n2-primitives/timeline.tsx",
+          "target": "components/ui/timeline.tsx",
           "type": "registry:ui"
         }
       ],
@@ -24983,7 +25520,8 @@
       "docs": "Use it for: Bounding slow third-party API calls, User-experience guardrails on async operations, Preventing hung requests from blocking UI, Circuit-breaker companion for time-based failure, Worker task time-boxing.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/timeout",
       "files": [
         {
-          "path": "lib/timeout.ts",
+          "path": "components/registry/n2-primitives/timeout.ts",
+          "target": "lib/timeout.ts",
           "type": "registry:lib"
         }
       ],
@@ -25028,7 +25566,8 @@
       "docs": "Use it for: Non-blocking success confirmations, Error notifications from background tasks, Network status change notifications, Feature unlock and achievement announcements, System event notifications.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/toast",
       "files": [
         {
-          "path": "components/ui/toast.tsx",
+          "path": "components/registry/n2-primitives/toast.tsx",
+          "target": "components/ui/toast.tsx",
           "type": "registry:ui"
         }
       ],
@@ -25074,7 +25613,8 @@
       "docs": "Use it for: Application-level toast rendering container, Global toast position management, Queue display for stacked notifications, Root-level feedback provider for async operations, Cross-page persistent notification surface.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/toaster",
       "files": [
         {
-          "path": "components/ui/toaster.tsx",
+          "path": "components/registry/n2-primitives/toaster.tsx",
+          "target": "components/ui/toaster.tsx",
           "type": "registry:ui"
         }
       ],
@@ -25120,7 +25660,8 @@
       "docs": "Use it for: Task management apps (standalone or part of larger workflow), Project milestone tracking, Daily planner apps, Team assignment lists, Onboarding step completion tracking.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/todo-item",
       "files": [
         {
-          "path": "components/ui/todo-item.tsx",
+          "path": "components/registry/n2-primitives/todo-item.tsx",
+          "target": "components/ui/todo-item.tsx",
           "type": "registry:ui"
         }
       ],
@@ -25169,7 +25710,8 @@
       "docs": "Use it for: Toggle buttons for bold/italic/underline in editors, Settings switches (dark mode, notifications), Enable/disable feature flags, Mute/unmute audio or video controls, Pin/unpin items in lists.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/toggle",
       "files": [
         {
-          "path": "components/ui/toggle.tsx",
+          "path": "components/registry/n2-primitives/toggle.tsx",
+          "target": "components/ui/toggle.tsx",
           "type": "registry:ui"
         }
       ],
@@ -25219,7 +25761,8 @@
       "docs": "Use it for: Text formatting toolbar (bold/italic/underline group), Alignment group (left/center/right/justify), View mode selection (grid/list/gallery), Time range picker (day/week/month/year), Multi-select filter groups in search.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/toggle-group",
       "files": [
         {
-          "path": "components/ui/toggle-group.tsx",
+          "path": "components/registry/n2-primitives/toggle-group.tsx",
+          "target": "components/ui/toggle-group.tsx",
           "type": "registry:ui"
         }
       ],
@@ -25266,7 +25809,8 @@
       "docs": "Use it for: wallet.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/token-balance-card",
       "files": [
         {
-          "path": "components/ui/token-balance-card.tsx",
+          "path": "components/registry/n2-primitives/token-balance-card.tsx",
+          "target": "components/ui/token-balance-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -25310,7 +25854,8 @@
       "docs": "Use it for: nhimbe, wallet, bushtrade.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/token-row",
       "files": [
         {
-          "path": "components/ui/token-row.tsx",
+          "path": "components/registry/n2-primitives/token-row.tsx",
+          "target": "components/ui/token-row.tsx",
           "type": "registry:ui"
         }
       ],
@@ -25353,7 +25898,8 @@
       "docs": "Use it for: Rich text editor toolbars, Admin table action bars, Image editor tool selection, Presentation mode controls, Mobile editing toolbars.\nVariants: default, grouped, with-overflow, vertical.\nIncludes: Grouped segment support, Overflow menu for narrow viewports, Keyboard navigation (Tab, arrow keys), Sticky positioning variant, Harness integration.\nAccessibility: role=toolbar with aria-label, Each action button has accessible name, Focus visible on each tool, Overflow menu announced on activation, Keyboard-navigable tool groups.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/toolbar",
       "files": [
         {
-          "path": "components/ui/toolbar.tsx",
+          "path": "components/registry/n2-primitives/toolbar.tsx",
+          "target": "components/ui/toolbar.tsx",
           "type": "registry:ui"
         }
       ],
@@ -25407,7 +25953,8 @@
       "docs": "Use it for: Icon button labels, Keyboard shortcut hints, Truncated text full value display, Explanatory hints on form fields, Help text on dashboard elements.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/tooltip",
       "files": [
         {
-          "path": "components/ui/tooltip.tsx",
+          "path": "components/registry/n2-primitives/tooltip.tsx",
+          "target": "components/ui/tooltip.tsx",
           "type": "registry:ui"
         }
       ],
@@ -25451,7 +25998,8 @@
       "docs": "Use it for: nhimbe, wallet, bushtrade.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/transaction-history-page",
       "files": [
         {
-          "path": "components/ui/transaction-history-page.tsx",
+          "path": "components/registry/n6-pages/transaction-history-page.tsx",
+          "target": "components/ui/transaction-history-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -25497,7 +26045,8 @@
       "docs": "Use it for: nhimbe, wallet, bushtrade.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/transaction-receipt",
       "files": [
         {
-          "path": "components/ui/transaction-receipt.tsx",
+          "path": "components/registry/n2-primitives/transaction-receipt.tsx",
+          "target": "components/ui/transaction-receipt.tsx",
           "type": "registry:ui"
         }
       ],
@@ -25540,7 +26089,8 @@
       "docs": "Use it for: Permission assignment (available roles and granted roles), User selection in team management, Multi-select with move between lists, Feature flag enable/disable UI, Access control configuration.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/transfer-list",
       "files": [
         {
-          "path": "components/ui/transfer-list.tsx",
+          "path": "components/registry/n2-primitives/transfer-list.tsx",
+          "target": "components/ui/transfer-list.tsx",
           "type": "registry:ui"
         }
       ],
@@ -25588,7 +26138,8 @@
       "docs": "Use it for: campfire, news, lingo.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/translation-indicator",
       "files": [
         {
-          "path": "components/ui/translation-indicator.tsx",
+          "path": "components/registry/n2-primitives/translation-indicator.tsx",
+          "target": "components/ui/translation-indicator.tsx",
           "type": "registry:ui"
         }
       ],
@@ -25631,7 +26182,8 @@
       "docs": "Use it for: File and folder browsers, Organization hierarchy displays, Nested category navigation, Component hierarchy in design tools, Location and region trees.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/tree-view",
       "files": [
         {
-          "path": "components/ui/tree-view.tsx",
+          "path": "components/registry/n2-primitives/tree-view.tsx",
+          "target": "components/ui/tree-view.tsx",
           "type": "registry:ui"
         }
       ],
@@ -25675,7 +26227,8 @@
       "docs": "Use it for: Real-time typing indicator in active chats, Presence feedback during message composition, AI processing indicator during response generation, Collaborative editing presence signals, Form-filling indicator in pair workflows.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/typing-indicator",
       "files": [
         {
-          "path": "components/ui/typing-indicator.tsx",
+          "path": "components/registry/n2-primitives/typing-indicator.tsx",
+          "target": "components/ui/typing-indicator.tsx",
           "type": "registry:ui"
         }
       ],
@@ -25718,7 +26271,8 @@
       "docs": "Use it for: Consistent heading and body text components, Typography primitives for composed layouts, Base text rendering across the design system, Theme-aware text styling, Accessible typographic hierarchy.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/typography",
       "files": [
         {
-          "path": "components/ui/typography.tsx",
+          "path": "components/registry/n2-primitives/typography.tsx",
+          "target": "components/ui/typography.tsx",
           "type": "registry:ui"
         }
       ],
@@ -25759,7 +26313,8 @@
       "docs": "Use it for: Low-memory detection in long-running sessions, Deferred loading based on device capability, Memory-adaptive content quality switching, Mobile device optimization in chat and feeds, Background task throttling on constrained devices.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/use-memory-pressure",
       "files": [
         {
-          "path": "hooks/use-memory-pressure.ts",
+          "path": "components/registry/n2-primitives/use-memory-pressure.ts",
+          "target": "hooks/use-memory-pressure.ts",
           "type": "registry:hook"
         }
       ],
@@ -25804,7 +26359,8 @@
       "docs": "Use it for: Responsive layout switching between mobile and desktop, Touch vs. mouse interaction adaptation, Mobile-specific feature enablement, Sidebar collapse based on screen size, Navigation pattern adaptation.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/use-mobile",
       "files": [
         {
-          "path": "hooks/use-mobile.ts",
+          "path": "components/registry/n2-primitives/use-mobile.ts",
+          "target": "hooks/use-mobile.ts",
           "type": "registry:hook"
         }
       ],
@@ -25846,7 +26402,8 @@
       "docs": "Use it for: Triggering toast notifications from anywhere in the app, Form submission success feedback, Error notification from async operations, System status messages (offline, reconnecting), Action confirmation messages.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/use-toast",
       "files": [
         {
-          "path": "hooks/use-toast.ts",
+          "path": "components/registry/n2-primitives/use-toast.ts",
+          "target": "hooks/use-toast.ts",
           "type": "registry:hook"
         }
       ],
@@ -25889,7 +26446,8 @@
       "docs": "Use it for: console.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/user-management-row",
       "files": [
         {
-          "path": "components/ui/user-management-row.tsx",
+          "path": "components/registry/n2-primitives/user-management-row.tsx",
+          "target": "components/ui/user-management-row.tsx",
           "type": "registry:ui"
         }
       ],
@@ -25938,7 +26496,8 @@
       "docs": "Use it for: cn() classname composition across all layers, Shared utility functions for formatting, Tailwind class merging helpers, Common type predicates and guards, Universal helpers imported everywhere.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/utils",
       "files": [
         {
-          "path": "lib/utils.ts",
+          "path": "components/registry/n2-primitives/utils.ts",
+          "target": "lib/utils.ts",
           "type": "registry:lib"
         }
       ],
@@ -25978,7 +26537,8 @@
       "docs": "Use it for: transport, bushtrade.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/vehicle-card",
       "files": [
         {
-          "path": "components/ui/vehicle-card.tsx",
+          "path": "components/registry/n2-primitives/vehicle-card.tsx",
+          "target": "components/ui/vehicle-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -26024,7 +26584,8 @@
       "docs": "Use it for: nhimbe, jobs, wallet, bushtrade, health.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/verification-page",
       "files": [
         {
-          "path": "components/ui/verification-page.tsx",
+          "path": "components/registry/n6-pages/verification-page.tsx",
+          "target": "components/ui/verification-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -26071,7 +26632,8 @@
       "docs": "Use it for: console.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/verification-review-card",
       "files": [
         {
-          "path": "components/ui/verification-review-card.tsx",
+          "path": "components/registry/n2-primitives/verification-review-card.tsx",
+          "target": "components/ui/verification-review-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -26116,7 +26678,8 @@
       "docs": "Use it for: Video-on-demand playback in Mukoko media, Course video playback in learning platforms, Tutorial and onboarding video playback, User-generated content video playback, Live stream players with replay.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/video-player",
       "files": [
         {
-          "path": "components/ui/video-player.tsx",
+          "path": "components/registry/n2-primitives/video-player.tsx",
+          "target": "components/ui/video-player.tsx",
           "type": "registry:ui"
         }
       ],
@@ -26160,7 +26723,8 @@
       "docs": "Use it for: bytes.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/video-trimmer",
       "files": [
         {
-          "path": "components/ui/video-trimmer.tsx",
+          "path": "components/registry/n2-primitives/video-trimmer.tsx",
+          "target": "components/ui/video-trimmer.tsx",
           "type": "registry:ui"
         }
       ],
@@ -26202,7 +26766,8 @@
       "docs": "Use it for: Large-dataset table rendering (10k+ rows), Long feed performance optimization, Admin data grids with thousands of records, Log viewer for high-volume output, Chat message history with massive scrollback.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/virtual-list",
       "files": [
         {
-          "path": "components/ui/virtual-list.tsx",
+          "path": "components/registry/n2-primitives/virtual-list.tsx",
+          "target": "components/ui/virtual-list.tsx",
           "type": "registry:ui"
         }
       ],
@@ -26247,7 +26812,8 @@
       "docs": "Use it for: health.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/vitals-display",
       "files": [
         {
-          "path": "components/ui/vitals-display.tsx",
+          "path": "components/registry/n2-primitives/vitals-display.tsx",
+          "target": "components/ui/vitals-display.tsx",
           "type": "registry:ui"
         }
       ],
@@ -26288,7 +26854,8 @@
       "docs": "Use it for: campfire.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/voice-note-player",
       "files": [
         {
-          "path": "components/ui/voice-note-player.tsx",
+          "path": "components/registry/n2-primitives/voice-note-player.tsx",
+          "target": "components/ui/voice-note-player.tsx",
           "type": "registry:ui"
         }
       ],
@@ -26331,7 +26898,8 @@
       "docs": "Use it for: circles.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/vote-buttons",
       "files": [
         {
-          "path": "components/ui/vote-buttons.tsx",
+          "path": "components/registry/n2-primitives/vote-buttons.tsx",
+          "target": "components/ui/vote-buttons.tsx",
           "type": "registry:ui"
         }
       ],
@@ -26372,7 +26940,8 @@
       "docs": "Use it for: wallet.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/wallet-card",
       "files": [
         {
-          "path": "components/ui/wallet-card.tsx",
+          "path": "components/registry/n2-primitives/wallet-card.tsx",
+          "target": "components/ui/wallet-card.tsx",
           "type": "registry:ui"
         }
       ],
@@ -26414,7 +26983,8 @@
       "docs": "Use it for: wallet.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/wallet-connect-button",
       "files": [
         {
-          "path": "components/ui/wallet-connect-button.tsx",
+          "path": "components/registry/n2-primitives/wallet-connect-button.tsx",
+          "target": "components/ui/wallet-connect-button.tsx",
           "type": "registry:ui"
         }
       ],
@@ -26458,7 +27028,8 @@
       "docs": "Use it for: nhimbe, wallet, bushtrade.\nVariants: default, loading.\nIncludes: X-axis page composition, Pure composition — no inline UI, Semantic CSS vars only, Children/slots for content.\nAccessibility: role=main, aria-label, Loading state with skeleton, Focus management.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/wallet-page",
       "files": [
         {
-          "path": "components/ui/wallet-page.tsx",
+          "path": "components/registry/n6-pages/wallet-page.tsx",
+          "target": "components/ui/wallet-page.tsx",
           "type": "registry:ui"
         }
       ],
@@ -26503,7 +27074,8 @@
       "docs": "Use it for: Webhook endpoint configuration in integrations, Event subscription management, Webhook delivery status monitoring, Third-party integration setup, Event-driven workflow configuration.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/webhook-card",
       "files": [
         {
-          "path": "components/ui/webhook-card.tsx",
+          "path": "components/registry/n2-primitives/webhook-card.tsx",
+          "target": "components/ui/webhook-card.tsx",
           "type": "registry:ui"
         }
       ],

--- a/scripts/generate-file-paths.mjs
+++ b/scripts/generate-file-paths.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Make `files[].path` mean what shadcn says it means, and move the install destination to
+ * `files[].target`.
+ *
+ *   pnpm registry:paths          rewrite registry.json
+ *   pnpm registry:paths --check  fail if it is out of date (CI)
+ *
+ * WHY THIS EXISTS
+ *
+ * shadcn's registry-item schema is explicit about the two fields:
+ *
+ *   path    the SOURCE location of the file inside the registry repository
+ *   target  the DESTINATION path in the consumer's project
+ *
+ * This registry had it backwards. Every item declared `path: "components/ui/button.tsx"` —
+ * the place the file should LAND — and no `target`. The real file is at
+ * `components/registry/n2-primitives/button.tsx`.
+ *
+ * Nothing caught it because our own API never reads `path` as a source: `/api/v1/ui/{name}`
+ * resolves the source by component NAME and inlines the content, so the wrong `path` was
+ * only ever used by the CLI as a destination hint — and the destination it derives from a
+ * `registry:ui` type plus that basename happens to be the same string. Right answer, wrong
+ * mechanism, and it only holds while every item's type implies its folder.
+ *
+ * It is not cosmetic. `shadcn registry validate nyuchi/mzizi` fails on all 574 items, and
+ * GitHub registries — `npx shadcn add nyuchi/mzizi/button`, which needs no API, no worker
+ * and no deploy — resolve files straight out of the repository at `path`. With the wrong
+ * path, that entire distribution channel is closed.
+ *
+ * GENERATED, NEVER HAND-EDITED. The source path is a fact about where the file is on disk,
+ * so hand-writing it creates a second copy that drifts the moment a component moves between
+ * node directories. `--check` gates it in CI.
+ */
+
+import { readdirSync, readFileSync, writeFileSync, statSync, existsSync } from "node:fs"
+import { join, extname, basename } from "node:path"
+
+const ROOT = process.cwd()
+const SOURCE_ROOT = join(ROOT, "components", "registry")
+const REGISTRY = join(ROOT, "registry.json")
+
+/**
+ * Extension preference, identical to `PRIMARY_EXTENSIONS` in `lib/registry.ts`.
+ *
+ * A component may have several implementations under one name (`button.tsx` + `button.rs`).
+ * `/api/v1/ui/{name}` serves the React one, so the React one is the source path here. If the
+ * two disagreed, the manifest would advertise a file the API does not serve.
+ */
+const PRIMARY = ["tsx", "ts", "jsx", "js"]
+
+const rank = (e) => {
+  const i = PRIMARY.indexOf(e)
+  return i === -1 ? PRIMARY.length : i
+}
+
+/** Repo-relative primary source path for every component name on disk. */
+function readSourceIndex() {
+  const index = new Map()
+  if (!existsSync(SOURCE_ROOT)) return index
+  for (const dir of readdirSync(SOURCE_ROOT)) {
+    const dirPath = join(SOURCE_ROOT, dir)
+    if (!/^n\d+-/.test(dir) || !statSync(dirPath).isDirectory()) continue
+    for (const file of readdirSync(dirPath)) {
+      if (!statSync(join(dirPath, file)).isFile()) continue
+      const name = basename(file, extname(file))
+      const ext = extname(file).replace(/^\./, "").toLowerCase()
+      const rel = `components/registry/${dir}/${file}`
+      const existing = index.get(name)
+      if (!existing) {
+        index.set(name, { rel, ext })
+        continue
+      }
+      if (rank(ext) < rank(existing.ext)) index.set(name, { rel, ext })
+    }
+  }
+  return index
+}
+
+function main() {
+  const check = process.argv.includes("--check")
+  const sources = readSourceIndex()
+  const manifest = JSON.parse(readFileSync(REGISTRY, "utf8"))
+
+  const problems = []
+  let changed = 0
+  let dataItems = 0
+
+  for (const item of manifest.items ?? []) {
+    const files = item.files ?? []
+    if (!files.length) {
+      // A data item (registry:theme) carries cssVars/css and no file. Nothing to path.
+      dataItems++
+      continue
+    }
+    const src = sources.get(item.name)
+    if (!src) {
+      problems.push(`${item.name}: no source file on disk under components/registry/`)
+      continue
+    }
+    for (const file of files) {
+      // The destination is whatever the item already installed to. Preserving it is the
+      // whole safety property of this change: every consumer that ran `shadcn add` before
+      // gets the same file in the same place after.
+      const target = file.target ?? file.path
+      if (file.path !== src.rel || file.target !== target) changed++
+      file.path = src.rel
+      file.target = target
+    }
+  }
+
+  if (problems.length) {
+    console.error("✖ cannot generate file paths:")
+    for (const p of problems) console.error(`  ${p}`)
+    process.exit(1)
+  }
+
+  if (check) {
+    if (changed > 0) {
+      console.error(
+        `✖ ${changed} registry file entr(ies) have a stale source path or a missing target.\n` +
+          "  Run `pnpm registry:paths` and commit the result."
+      )
+      process.exit(1)
+    }
+    console.log(
+      `✓ files[].path points at the real source and files[].target at the install ` +
+        `destination (${(manifest.items ?? []).length - dataItems} filed items).`
+    )
+    return
+  }
+
+  writeFileSync(REGISTRY, JSON.stringify(manifest, null, 2) + "\n")
+  console.log(
+    `✓ rewrote ${changed} file entr(ies): path → source on disk, target → install destination.`
+  )
+}
+
+main()

--- a/scripts/validate-registry.mjs
+++ b/scripts/validate-registry.mjs
@@ -322,6 +322,29 @@ function main() {
       )
     }
 
+    // — `path` is the SOURCE, `target` is the DESTINATION —
+    //
+    // shadcn's schema is explicit about which is which, and this registry had them merged:
+    // every item declared the install destination as `path` and no `target` at all. Our own
+    // API hid it, because `/api/v1/ui/{name}` resolves the source by component NAME and
+    // inlines the content — `path` was never read as a source, so a wrong one cost nothing
+    // locally. It cost the GitHub-registry channel entirely: `shadcn registry validate
+    // nyuchi/mzizi` failed on all 574 items, because that path is resolved against the repo.
+    for (const file of item.files ?? []) {
+      const p = file.path ?? ""
+      if (!p.startsWith("components/registry/")) {
+        err(
+          n,
+          `file path "${p}" is not a source path. \`path\` must point at the file as it ` +
+            "exists in THIS repo (components/registry/n<N>-<label>/…); the install " +
+            "destination belongs in `target`."
+        )
+      }
+      if (!file.target) {
+        err(n, `file "${p}" has no \`target\` — nothing says where it installs.`)
+      }
+    }
+
     // — a source containing JSX must install to a .tsx path —
     //
     // `nyuchi-resilience` shipped 18 KB of JSX into `lib/resilience/health-monitor.ts`;
@@ -339,7 +362,10 @@ function main() {
     // `<b>bold</b>` inside a doc comment all look like JSX to a pattern and are not.
     {
       const src = disk.get(n)
-      const declaredPath = item.files?.[0]?.path
+      // The INSTALL path is `target`. It used to be `path`, and reading `path` here now
+      // would compare the source's extension against itself and never fire — the gate would
+      // still print green while checking nothing.
+      const declaredPath = item.files?.[0]?.target
       // `rel` is relative to components/registry (e.g. `n1-tokens/nyuchi-tokens.ts`), and a
       // component's primary source is not always TypeScript — some are .md or .rs.
       const isTs = src && /\.tsx?$/.test(src.rel ?? "")


### PR DESCRIPTION
## Summary

`npx shadcn@latest registry validate nyuchi/mzizi` fails on **574 of 574 items**, every one
with `Failed to read file`. One error class, one cause.

shadcn's registry-item schema is explicit about the two fields:

| field | meaning |
| --- | --- |
| `path` | where the file **is** — its source location in the registry repository |
| `target` | where the file **goes** — the destination in the consumer's project |

This registry merged them. Every item declared `path: "components/ui/button.tsx"` — the
install destination — and no `target`. The real file is at
`components/registry/n2-primitives/button.tsx`.

**Why nothing caught it.** Our own API never reads `path` as a source: `/api/v1/ui/{name}`
resolves the file by component *name* and inlines the content, so a wrong `path` cost
nothing locally — the CLI used it only to derive a destination from `type` + basename, and
for a `registry:ui` item that derivation returns the same string. Right answer, wrong
mechanism, and it only holds while every item's type implies its folder — which
`accessibility-audit` (a `.md` file on a `registry:ui` item) already did not.

**What it cost.** The entire GitHub-registry channel. `npx shadcn add nyuchi/mzizi/button`
needs no API, no worker and no deploy — the CLI reads files straight out of the public repo
at `path`. With the destination in that field, not one file resolved.

## Changes

- `scripts/generate-file-paths.mjs` sets `path` from the file's real location on disk and
  moves the old value to `target`. Generated rather than hand-written, because the source
  path is a fact about disk and drifts the moment a component changes node directory.
- `/api/v1/ui/[name]` projects `target`. Without it the CLI falls back to deriving
  destinations again, which sends `accessibility-audit`'s `.md` into `components/ui/`.
- `RegistryFile` gains `target`.
- Two gates: `registry:paths:check` in CI, and validator rules that a `path` outside
  `components/registry/` is an error, as is a file with no `target`.
- The JSX-extension gate now reads `target` — left pointing at `path` it would compare the
  source's extension against itself and silently never fire again.

## Type

- [x] Bug fix
- [x] CI/infrastructure

## Pre-commit Gate

- [x] `pnpm lint` — zero warnings
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm test` — 204 tests pass
- [x] `pnpm audit` — no known vulnerabilities

## Registry / Design System

- [x] `registry.json` regenerated and `pnpm registry:normalize` run
- [x] `registry:verify`, `registry:validate`, `registry:paths:check`,
      `tokens:registry:check`, `registry:metadata:check` — all green (574 items)

### Verified with shadcn's own tooling

```
$ npx shadcn@latest registry validate nyuchi/mzizi
× Registry validation failed.  Checked 1 registry file and 574 items.     ← before

$ npx shadcn@latest registry validate nyuchi/mzizi#claude/mzizi-skills-publishing-i1r02q
√ Registry is valid.  √ Checked 1 registry file and 574 items.            ← this branch
```

**The GitHub channel now works end to end**, against this branch, with the API not involved:

- `shadcn add nyuchi/mzizi/nyuchi-tokens#<branch>` → 387 custom properties merged into
  `app/globals.css`
- `shadcn add nyuchi/mzizi/button#<branch>` → `components/ui/button.tsx`, 3921 B
- `shadcn add nyuchi/mzizi/nyuchi-resilience#<branch>` → the full 20-file dependency
  fan-out, **0 empty files** — bare `registryDependencies` resolve within the same repo

### Destinations are unchanged — this is the safety property

Every `target` is the item's previous `path`, so a consumer who ran `shadcn add` before gets
the same file in the same place after. Verified by installing `button`,
`accessibility-audit`, `nyuchi-tokens`, `nyuchi-tokens-typescript` and `nyuchi-resilience`
through a route-shaped payload and diffing the written tree against the pre-change install:
identical.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_