### PR TITLE
chore(mcp): register the shadcn MCP server for local development

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
     "supabase": {
       "type": "http",
       "url": "https://mcp.supabase.com/mcp?project_ref=grjsboqkaywpwatvrzmy&read_only=true"
+    },
+    "shadcn": {
+      "command": "npx",
+      "args": ["shadcn@latest", "mcp"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mzizi",
   "version": "1.0.0",
   "private": true,
-  "description": "Mzizi \u2014 an open-architecture project of the Bundu Foundation. Open 3D frontend architecture, component registry, and MCP server, operated and developed by Nyuchi.",
+  "description": "Mzizi — an open-architecture project of the Bundu Foundation. Open 3D frontend architecture, component registry, and MCP server, operated and developed by Nyuchi.",
   "homepage": "https://mzizi.dev",
   "packageManager": "pnpm@10.33.0",
   "scripts": {
@@ -139,7 +139,7 @@
     "postcss": "^8.5.25",
     "prettier": "^3.9.6",
     "prettier-plugin-tailwindcss": "^0.8.1",
-    "shadcn": "^4.16.0",
+    "shadcn": "^4.16.2",
     "tailwindcss": "^4.3.3",
     "tsx": "^4.23.1",
     "tw-animate-css": "1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,8 +314,8 @@ importers:
         specifier: ^0.8.1
         version: 0.8.1(prettier@3.9.6)
       shadcn:
-        specifier: ^4.16.0
-        version: 4.16.0(typescript@6.0.3)
+        specifier: ^4.16.2
+        version: 4.16.2(typescript@6.0.3)
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -4982,8 +4982,8 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  shadcn@4.16.0:
-    resolution: {integrity: sha512-kPr4RrQmbbZeAjwBYeBSpFvAHV8rkTlNPUluIxkRriq5TpevfFelVO5xvcF6oguHPVn0R6wPuVer4HudfcLy/A==}
+  shadcn@4.16.2:
+    resolution: {integrity: sha512-M1AvZKFWcCzWRDoyApIqJMSLIpY8Ev4uBGuiPLSFmiTbixXhPmzotSTvLzFmBrfoIxG9aIg2dZOETblEaXGUnQ==}
     engines: {node: '>=20.18.1'}
     hasBin: true
 
@@ -10483,7 +10483,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@4.16.0(typescript@6.0.3):
+  shadcn@4.16.2(typescript@6.0.3):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/parser': 7.29.7


### PR DESCRIPTION
## Summary

`npx shadcn@latest mcp init --client claude` adds the shadcn MCP server to `.mcp.json`
alongside supabase, so the registry can be checked against shadcn's own tooling rather than
against our reading of its schema.

That distinction is not academic. `registry.json` passed every gate we had written while
`shadcn registry validate nyuchi/mzizi` failed on **574 of 574 items** — `files[].path` held
the install destination instead of the file's source location (fixed in #249). A validator we
do not own is the only kind that can find a defect our own assumptions caused.

## Changes

- `.mcp.json` — adds the `shadcn` server (`npx shadcn@latest mcp`)
- `package.json` / `pnpm-lock.yaml` — shadcn `4.16.0` → `4.16.2`, the version
  `registry validate` ran under
- prettier normalised an escaped em-dash back to a literal one in the package description

No secrets, no config values: the shadcn server takes no credentials.

## Type

- [x] CI/infrastructure

## Pre-commit Gate

- [x] `pnpm typecheck` — zero errors
- [x] `pnpm audit` — no known vulnerabilities
- [x] prettier — clean

## Note

Branched fresh from `main` rather than stacked on the merged #249 history.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_