### PR TITLE
feat(registry): add mzizi-base, the design system as one shadcn init

### DIFF
--- a/app/api/v1/ui/[name]/route.ts
+++ b/app/api/v1/ui/[name]/route.ts
@@ -61,7 +61,16 @@ export async function GET(_request: Request, { params }: { params: Promise<{ nam
     // A DATA item (registry:theme / registry:style) carries `cssVars`/`css` and no file.
     // Served before the source lookup, because there is no source to look up and the 404
     // below would otherwise hide the design tokens from every consumer.
-    const isDataItem = Boolean(component.cssVars || component.css)
+    // A `registry:base` carries its payload as CONFIG and dependencies, with no cssVars of
+    // its own — `mzizi-base` pulls N1 through registryDependencies rather than duplicating
+    // 324 values. Testing only for cssVars/css would send it down the source path below and
+    // 404 the one item a new project installs first.
+    const isDataItem = Boolean(
+      component.cssVars ||
+      component.css ||
+      component.type === "registry:base" ||
+      component.type === "registry:style"
+    )
     if (isDataItem && !component.files?.length) {
       logger.info("Theme item served", {
         data: { name, cssVarGroups: Object.keys(component.cssVars ?? {}) },
@@ -86,6 +95,13 @@ export async function GET(_request: Request, { params }: { params: Promise<{ nam
           registryDependencies: component.registryDependencies,
           ...(component.cssVars ? { cssVars: component.cssVars } : {}),
           ...(component.css ? { css: component.css } : {}),
+          // The base's payload IS this config — drop it and `shadcn init mzizi-base`
+          // writes a default components.json, which is the same class of silent-empty
+          // failure as serving a component with no content.
+          ...(component.style ? { style: component.style } : {}),
+          ...(component.iconLibrary ? { iconLibrary: component.iconLibrary } : {}),
+          ...(component.baseColor ? { baseColor: component.baseColor } : {}),
+          ...(component.tailwind ? { tailwind: component.tailwind } : {}),
         },
         { headers: CORS_CACHE }
       )

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -116,6 +116,19 @@ export type RegistryItem = {
   }
   /** Raw CSS the item contributes, for rules that are not custom properties. */
   css?: Record<string, unknown>
+  /**
+   * Project configuration, for `registry:base` / `registry:style` items.
+   *
+   * These sit at the TOP LEVEL of a registry item, which is what the published
+   * registry-item schema declares — not inside a `config` object, which is what the docs
+   * example shows. Only the top-level form works: verified against shadcn 4.16.2 by running
+   * a real `init` twice, once per shape. Top level wrote a correct `components.json` and
+   * merged the item's cssVars; nested `config` errored out and merged nothing.
+   */
+  style?: string
+  iconLibrary?: string
+  baseColor?: string
+  tailwind?: Record<string, unknown>
   /** Display name shown by a registry browser and the CLI. */
   title?: string
   categories?: string[]
@@ -143,6 +156,26 @@ export type RegistryItem = {
 }
 
 type Manifest = { items?: RegistryItem[] }
+
+/**
+ * Items whose payload is DATA, not a source file.
+ *
+ * Two kinds, and the distinction is not "has cssVars":
+ *
+ *   registry:theme   the tokens themselves (nyuchi-tokens) — payload is `cssVars`/`css`
+ *   registry:base    a project foundation (mzizi-base)     — payload is the CONFIG
+ *                    (style / iconLibrary / baseColor / tailwind) plus dependencies
+ *
+ * A base legitimately carries no `cssVars` at all: `mzizi-base` pulls N1 through
+ * `registryDependencies: ["nyuchi-tokens"]` rather than duplicating 324 values, because N1
+ * is the only node allowed to define CSS values. Testing for `cssVars` alone would drop it
+ * here and answer 404 for the one item a new project installs first.
+ */
+function isDataItem(item: RegistryItem): boolean {
+  return Boolean(
+    item.cssVars || item.css || item.type === "registry:base" || item.type === "registry:style"
+  )
+}
 
 let _cache: RegistryItem[] | null = null
 
@@ -254,7 +287,7 @@ export function readComponents(): RegistryItem[] {
     //
     // Without this branch the item is dropped here and `/api/v1/ui/nyuchi-tokens` answers
     // 404 — the tokens would be correct in the manifest and invisible to every consumer.
-    if (!item.files?.length && (item.cssVars || item.css)) {
+    if (!item.files?.length && isDataItem(item)) {
       // The node comes from the manifest here and ONLY here, because there is no directory
       // to read it from. Every filed component still derives it from disk below, so the
       // invariant that matters — a component's node cannot disagree with where its code is

--- a/registry.json
+++ b/registry.json
@@ -11968,6 +11968,55 @@
     },
     {
       "author": "Bundu Foundation, operated by Nyuchi Africa (Pvt) Ltd — https://mzizi.dev",
+      "baseColor": "neutral",
+      "categories": [
+        "styling-libs"
+      ],
+      "dependencies": [
+        "class-variance-authority",
+        "clsx",
+        "tailwind-merge",
+        "lucide-react",
+        "tw-animate-css",
+        "radix-ui"
+      ],
+      "description": "The whole Mzizi design system as one installable foundation. `shadcn init` writes the project configuration — new-york style, lucide icons, neutral base, the @/ aliases every component imports through — installs the runtime packages the registry depends on, and pulls N1's 324 design tokens via nyuchi-tokens. Start a project with this and every one of the other 573 components installs into a project already shaped to receive it.",
+      "docs": "Use it for: Starting a new Nyuchi or Bundu app from zero, Scaffolding by the mzizi CLI (fundi), Giving an agent one command that shapes a project for the registry.\nIncludes: Writes components.json — style, aliases, icon library, base colour, Installs the runtime packages every registry component needs, Pulls all 324 N1 design tokens through nyuchi-tokens, One `shadcn init` instead of manual setup plus N adds.\nAccessibility: Inherits N1's AAA contrast pairings and touch-target tokens.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-base",
+      "iconLibrary": "lucide",
+      "meta": {
+        "a11y": [
+          "Inherits N1's AAA contrast pairings and touch-target tokens"
+        ],
+        "collection": "styling-libs",
+        "features": [
+          "Writes components.json — style, aliases, icon library, base colour",
+          "Installs the runtime packages every registry component needs",
+          "Pulls all 324 N1 design tokens through nyuchi-tokens",
+          "One `shadcn init` instead of manual setup plus N adds"
+        ],
+        "node": 1,
+        "nodeLabel": "tokens",
+        "owner": "bundu",
+        "useCases": [
+          "Starting a new Nyuchi or Bundu app from zero",
+          "Scaffolding by the mzizi CLI (fundi)",
+          "Giving an agent one command that shapes a project for the registry"
+        ]
+      },
+      "name": "mzizi-base",
+      "registryDependencies": [
+        "https://mzizi.dev/api/v1/ui/nyuchi-tokens",
+        "https://mzizi.dev/api/v1/ui/utils"
+      ],
+      "style": "new-york",
+      "tailwind": {
+        "baseColor": "neutral"
+      },
+      "title": "mzizi Base",
+      "type": "registry:base"
+    },
+    {
+      "author": "Bundu Foundation, operated by Nyuchi Africa (Pvt) Ltd — https://mzizi.dev",
       "categories": [
         "safety"
       ],

--- a/scripts/validate-registry.mjs
+++ b/scripts/validate-registry.mjs
@@ -272,8 +272,23 @@ function main() {
      * The two checks below assume every item is a component with a file. Applied to a
      * theme they demand exactly the thing that made the registry framework-specific.
      */
-    const isDataItem = Boolean(item.cssVars || item.css)
+    // A `registry:base`/`registry:style` is a data item whose payload is the project CONFIG,
+    // not cssVars — `mzizi-base` deliberately has none, pulling N1 through
+    // registryDependencies so the tokens are defined in exactly one place.
+    const isConfigItem = item.type === "registry:base" || item.type === "registry:style"
+    const isDataItem = Boolean(item.cssVars || item.css || isConfigItem)
     const hasFiles = Array.isArray(item.files) && item.files.length > 0
+
+    // A base that carries no config writes a DEFAULT components.json — the project ends up
+    // shaped for stock shadcn, not for this registry, and nothing errors.
+    if (isConfigItem && !item.style && !item.iconLibrary && !item.baseColor && !item.tailwind) {
+      err(
+        item.name,
+        `is a ${item.type} but carries no configuration (style / iconLibrary / baseColor / ` +
+          "tailwind). These belong at the TOP LEVEL of the item — the `config: {…}` shape in " +
+          "shadcn's docs example is not read by the CLI (verified against 4.16.2)."
+      )
+    }
 
     if (!hasFiles && !isDataItem) err(n, "has no files[] and no cssVars/css — it installs nothing")
 


### PR DESCRIPTION
## Summary

`registry:base` is shadcn's type for a complete project foundation, and it is what the mzizi
CLI (fundi) and a template app want: one command that shapes a project to receive the
registry, instead of a manual `components.json` plus N adds.

```bash
npx shadcn@latest init https://mzizi.dev/api/v1/ui/mzizi-base
```

writes `components.json` (new-york, lucide, neutral, the `@/` aliases every component imports
through), installs the runtime packages the registry depends on, and pulls N1's 324 design
tokens via `nyuchi-tokens`.

## The docs example is wrong for the current CLI

shadcn's docs nest `style`/`iconLibrary`/`tailwind` inside a `config` object. The published
JSON Schema declares them at the **top level**. Only the top-level form works — established
by running a real `init` twice into a real Next project against shadcn 4.16.2:

| shape | result |
| --- | --- |
| top-level | init completed; `components.json` got `style: "new-york"`; cssVars merged |
| `config: {…}` | init **errored**; `components.json` got `style: "base-config"`; **0** cssVars |

Both the item and the validator record this, so nobody re-derives it.

## Plumbing a config item needed

A `registry:base` has no files **and** no cssVars — `mzizi-base` pulls N1 through
`registryDependencies` rather than carrying a second copy of 324 values, because N1 is the
only node allowed to define CSS values. The data-item test was `cssVars || css`, so the base
would have been dropped by `readComponents()` and 404'd: the one item a new project installs
first.

- `isDataItem()` now covers `registry:base`/`registry:style` in the reader, the route and the
  validator
- the route projects `style` / `iconLibrary` / `baseColor` / `tailwind` — dropping those makes
  `init` write a **default** `components.json`, the same class of silent-empty failure as
  serving a component with no content
- a validator rule: a base carrying no configuration at all is an error

## Verified end to end

`init` into a fresh Next project:

- wrote the correct `components.json` — `style: new-york`, `iconLibrary: lucide`,
  `tailwind.baseColor: neutral`, the five `@/` aliases
- merged **387 custom properties** into `app/globals.css` (`--mineral-gold` `#5d4037` light)
- created `lib/utils.ts`

Then `shadcn add https://mzizi.dev/api/v1/ui/button` into that project produced **mzizi's**
button — 3921 bytes, `rounded-full` — not shadcn's.

## Type

- [x] New feature

## Pre-commit Gate

- [x] `pnpm lint` — zero warnings
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm test` — 204 tests pass
- [x] `pnpm audit` — no known vulnerabilities

## Registry / Design System

- [x] `registry.json` updated and `pnpm registry:normalize` run — 575 items
- [x] `registry:verify`, `registry:validate`, `registry:paths:check`,
      `tokens:registry:check`, `registry:metadata:check` — all green

## Not in this PR — a separate finding that needs a decision

While testing the base I measured how `registryDependencies` actually resolve. **567 edges
across 41 distinct names are bare** (`card` ×103, `button` ×87, `chart` ×73, `badge` ×57,
`input` ×43 …), and **every one of those 41 names is also an item in this registry**. A bare
name resolves against **ui.shadcn.com**, not against the registry the item came from — so
installing a mzizi component that depends on `badge` writes **shadcn's** badge (1776 B,
`rounded-full`) over **ours** (1909 B, `h-5 rounded-md`, `group/badge`). Measured, not
inferred. 38 of the 41 exist upstream and swap silently; 3 do not and fail loudly.

This is deliberate — `validate-registry.mjs` documents a `SHADCN_PRIMITIVES` set and says a
bare name is "CORRECT for these" — and the file header records that 145 deps were once written
`@mzizi/<name>` and converted to bare because the namespace 404'd at the time. **That reason
no longer holds**: `@mzizi/badge` now resolves correctly (verified: 1909 B, ours) once the
consumer's `components.json` carries a `registries` mapping. A `registry:base` cannot write
that mapping — also verified, the CLI wrote `registries: {}` — but the CLI and a template app
can.

Left untouched pending a decision; nothing here changes it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_