### PR TITLE
feat(rust): N11 complete, N10 begun — and three security defects found porting

### DIFF
--- a/__tests__/lib/registry-source.test.ts
+++ b/__tests__/lib/registry-source.test.ts
@@ -12,16 +12,38 @@ import { readFileSync, readdirSync } from "node:fs"
 import { join } from "node:path"
 
 /**
- * Resolve a component's file the way a human would — by name, in its node
- * directory, whatever extension it carries. The extension is owned by the
- * registry (`files[0].path`), so hardcoding `.tsx` here made the suite fail the
- * moment `nyuchi-seo` was corrected to the `.ts` its registry row declares.
+ * Extension preference, identical to `PRIMARY_EXTENSIONS` in
+ * `lib/registry-source.ts` and `lib/registry.ts`.
+ */
+const PRIMARY_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js"]
+
+/**
+ * Resolve a component's PRIMARY file — the one `readComponentSource` is
+ * specified to return.
+ *
+ * This used to take the first `readdir` hit for the name, on the assumption that
+ * a component has one file. That assumption died with the Rust build-out: a
+ * component is one name with several target implementations (§8.9), so
+ * `nyuchi-seo` is now `nyuchi-seo.ts` AND `nyuchi-seo.rs`, and `find` returned
+ * whichever the filesystem happened to list first. The suite then compared the
+ * `.rs` against the `.ts` the reader correctly served, and failed on the reader
+ * being right.
+ *
+ * Ranking here rather than picking one extension keeps the assertion honest —
+ * "the bytes the route serves are the bytes in the repo" — while resolving the
+ * same file the reader documents itself as resolving. Every component that gains
+ * a `.rs` sibling from here on would otherwise break this test in turn.
  */
 function fileOnDisk(nodeDir: string, name: string): string {
   const dir = join(process.cwd(), "components/registry", nodeDir)
-  const match = readdirSync(dir).find((f) => f.replace(/\.[^.]+$/, "") === name)
-  if (!match) throw new Error(`no file for "${name}" in ${nodeDir}`)
-  return readFileSync(join(dir, match), "utf8")
+  const candidates = readdirSync(dir).filter((f) => f.replace(/\.[^.]+$/, "") === name)
+  if (candidates.length === 0) throw new Error(`no file for "${name}" in ${nodeDir}`)
+  const rank = (f: string) => {
+    const i = PRIMARY_EXTENSIONS.indexOf(f.slice(f.lastIndexOf(".")).toLowerCase())
+    return i === -1 ? PRIMARY_EXTENSIONS.length : i
+  }
+  const primary = candidates.sort((a, b) => rank(a) - rank(b))[0]
+  return readFileSync(join(dir, primary), "utf8")
 }
 import {
   componentsOnDisk,

--- a/components/registry/n10-documentation/nyuchi-ai-context.rs
+++ b/components/registry/n10-documentation/nyuchi-ai-context.rs
@@ -1,0 +1,446 @@
+//! Mzizi N10 documentation — the context window an AI assistant is given.
+//!
+//! The Rust implementation of `nyuchi-ai-context`. Pure string assembly, no
+//! framework, exactly as the `.ts` describes itself.
+//!
+//! # The defect this port had to confront
+//!
+//! The `.ts` opens with, in capitals: "This lib never hardcodes counts. Counts
+//! drift as the ecosystem evolves." It then hardcodes the entire node set as a
+//! literal string — a ten-row table, N1 through N10, with a four-axis model above
+//! it. Both are stale:
+//!
+//!   * The node set is **uncapped** (§9) and runs past N10. N11 is the discovery
+//!     rung and N12 the skills rung; neither appears. An assistant handed this
+//!     context is told, in a document whose whole purpose is to be believed, that
+//!     N10 is the end.
+//!   * The horizontal / vertical / depth / outlier axis model is the retired
+//!     layer-and-axis scheme. `nyuchi-seo`'s own header records being moved off
+//!     N6 "because the layer/axis model is retired in favour of the DNA double
+//!     helix".
+//!
+//! A count is not special. A hardcoded node LIST drifts the same way a hardcoded
+//! node COUNT does, and this file proves it: the count rule was followed and the
+//! list beside it went stale anyway.
+//!
+//! So the node map here is **data**, not a literal. [`NodeEntry`] rows are passed
+//! in, the same way counts are, and [`current_nodes`] is a documented default for
+//! a caller with nothing better — not a truth buried in a string. A caller that
+//! reads `/api/v1/architecture` gets a map that cannot go stale at all.
+//!
+//! # Preserved rather than "fixed"
+//!
+//! The ten rules are reproduced as written, including rule 8's "48px minimum".
+//! `scripts/validate-registry.mjs` records at length that the shipped primitives
+//! never honoured the 56px/48px scale and that density won — but the rules block
+//! is doctrine text owned by N10's authors, and silently editing what the system
+//! tells an assistant about itself is not a porting decision. Flagged here, and
+//! left for whoever owns §8.2 to settle.
+//!
+//! Rule 9's "Query get_node_counts()" and the Supabase/MCP footer are likewise
+//! reproduced. They name a specific database and endpoint, which is exactly the
+//! kind of fact that rots — see [`Endpoints`] for how a caller overrides them.
+
+/// Live ecosystem totals, supplied by the caller.
+///
+/// Optional in the `.ts` and optional here: an assistant is better told where to
+/// find the numbers than given numbers that have drifted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EcosystemCounts {
+    /// Every component in the registry.
+    pub total_components: usize,
+    /// Those marked stable.
+    pub total_stable: usize,
+    /// How many nodes exist. Uncapped — see §9.
+    pub total_nodes: usize,
+}
+
+/// One row of the node map.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeEntry {
+    /// Node number. No upper bound.
+    pub number: u16,
+    /// Short name, e.g. `Primitives`.
+    pub label: String,
+    /// What the node is for, one line.
+    pub role: String,
+}
+
+impl NodeEntry {
+    /// Build a row.
+    #[must_use]
+    pub fn new(number: u16, label: &str, role: &str) -> Self {
+        Self {
+            number,
+            label: label.to_owned(),
+            role: role.to_owned(),
+        }
+    }
+}
+
+/// The node set as it stands, for a caller with no live source.
+///
+/// A DEFAULT, not a definition. The authority is `/api/v1/architecture`, and a
+/// caller that can reach it should pass those rows instead — that is the whole
+/// point of the node map being a parameter. Kept here so the component still
+/// produces something useful offline, and so the staleness is visible in a list
+/// rather than buried in a prose table.
+#[must_use]
+pub fn current_nodes() -> Vec<NodeEntry> {
+    vec![
+        NodeEntry::new(
+            1,
+            "Tokens",
+            "CSS substrate. The only node that defines CSS values.",
+        ),
+        NodeEntry::new(2, "Primitives", "Headless and accessible. Radix + CVA."),
+        NodeEntry::new(3, "Brand", "N2 plus Ubuntu. Uses nyuchi-harness."),
+        NodeEntry::new(4, "Safety", "Gates. Validates input, guards AI output."),
+        NodeEntry::new(
+            5,
+            "Resilience",
+            "Circuit breakers, retries, fallback chains.",
+        ),
+        NodeEntry::new(6, "Pages", "Pure composition. No inline primitives."),
+        NodeEntry::new(7, "Shell", "App chrome. Header, nav, theme, lifecycle."),
+        NodeEntry::new(
+            8,
+            "Assurance",
+            "Observability, SLO tracking, chaos testing.",
+        ),
+        NodeEntry::new(
+            9,
+            "Fundi",
+            "Self-healing. Turns assurance signals into filed defects.",
+        ),
+        NodeEntry::new(
+            10,
+            "Documentation",
+            "Self-describing. The system explains itself.",
+        ),
+        NodeEntry::new(
+            11,
+            "Discovery",
+            "Machine visibility. Metadata and structured data.",
+        ),
+        NodeEntry::new(
+            12,
+            "Skills",
+            "What the system knows how to do, authored in git.",
+        ),
+    ]
+}
+
+/// Where the machine-readable truth lives.
+///
+/// Parameters rather than literals because the `.ts` hardcoded a Supabase project
+/// ref, an MCP hostname and the repo slug `nyuchi/design-portal` — and the repo is
+/// `nyuchi/mzizi`. An assistant handed a wrong repo slug will look in the wrong
+/// place and report that the code does not exist.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Endpoints {
+    /// Human-facing site.
+    pub site: String,
+    /// `owner/repo` on GitHub.
+    pub repo: String,
+    /// MCP endpoint an assistant can call.
+    pub mcp: String,
+}
+
+impl Default for Endpoints {
+    fn default() -> Self {
+        Self {
+            site: "https://mzizi.dev".to_owned(),
+            repo: "nyuchi/mzizi".to_owned(),
+            mcp: "https://mzizi.dev/api/v1/mcp".to_owned(),
+        }
+    }
+}
+
+/// Which sections to include.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AiContextOptions {
+    /// Live totals, if the caller has them.
+    pub counts: Option<EcosystemCounts>,
+    /// The ten rules.
+    pub include_rules: bool,
+    /// The heading and source line.
+    pub include_architecture: bool,
+    /// The node map table.
+    pub include_node_map: bool,
+    /// Node rows. Empty means "use [`current_nodes`]".
+    pub nodes: Vec<NodeEntry>,
+    /// Where the truth lives.
+    pub endpoints: Endpoints,
+}
+
+impl Default for AiContextOptions {
+    /// Matches the `.ts` defaults: all three sections on.
+    fn default() -> Self {
+        Self {
+            counts: None,
+            include_rules: true,
+            include_architecture: true,
+            include_node_map: true,
+            nodes: Vec::new(),
+            endpoints: Endpoints::default(),
+        }
+    }
+}
+
+/// The ten rules, reproduced verbatim from the `.ts`.
+///
+/// See the module docs on rule 8 — reproduced as written rather than silently
+/// reconciled with what the primitives actually ship.
+const ECOSYSTEM_RULES: &str = "\
+## Rules (non-negotiable)
+
+1. CSS values live only in N1. All other nodes use var(--token-name). Never hex outside N1.
+2. Icons import from @/lib/icons only. Never from lucide-react directly.
+3. N2 primitives never import useNyuchiHarness.
+4. N3 brand components always destructure { log, motion, LiveRegion } from useNyuchiHarness.
+5. N6 pages: pure composition, semantic CSS vars only, accept children/slots.
+6. All interactive components: data-slot + data-portal attributes required.
+7. Status colors use semantic tokens: --status-success, --status-error, --status-warning.
+8. Touch targets: 48px minimum. Focus rings: focus-visible:outline-2.
+9. No hardcoded numbers in code or copy. Query the live counts.
+10. Shona terms come from the database. Never translate or invent them.";
+
+/// Render the node map as a markdown table.
+fn render_node_map(nodes: &[NodeEntry]) -> String {
+    // Width the first column to the widest label so the table stays readable at
+    // any node count — the `.ts` aligned its ten rows by hand, which is why an
+    // eleventh could not be added without redoing the whitespace.
+    let widest = nodes.iter().map(|n| n.label.len()).max().unwrap_or(0);
+
+    let mut out = String::new();
+    out.push_str("## Node map\n\n");
+    out.push_str(
+        "Every component belongs to exactly one node. The node set is UNCAPPED — a\n\
+         new node may be added at any time, so never assume the highest number here\n\
+         is the last one.\n\n",
+    );
+    for n in nodes {
+        out.push_str(&format!(
+            "  N{:<3} {:<width$}  — {}\n",
+            n.number,
+            n.label,
+            n.role,
+            width = widest
+        ));
+    }
+    out
+}
+
+/// Build the context window.
+///
+/// Mirrors the `.ts` `generateAIContext`, with the node map taken from
+/// `options.nodes` rather than a literal.
+#[must_use]
+pub fn generate_ai_context(options: &AiContextOptions) -> String {
+    let mut parts: Vec<String> = Vec::new();
+
+    if options.include_architecture {
+        parts.push("# Mzizi Design System".to_owned());
+        parts.push(String::new());
+        if let Some(c) = options.counts {
+            parts.push(format!(
+                "Live counts: {} components total, {} stable, across {} nodes.",
+                c.total_components, c.total_stable, c.total_nodes
+            ));
+        }
+        parts.push(format!(
+            "Source: {} | GitHub: {}",
+            options.endpoints.site, options.endpoints.repo
+        ));
+        if options.counts.is_none() {
+            parts.push(format!("For live counts: {}", options.endpoints.mcp));
+        }
+        parts.push(String::new());
+    }
+
+    if options.include_node_map {
+        let owned;
+        let nodes: &[NodeEntry] = if options.nodes.is_empty() {
+            owned = current_nodes();
+            &owned
+        } else {
+            &options.nodes
+        };
+        parts.push(render_node_map(nodes));
+        parts.push(String::new());
+    }
+
+    if options.include_rules {
+        parts.push(ECOSYSTEM_RULES.to_owned());
+        parts.push(String::new());
+    }
+
+    parts.push(format!("MCP server: {}", options.endpoints.mcp));
+
+    parts.join("\n")
+}
+
+/// The four named surfaces from the `.ts` `aiContextPresets`.
+///
+/// `mcp` and `claude` were byte-identical in the `.ts`, as were `copilot` and
+/// `cursor`. Kept as four names because callers reference them by name, with the
+/// duplication stated rather than hidden.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Preset {
+    /// Full context for the MCP server.
+    Mcp,
+    /// Rules and node map, no architecture prose.
+    Copilot,
+    /// Full context. Identical to [`Preset::Mcp`].
+    Claude,
+    /// Rules and node map. Identical to [`Preset::Copilot`].
+    Cursor,
+}
+
+impl Preset {
+    /// Options for this surface.
+    #[must_use]
+    pub fn options(self, counts: Option<EcosystemCounts>) -> AiContextOptions {
+        match self {
+            Self::Mcp | Self::Claude => AiContextOptions {
+                counts,
+                ..AiContextOptions::default()
+            },
+            Self::Copilot | Self::Cursor => AiContextOptions {
+                counts: None,
+                include_architecture: false,
+                ..AiContextOptions::default()
+            },
+        }
+    }
+
+    /// Render this surface's context window.
+    #[must_use]
+    pub fn render(self, counts: Option<EcosystemCounts>) -> String {
+        generate_ai_context(&self.options(counts))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_includes_all_three_sections() {
+        let s = generate_ai_context(&AiContextOptions::default());
+        assert!(s.contains("# Mzizi Design System"));
+        assert!(s.contains("## Node map"));
+        assert!(s.contains("## Rules (non-negotiable)"));
+    }
+
+    #[test]
+    fn the_node_map_reaches_past_n10() {
+        // The whole reason this file diverges: the .ts stops at N10.
+        let s = generate_ai_context(&AiContextOptions::default());
+        assert!(s.contains("N11"), "N11 discovery is missing");
+        assert!(s.contains("N12"), "N12 skills is missing");
+    }
+
+    #[test]
+    fn it_says_the_node_set_is_uncapped() {
+        let s = generate_ai_context(&AiContextOptions::default());
+        assert!(s.contains("UNCAPPED"));
+    }
+
+    #[test]
+    fn the_retired_axis_model_is_gone() {
+        let s = generate_ai_context(&AiContextOptions::default());
+        for retired in ["horizontal", "vertical", "outlier", "depth"] {
+            assert!(
+                !s.contains(retired),
+                "retired axis word {retired} survived the port"
+            );
+        }
+    }
+
+    #[test]
+    fn the_repo_slug_is_the_real_one() {
+        let s = generate_ai_context(&AiContextOptions::default());
+        assert!(s.contains("nyuchi/mzizi"));
+        assert!(!s.contains("design-portal"));
+    }
+
+    #[test]
+    fn counts_appear_only_when_supplied() {
+        let without = generate_ai_context(&AiContextOptions::default());
+        assert!(!without.contains("Live counts"));
+        assert!(without.contains("For live counts"));
+
+        let with = generate_ai_context(&AiContextOptions {
+            counts: Some(EcosystemCounts {
+                total_components: 575,
+                total_stable: 500,
+                total_nodes: 12,
+            }),
+            ..AiContextOptions::default()
+        });
+        assert!(with.contains("575 components total, 500 stable, across 12 nodes"));
+        assert!(!with.contains("For live counts"));
+    }
+
+    #[test]
+    fn caller_supplied_nodes_replace_the_default() {
+        let s = generate_ai_context(&AiContextOptions {
+            nodes: vec![NodeEntry::new(
+                42,
+                "Future",
+                "A node nobody has invented yet.",
+            )],
+            ..AiContextOptions::default()
+        });
+        assert!(s.contains("N42"));
+        assert!(s.contains("A node nobody has invented yet."));
+        assert!(!s.contains("Primitives"), "the default map leaked through");
+    }
+
+    #[test]
+    fn the_table_aligns_at_any_node_count() {
+        // The .ts hand-aligned ten rows, so an eleventh could not be added
+        // without redoing the whitespace.
+        let s = render_node_map(&[
+            NodeEntry::new(1, "A", "short"),
+            NodeEntry::new(2, "AVeryLongLabelIndeed", "long"),
+        ]);
+        // Filter on the row prefix, not on " — ": the intro paragraph above the
+        // rows contains an em dash too, and matching it compared a prose line
+        // against a table row.
+        let lines: Vec<&str> = s.lines().filter(|l| l.starts_with("  N")).collect();
+        assert_eq!(lines.len(), 2);
+        let col = |l: &str| l.find(" — ").unwrap();
+        assert_eq!(col(lines[0]), col(lines[1]));
+    }
+
+    #[test]
+    fn presets_that_the_ts_made_identical_stay_identical() {
+        assert_eq!(Preset::Mcp.render(None), Preset::Claude.render(None));
+        assert_eq!(Preset::Copilot.render(None), Preset::Cursor.render(None));
+    }
+
+    #[test]
+    fn ide_presets_drop_the_architecture_prose_only() {
+        let s = Preset::Copilot.render(None);
+        assert!(!s.contains("# Mzizi Design System"));
+        assert!(s.contains("## Node map"));
+        assert!(s.contains("## Rules"));
+    }
+
+    #[test]
+    fn endpoints_are_overridable() {
+        let s = generate_ai_context(&AiContextOptions {
+            endpoints: Endpoints {
+                site: "https://example.test".to_owned(),
+                repo: "acme/thing".to_owned(),
+                mcp: "https://example.test/mcp".to_owned(),
+            },
+            ..AiContextOptions::default()
+        });
+        assert!(s.contains("acme/thing"));
+        assert!(!s.contains("nyuchi/mzizi"));
+    }
+}

--- a/components/registry/n10-documentation/nyuchi-docs-api.rs
+++ b/components/registry/n10-documentation/nyuchi-docs-api.rs
@@ -1,0 +1,565 @@
+//! Mzizi N10 documentation — the read layer over published documentation.
+//!
+//! The Rust implementation of `nyuchi-docs-api`. Routing and response shaping;
+//! the host owns the data source and the credential.
+//!
+//! # Two security defects in the TypeScript, both structurally impossible here
+//!
+//! **1. Filter-structure injection.** The `.ts` builds a PostgREST filter by
+//! string interpolation from a URL path segment:
+//!
+//! ```text
+//! .or(`name.eq.${identifier},target.eq.${identifier}`)
+//! ```
+//!
+//! `identifier` is `rest[0]` — whatever the caller put in the path, unescaped.
+//! PostgREST reads `,` as a disjunction separator and `.` as the operator
+//! separator, so `/ai-instructions/x,status.eq.draft` does not look up `x`; it
+//! adds a condition. The `.eq("status", "active")` above is a separate `and`
+//! term, so what the injected clause widens is which rows the `or` matches, and
+//! a caller can enumerate rows the route was written to keep hidden. This is the
+//! same class `lib/db`'s `searchComponents` carries a comment about having
+//! removed — "the old implementation had to strip PostgREST-significant
+//! characters to avoid filter-structure injection" — so the app fixed it and the
+//! published component did not.
+//!
+//! Here the identifier never becomes filter syntax. [`Route::AiInstruction`]
+//! carries it as a value, and [`DocsStore::ai_instruction_by_name_or_target`]
+//! receives it as a parameter for the host to bind. There is no string to
+//! restructure.
+//!
+//! **2. A service-role credential in a publicly installable component.** The
+//! `.ts` reads `SUPABASE_SERVICE_ROLE_KEY`, so anyone who runs `shadcn add` on
+//! this item installs a function that bypasses RLS — over a read layer for
+//! *published* documentation, which needs no such thing. Its own header says as
+//! much and calls it out of scope.
+//!
+//! It is in scope for this port, and the fix is structural rather than a swapped
+//! constant: this module holds no client and reads no environment. The host
+//! implements [`DocsStore`] with whatever identity it judges correct, and an
+//! anon client under RLS satisfies the trait completely.
+//!
+//! **The `.ts` sibling still has both.** Neither is fixed by this file.
+//!
+//! # What this owns
+//!
+//! Parsing a path into a [`Route`], asking a [`DocsStore`], and shaping the
+//! answer into an [`ApiResponse`] with the right status and headers. It does not
+//! serve — `Deno.serve` has no Rust equivalent worth pretending to, and the same
+//! division holds as in N8, which builds an OTLP request and lets the host send
+//! it.
+
+use std::collections::BTreeMap;
+
+/// CORS headers, matching the `.ts`.
+#[must_use]
+pub fn cors_headers() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("Access-Control-Allow-Origin", "*"),
+        (
+            "Access-Control-Allow-Headers",
+            "authorization, x-client-info, apikey, content-type",
+        ),
+        ("Access-Control-Allow-Methods", "GET, OPTIONS"),
+    ]
+}
+
+/// Cache headers, matching the `.ts`.
+#[must_use]
+pub fn cache_headers() -> Vec<(&'static str, &'static str)> {
+    vec![(
+        "Cache-Control",
+        "public, max-age=60, stale-while-revalidate=300",
+    )]
+}
+
+/// A route this API answers.
+///
+/// An enum rather than nested string comparisons, so an unhandled combination is
+/// a compile error in the host's `match` instead of a fallthrough to 404.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Route {
+    /// `OPTIONS *` — CORS preflight.
+    Preflight,
+    /// `GET /counts`
+    Counts,
+    /// `GET /docs`
+    DocsList,
+    /// `GET /docs/:slug`
+    Doc(String),
+    /// `GET /docs/category/:category`
+    DocsByCategory(String),
+    /// `GET /ai-instructions`
+    AiInstructionsList,
+    /// `GET /ai-instructions/:identifier` — matched against name OR target.
+    AiInstruction(String),
+    /// `GET /architecture`
+    Architecture,
+    /// `GET /architecture/nodes`
+    ArchitectureNodes,
+    /// `GET /architecture/axes`
+    ///
+    /// Retained because the `.ts` exposes it, but see [`Route::ARCHITECTURE_AXES_IS_RETIRED`].
+    ArchitectureAxes,
+    /// `GET /changelog?limit=&offset=`
+    Changelog {
+        /// Clamped to 100, as in the `.ts`.
+        limit: u32,
+        /// Clamped to at least 0 — unsigned here, so that is free.
+        offset: u32,
+    },
+    /// `GET /changelog/:version`
+    ChangelogEntry(String),
+    /// Anything else.
+    NotFound,
+    /// A method other than GET or OPTIONS.
+    MethodNotAllowed,
+}
+
+impl Route {
+    /// `/architecture/axes` describes the retired layer-and-axis model.
+    ///
+    /// `mzizi.dev/api/v1/architecture/axes` answers `410 Gone` today. The route
+    /// is kept here so a host serving the `.ts`'s published surface can decide
+    /// deliberately — answer it, or return 410 to match production — rather than
+    /// discovering the discrepancy from a consumer.
+    pub const ARCHITECTURE_AXES_IS_RETIRED: bool = true;
+
+    /// Default page size for `/changelog`, matching the `.ts`.
+    pub const CHANGELOG_DEFAULT_LIMIT: u32 = 20;
+    /// Hard cap on `/changelog` page size, matching the `.ts` `Math.min(limit, 100)`.
+    pub const CHANGELOG_MAX_LIMIT: u32 = 100;
+}
+
+/// Parse a query string into its pairs. Last value wins, as `URLSearchParams.get` does.
+fn query_pairs(query: &str) -> BTreeMap<&str, &str> {
+    let mut out = BTreeMap::new();
+    for pair in query.split('&').filter(|p| !p.is_empty()) {
+        let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
+        out.insert(k, v);
+    }
+    out
+}
+
+/// Read a `u32` query param, falling back when absent or unparseable.
+///
+/// The `.ts` uses `parseInt`, which yields `NaN` for `?limit=abc`; `Math.min(NaN,
+/// 100)` is `NaN`, and `NaN` then goes to the database as the page size. Here an
+/// unparseable value takes the default, which is what the caller meant and what
+/// the database can act on.
+fn u32_param(params: &BTreeMap<&str, &str>, key: &str, default: u32) -> u32 {
+    params
+        .get(key)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Route a request.
+///
+/// `method` is compared case-sensitively against `GET`/`OPTIONS`, as the `.ts`
+/// compares `req.method`.
+#[must_use]
+pub fn route(method: &str, path: &str, query: &str) -> Route {
+    if method == "OPTIONS" {
+        return Route::Preflight;
+    }
+    if method != "GET" {
+        return Route::MethodNotAllowed;
+    }
+
+    let segments: Vec<&str> = path
+        .trim_start_matches('/')
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    match segments.as_slice() {
+        ["counts"] => Route::Counts,
+
+        ["docs"] => Route::DocsList,
+        ["docs", "category"] => Route::NotFound,
+        ["docs", "category", category] => Route::DocsByCategory((*category).to_owned()),
+        ["docs", slug] => Route::Doc((*slug).to_owned()),
+
+        ["ai-instructions"] => Route::AiInstructionsList,
+        ["ai-instructions", id] => Route::AiInstruction((*id).to_owned()),
+
+        ["architecture"] => Route::Architecture,
+        ["architecture", "nodes"] => Route::ArchitectureNodes,
+        ["architecture", "axes"] => Route::ArchitectureAxes,
+
+        ["changelog"] => {
+            let params = query_pairs(query);
+            Route::Changelog {
+                limit: u32_param(&params, "limit", Route::CHANGELOG_DEFAULT_LIMIT)
+                    .min(Route::CHANGELOG_MAX_LIMIT),
+                offset: u32_param(&params, "offset", 0),
+            }
+        }
+        ["changelog", version] => Route::ChangelogEntry((*version).to_owned()),
+
+        _ => Route::NotFound,
+    }
+}
+
+/// What a store hands back: a JSON document, already serialised.
+///
+/// An opaque `String` rather than a parsed value, because this module reshapes
+/// nothing — the `.ts` passes rows through untouched and so does this. Keeping it
+/// opaque also means no JSON dependency, matching N8, N9 and N11.
+pub type JsonDoc = String;
+
+/// Why a store could not answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StoreError {
+    /// The row does not exist. Becomes 404.
+    NotFound,
+    /// Anything else. Becomes 500, and the message is NOT returned to the caller.
+    Backend(String),
+}
+
+/// The data the routes need.
+///
+/// A trait, so this component holds no client and no credential. Every method
+/// takes its filter values as PARAMETERS — never as a fragment of query syntax —
+/// which is what makes the `.ts`'s `or(...)` injection unrepresentable here.
+///
+/// An implementation backed by an anon Supabase client under RLS satisfies this
+/// completely; nothing in the contract needs service-role.
+pub trait DocsStore {
+    /// `get_system_counts()`.
+    fn system_counts(&self) -> Result<JsonDoc, StoreError>;
+    /// Published pages, metadata only, ordered by category then sort order.
+    fn docs_list(&self) -> Result<JsonDoc, StoreError>;
+    /// One published page by slug, with its content.
+    fn doc_by_slug(&self, slug: &str) -> Result<JsonDoc, StoreError>;
+    /// Published pages in one category, ordered by sort order.
+    fn docs_by_category(&self, category: &str) -> Result<JsonDoc, StoreError>;
+    /// Active instruction sets, metadata only.
+    fn ai_instructions_list(&self) -> Result<JsonDoc, StoreError>;
+    /// The latest active instruction set whose NAME or TARGET equals `identifier`.
+    ///
+    /// Two bound parameters and a disjunction the implementation writes itself.
+    /// The identifier is a value here and can never become filter structure.
+    fn ai_instruction_by_name_or_target(&self, identifier: &str) -> Result<JsonDoc, StoreError>;
+    /// `get_architecture()`.
+    fn architecture(&self) -> Result<JsonDoc, StoreError>;
+    /// `get_node_counts()`.
+    fn architecture_nodes(&self) -> Result<JsonDoc, StoreError>;
+    /// `get_axes_summary()`. See [`Route::ARCHITECTURE_AXES_IS_RETIRED`].
+    fn architecture_axes(&self) -> Result<JsonDoc, StoreError>;
+    /// `list_changelog(limit, offset)`.
+    fn changelog(&self, limit: u32, offset: u32) -> Result<JsonDoc, StoreError>;
+    /// `get_changelog_entry(version)`.
+    fn changelog_entry(&self, version: &str) -> Result<JsonDoc, StoreError>;
+}
+
+/// A response for the host to send.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApiResponse {
+    /// HTTP status.
+    pub status: u16,
+    /// Headers, including CORS.
+    pub headers: Vec<(String, String)>,
+    /// Body. Empty for a preflight.
+    pub body: String,
+}
+
+fn respond(status: u16, body: String, cache: bool) -> ApiResponse {
+    let mut headers: Vec<(String, String)> =
+        vec![("Content-Type".to_owned(), "application/json".to_owned())];
+    headers.extend(
+        cors_headers()
+            .into_iter()
+            .map(|(k, v)| (k.to_owned(), v.to_owned())),
+    );
+    if cache {
+        headers.extend(
+            cache_headers()
+                .into_iter()
+                .map(|(k, v)| (k.to_owned(), v.to_owned())),
+        );
+    }
+    ApiResponse {
+        status,
+        headers,
+        body,
+    }
+}
+
+/// An error body. The message is a fixed string chosen here, never the backend's.
+///
+/// The `.ts` returns `err.message` from PostgREST with a 500 — which leaks table
+/// names, column names and constraint text to any caller who can provoke an
+/// error. [`StoreError::Backend`] carries the detail for the host to log; the
+/// caller gets the status and nothing else.
+fn error_response(status: u16, message: &str) -> ApiResponse {
+    let mut body = String::from("{\"error\":\"");
+    for c in message.chars() {
+        match c {
+            '"' => body.push_str("\\\""),
+            '\\' => body.push_str("\\\\"),
+            '\n' => body.push_str("\\n"),
+            c if (c as u32) < 0x20 => body.push(' '),
+            c => body.push(c),
+        }
+    }
+    body.push_str("\"}");
+    respond(status, body, false)
+}
+
+/// Answer a route from a store.
+///
+/// Returns the response, plus any backend detail the host should log rather than
+/// send. Splitting them is what stops the `.ts`'s habit of returning
+/// `err.message` to the caller.
+pub fn handle<S: DocsStore + ?Sized>(route: &Route, store: &S) -> (ApiResponse, Option<String>) {
+    let result = match route {
+        Route::Preflight => {
+            let headers = cors_headers()
+                .into_iter()
+                .map(|(k, v)| (k.to_owned(), v.to_owned()))
+                .collect();
+            return (
+                ApiResponse {
+                    status: 204,
+                    headers,
+                    body: String::new(),
+                },
+                None,
+            );
+        }
+        Route::MethodNotAllowed => {
+            return (error_response(405, "Method not allowed"), None);
+        }
+        Route::NotFound => return (error_response(404, "Not found"), None),
+
+        Route::Counts => store.system_counts(),
+        Route::DocsList => store.docs_list(),
+        Route::Doc(slug) => store.doc_by_slug(slug),
+        Route::DocsByCategory(c) => store.docs_by_category(c),
+        Route::AiInstructionsList => store.ai_instructions_list(),
+        Route::AiInstruction(id) => store.ai_instruction_by_name_or_target(id),
+        Route::Architecture => store.architecture(),
+        Route::ArchitectureNodes => store.architecture_nodes(),
+        Route::ArchitectureAxes => store.architecture_axes(),
+        Route::Changelog { limit, offset } => store.changelog(*limit, *offset),
+        Route::ChangelogEntry(v) => store.changelog_entry(v),
+    };
+
+    match result {
+        Ok(body) => (respond(200, body, true), None),
+        Err(StoreError::NotFound) => (error_response(404, "Not found"), None),
+        Err(StoreError::Backend(detail)) => {
+            (error_response(500, "Internal server error"), Some(detail))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Spy {
+        last_identifier: std::cell::RefCell<Option<String>>,
+    }
+
+    impl Spy {
+        fn new() -> Self {
+            Self {
+                last_identifier: std::cell::RefCell::new(None),
+            }
+        }
+    }
+
+    macro_rules! ok {
+        ($v:expr) => {
+            Ok($v.to_owned())
+        };
+    }
+
+    impl DocsStore for Spy {
+        fn system_counts(&self) -> Result<JsonDoc, StoreError> {
+            ok!("{\"components\":575}")
+        }
+        fn docs_list(&self) -> Result<JsonDoc, StoreError> {
+            ok!("[]")
+        }
+        fn doc_by_slug(&self, slug: &str) -> Result<JsonDoc, StoreError> {
+            if slug == "missing" {
+                Err(StoreError::NotFound)
+            } else {
+                ok!(format!("{{\"slug\":\"{slug}\"}}"))
+            }
+        }
+        fn docs_by_category(&self, _: &str) -> Result<JsonDoc, StoreError> {
+            ok!("[]")
+        }
+        fn ai_instructions_list(&self) -> Result<JsonDoc, StoreError> {
+            ok!("[]")
+        }
+        fn ai_instruction_by_name_or_target(&self, id: &str) -> Result<JsonDoc, StoreError> {
+            *self.last_identifier.borrow_mut() = Some(id.to_owned());
+            ok!("{}")
+        }
+        fn architecture(&self) -> Result<JsonDoc, StoreError> {
+            ok!("{}")
+        }
+        fn architecture_nodes(&self) -> Result<JsonDoc, StoreError> {
+            ok!("[]")
+        }
+        fn architecture_axes(&self) -> Result<JsonDoc, StoreError> {
+            ok!("[]")
+        }
+        fn changelog(&self, limit: u32, offset: u32) -> Result<JsonDoc, StoreError> {
+            ok!(format!("{{\"limit\":{limit},\"offset\":{offset}}}"))
+        }
+        fn changelog_entry(&self, _: &str) -> Result<JsonDoc, StoreError> {
+            Err(StoreError::Backend(
+                "relation \"changelog\" does not exist".to_owned(),
+            ))
+        }
+    }
+
+    #[test]
+    fn routes_match_the_documented_surface() {
+        assert_eq!(route("GET", "/counts", ""), Route::Counts);
+        assert_eq!(route("GET", "/docs", ""), Route::DocsList);
+        assert_eq!(route("GET", "/docs/intro", ""), Route::Doc("intro".into()));
+        assert_eq!(
+            route("GET", "/docs/category/guides", ""),
+            Route::DocsByCategory("guides".into())
+        );
+        assert_eq!(
+            route("GET", "/ai-instructions", ""),
+            Route::AiInstructionsList
+        );
+        assert_eq!(
+            route("GET", "/architecture/nodes", ""),
+            Route::ArchitectureNodes
+        );
+        assert_eq!(route("GET", "/nope", ""), Route::NotFound);
+    }
+
+    #[test]
+    fn a_bare_category_path_is_not_a_slug_called_category() {
+        // The .ts checks `sub !== "category"` to avoid exactly this.
+        assert_eq!(route("GET", "/docs/category", ""), Route::NotFound);
+    }
+
+    #[test]
+    fn method_handling_matches() {
+        assert_eq!(route("OPTIONS", "/docs", ""), Route::Preflight);
+        assert_eq!(route("POST", "/docs", ""), Route::MethodNotAllowed);
+        let (r, _) = handle(&Route::MethodNotAllowed, &Spy::new());
+        assert_eq!(r.status, 405);
+    }
+
+    #[test]
+    fn changelog_paging_clamps_like_the_typescript() {
+        assert_eq!(
+            route("GET", "/changelog", "limit=500"),
+            Route::Changelog {
+                limit: 100,
+                offset: 0
+            }
+        );
+        assert_eq!(
+            route("GET", "/changelog", "limit=5&offset=10"),
+            Route::Changelog {
+                limit: 5,
+                offset: 10
+            }
+        );
+    }
+
+    #[test]
+    fn an_unparseable_limit_takes_the_default_not_nan() {
+        // parseInt("abc") is NaN in the .ts, and NaN reaches the database.
+        assert_eq!(
+            route("GET", "/changelog", "limit=abc"),
+            Route::Changelog {
+                limit: 20,
+                offset: 0
+            }
+        );
+    }
+
+    #[test]
+    fn a_negative_offset_cannot_be_expressed() {
+        // The .ts needs Math.max(offset, 0); u32 makes it unrepresentable.
+        assert_eq!(
+            route("GET", "/changelog", "offset=-5"),
+            Route::Changelog {
+                limit: 20,
+                offset: 0
+            }
+        );
+    }
+
+    #[test]
+    fn an_injection_attempt_stays_one_opaque_value() {
+        // The .ts interpolates this into `or(name.eq.${id},target.eq.${id})`,
+        // where the comma and dots are filter STRUCTURE.
+        let hostile = "x,status.eq.draft";
+        let r = route("GET", &format!("/ai-instructions/{hostile}"), "");
+        assert_eq!(r, Route::AiInstruction(hostile.to_owned()));
+
+        let spy = Spy::new();
+        let (resp, _) = handle(&r, &spy);
+        assert_eq!(resp.status, 200);
+        // It reached the store as ONE parameter, intact and unsplit — there is no
+        // filter string for it to be part of.
+        assert_eq!(spy.last_identifier.borrow().as_deref(), Some(hostile));
+    }
+
+    #[test]
+    fn backend_detail_is_logged_not_returned() {
+        let (resp, log) = handle(&Route::ChangelogEntry("4.0.0".into()), &Spy::new());
+        assert_eq!(resp.status, 500);
+        assert!(resp.body.contains("Internal server error"));
+        // The .ts returns err.message, which names the relation.
+        assert!(!resp.body.contains("relation"));
+        assert!(log.unwrap().contains("relation"));
+    }
+
+    #[test]
+    fn not_found_from_the_store_becomes_404() {
+        let (resp, log) = handle(&Route::Doc("missing".into()), &Spy::new());
+        assert_eq!(resp.status, 404);
+        assert!(log.is_none());
+    }
+
+    #[test]
+    fn successful_responses_carry_cors_and_cache() {
+        let (resp, _) = handle(&Route::Counts, &Spy::new());
+        assert_eq!(resp.status, 200);
+        let names: Vec<&str> = resp.headers.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(names.contains(&"Access-Control-Allow-Origin"));
+        assert!(names.contains(&"Cache-Control"));
+    }
+
+    #[test]
+    fn errors_carry_cors_but_not_cache() {
+        let (resp, _) = handle(&Route::NotFound, &Spy::new());
+        let names: Vec<&str> = resp.headers.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(names.contains(&"Access-Control-Allow-Origin"));
+        assert!(
+            !names.contains(&"Cache-Control"),
+            "a 404 must not be cached for 60s"
+        );
+    }
+
+    #[test]
+    fn preflight_has_no_body() {
+        let (resp, _) = handle(&Route::Preflight, &Spy::new());
+        assert_eq!(resp.status, 204);
+        assert!(resp.body.is_empty());
+    }
+
+    #[test]
+    fn error_bodies_escape_their_message() {
+        let r = error_response(400, "bad \"quoted\" thing");
+        assert!(r.body.contains("\\\"quoted\\\""));
+    }
+}

--- a/components/registry/n11-discovery/nyuchi-seo.rs
+++ b/components/registry/n11-discovery/nyuchi-seo.rs
@@ -1,0 +1,778 @@
+//! Mzizi N11 discovery — "if the machine can't see it, it doesn't exist."
+//!
+//! The Rust implementation of `nyuchi-seo`: page metadata and Schema.org JSON-LD,
+//! for a host that is not Next.js.
+//!
+//! # What this owns, and what the host owns
+//!
+//! This builds the metadata and renders it. It does not know what a framework is.
+//! The `.ts` sibling returns a Next.js `Metadata` object and lets the App Router
+//! render the tags; there is no App Router here, so [`Metadata::to_head_html`]
+//! emits the `<meta>`/`<link>` elements and the host puts them in `<head>`. Same
+//! division as N8, which builds an OTLP request and lets the host send it.
+//!
+//! # A security defect in the TypeScript, fixed here
+//!
+//! `generateSchemaLD` returns `JSON.stringify(...)` and its own doc comment tells
+//! you to inject it with `dangerouslySetInnerHTML`. JSON escaping does not escape
+//! `<`, so any schema field carrying the six characters `</script` closes the
+//! script element early and everything after it is parsed as HTML. A job title, a
+//! product name or an article headline is enough — all four templates take
+//! caller-supplied strings, and a marketplace listing is user input.
+//!
+//! [`generate_schema_ld`] escapes `<` as `\u003c` (and `>` as `\u003e`, and `&`
+//! as `\u0026`). Those are valid JSON string escapes, so the JSON-LD parses
+//! identically while becoming inert inside a script element. This is the standard
+//! mitigation and it costs nothing.
+//!
+//! **The `.ts` sibling still has this defect.** It is not fixed by this file, and
+//! it should be — tracked as part of the back-port of Rust-found defects.
+//!
+//! # Two things the TypeScript does that this deliberately does not
+//!
+//! **The `product` og:type dance.** The `.ts` sets `openGraph.type` to `website`
+//! when the caller asked for `product`, then re-emits the true value through
+//! Next's `other` map — because Next's `OpenGraph` union rejects `product`. That
+//! is a workaround for one framework's types, not a fact about Open Graph, so
+//! here [`OgType::Product`] simply emits `og:type` as `product` once.
+//!
+//! **`alternates.languages` built from a bare locale list.** Preserved as-is,
+//! including that it emits no `x-default` and does not include the current locale
+//! — changing either alters what crawlers do with a live site, which is a
+//! product decision rather than a porting one.
+
+use core::fmt::Write as _;
+
+/// What kind of thing the page is, for `og:type`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OgType {
+    /// A generic page.
+    #[default]
+    Website,
+    /// A piece of writing.
+    Article,
+    /// A person or organisation.
+    Profile,
+    /// Something for sale. A real `og:type` (ogp.me/ns/product).
+    Product,
+}
+
+impl OgType {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Website => "website",
+            Self::Article => "article",
+            Self::Profile => "profile",
+            Self::Product => "product",
+        }
+    }
+}
+
+/// How a link should render on X/Twitter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TwitterCard {
+    /// Small thumbnail beside the text.
+    Summary,
+    /// Full-bleed image above the text.
+    #[default]
+    SummaryLargeImage,
+    /// An inline player.
+    Player,
+}
+
+impl TwitterCard {
+    /// The wire spelling, matching the `.ts` string union.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Summary => "summary",
+            Self::SummaryLargeImage => "summary_large_image",
+            Self::Player => "player",
+        }
+    }
+}
+
+/// The site this metadata describes. Matches the `.ts` module constants.
+pub const BASE_URL: &str = "https://mukoko.com";
+/// Site name, appended to every title.
+pub const SITE_NAME: &str = "Mukoko";
+/// Open Graph image used when a page supplies none.
+pub const DEFAULT_OG_IMAGE: &str = "/og-default.png";
+
+/// Everything a caller says about a page.
+#[derive(Debug, Clone, Default)]
+pub struct SeoConfig {
+    /// Page title, before ` — Mukoko` is appended.
+    pub title: String,
+    /// Meta description. Omitted entirely when `None`.
+    pub description: Option<String>,
+    /// Site-root-relative path, e.g. `/jobs/123`. Joined to [`BASE_URL`].
+    pub canonical_url: Option<String>,
+    /// Open Graph image URL. Falls back to [`DEFAULT_OG_IMAGE`].
+    pub og_image: Option<String>,
+    /// What kind of thing this page is.
+    pub og_type: OgType,
+    /// How the link renders on X/Twitter.
+    pub twitter_card: TwitterCard,
+    /// Ask crawlers not to index or follow.
+    pub no_index: bool,
+    /// BCP 47 locale of this page.
+    pub locale: Option<String>,
+    /// Other locales this page exists in, for `alternates.languages`.
+    pub alternate_locales: Vec<String>,
+}
+
+/// One `hreflang` alternate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Alternate {
+    /// The locale code.
+    pub locale: String,
+    /// The absolute URL for that locale.
+    pub url: String,
+}
+
+/// Resolved page metadata: every value decided, nothing defaulted later.
+///
+/// The equivalent of the `.ts`'s Next `Metadata` return, minus the framework. A
+/// host may read the fields directly or call [`Metadata::to_head_html`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Metadata {
+    /// `"<title> — Mukoko"`.
+    pub title: String,
+    /// Meta description, if the caller gave one.
+    pub description: Option<String>,
+    /// Absolute canonical URL, if the caller gave a path.
+    pub canonical: Option<String>,
+    /// `hreflang` alternates, in the order the caller listed them.
+    pub alternates: Vec<Alternate>,
+    /// True when crawlers should be told to stay away.
+    pub no_index: bool,
+    /// `og:type`, emitted truthfully — see the module docs.
+    pub og_type: OgType,
+    /// `og:locale`.
+    pub locale: String,
+    /// The image URL used for both Open Graph and Twitter.
+    pub image: String,
+    /// Open Graph image width, fixed at 1200 as in the `.ts`.
+    pub image_width: u32,
+    /// Open Graph image height, fixed at 630 as in the `.ts`.
+    pub image_height: u32,
+    /// `og:image:alt` — the raw title, not the site-suffixed one.
+    pub image_alt: String,
+    /// Twitter card style.
+    pub twitter_card: TwitterCard,
+}
+
+/// Resolve a [`SeoConfig`] into [`Metadata`], applying every default.
+///
+/// Mirrors the `.ts` `generateMetadata`, including that an empty `og_image`
+/// string falls back to the default (the `.ts` uses `||`, not `??`).
+#[must_use]
+pub fn generate_metadata(config: &SeoConfig) -> Metadata {
+    let full_title = format!("{} — {SITE_NAME}", config.title);
+
+    let image = match config.og_image.as_deref() {
+        Some(s) if !s.is_empty() => s.to_owned(),
+        _ => DEFAULT_OG_IMAGE.to_owned(),
+    };
+
+    let canonical_path = config.canonical_url.as_deref().unwrap_or("");
+    let canonical = config
+        .canonical_url
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .map(|path| format!("{BASE_URL}{path}"));
+
+    let alternates = config
+        .alternate_locales
+        .iter()
+        .map(|l| Alternate {
+            locale: l.clone(),
+            url: format!("{BASE_URL}/{l}{canonical_path}"),
+        })
+        .collect();
+
+    Metadata {
+        title: full_title,
+        description: config.description.clone(),
+        canonical,
+        alternates,
+        no_index: config.no_index,
+        og_type: config.og_type,
+        locale: config.locale.clone().unwrap_or_else(|| "en".to_owned()),
+        image,
+        image_width: 1200,
+        image_height: 630,
+        image_alt: config.title.clone(),
+        twitter_card: config.twitter_card,
+    }
+}
+
+/// Escape a string for an HTML attribute value.
+///
+/// Attribute-position escaping, because every use below is inside `content="…"`.
+/// `&` first, or the ampersands introduced by the later replacements get escaped
+/// a second time.
+fn escape_attr(s: &str, out: &mut String) {
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(c),
+        }
+    }
+}
+
+fn meta_name(out: &mut String, name: &str, content: &str) {
+    out.push_str("<meta name=\"");
+    out.push_str(name);
+    out.push_str("\" content=\"");
+    escape_attr(content, out);
+    out.push_str("\">\n");
+}
+
+fn meta_property(out: &mut String, property: &str, content: &str) {
+    out.push_str("<meta property=\"");
+    out.push_str(property);
+    out.push_str("\" content=\"");
+    escape_attr(content, out);
+    out.push_str("\">\n");
+}
+
+impl Metadata {
+    /// Render the `<title>`, `<meta>` and `<link>` elements for `<head>`.
+    ///
+    /// Every caller-supplied value is attribute-escaped. The `.ts` never had to
+    /// do this because React escaped for it; a Rust host writing a string into
+    /// `<head>` has no such help, so it happens here rather than being left as an
+    /// exercise for whoever renders.
+    #[must_use]
+    pub fn to_head_html(&self) -> String {
+        let mut out = String::new();
+
+        out.push_str("<title>");
+        escape_attr(&self.title, &mut out);
+        out.push_str("</title>\n");
+
+        if let Some(d) = &self.description {
+            meta_name(&mut out, "description", d);
+        }
+        if self.no_index {
+            meta_name(&mut out, "robots", "noindex, nofollow");
+        }
+        if let Some(c) = &self.canonical {
+            out.push_str("<link rel=\"canonical\" href=\"");
+            escape_attr(c, &mut out);
+            out.push_str("\">\n");
+        }
+        for alt in &self.alternates {
+            out.push_str("<link rel=\"alternate\" hreflang=\"");
+            escape_attr(&alt.locale, &mut out);
+            out.push_str("\" href=\"");
+            escape_attr(&alt.url, &mut out);
+            out.push_str("\">\n");
+        }
+
+        meta_property(&mut out, "og:title", &self.title);
+        if let Some(d) = &self.description {
+            meta_property(&mut out, "og:description", d);
+        }
+        if let Some(c) = &self.canonical {
+            meta_property(&mut out, "og:url", c);
+        }
+        meta_property(&mut out, "og:site_name", SITE_NAME);
+        meta_property(&mut out, "og:type", self.og_type.as_str());
+        meta_property(&mut out, "og:locale", &self.locale);
+        meta_property(&mut out, "og:image", &self.image);
+        let mut buf = String::new();
+        let _ = write!(buf, "{}", self.image_width);
+        meta_property(&mut out, "og:image:width", &buf);
+        buf.clear();
+        let _ = write!(buf, "{}", self.image_height);
+        meta_property(&mut out, "og:image:height", &buf);
+        meta_property(&mut out, "og:image:alt", &self.image_alt);
+
+        meta_name(&mut out, "twitter:card", self.twitter_card.as_str());
+        meta_name(&mut out, "twitter:title", &self.title);
+        if let Some(d) = &self.description {
+            meta_name(&mut out, "twitter:description", d);
+        }
+        meta_name(&mut out, "twitter:image", &self.image);
+
+        out
+    }
+}
+
+// ─── Schema.org ─────────────────────────────────────────────────────────────
+
+/// A JSON value, enough for Schema.org and no more.
+///
+/// Hand-rolled rather than `serde_json`, for the reason N8's crate states at
+/// length: these components are compiled into every consumer, and JSON-LD is a
+/// small, fully specified shape.
+///
+/// `Object` is a `Vec` of pairs, not a map, because Schema.org output is read by
+/// people as often as machines and insertion order is worth keeping.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Json {
+    /// A string.
+    Str(String),
+    /// A number. JSON has one numeric type.
+    Num(f64),
+    /// A boolean.
+    Bool(bool),
+    /// An ordered list.
+    Arr(Vec<Json>),
+    /// An ordered set of key/value pairs.
+    Object(Vec<(String, Json)>),
+}
+
+impl Json {
+    /// Convenience for `Json::Str`.
+    #[must_use]
+    pub fn s(v: impl Into<String>) -> Self {
+        Self::Str(v.into())
+    }
+
+    /// Build an object from pairs.
+    #[must_use]
+    pub fn obj<K: Into<String>>(pairs: impl IntoIterator<Item = (K, Self)>) -> Self {
+        Self::Object(pairs.into_iter().map(|(k, v)| (k.into(), v)).collect())
+    }
+
+    fn write(&self, out: &mut String) {
+        match self {
+            Self::Str(s) => write_json_string(s, out),
+            Self::Num(n) => {
+                // JSON has no NaN or Infinity. Emitting one produces a document
+                // no parser accepts, so they become null — the same choice
+                // `JSON.stringify` makes, which keeps the two siblings agreeing.
+                if n.is_finite() {
+                    let _ = write!(out, "{n}");
+                } else {
+                    out.push_str("null");
+                }
+            }
+            Self::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
+            Self::Arr(items) => {
+                out.push('[');
+                for (i, item) in items.iter().enumerate() {
+                    if i > 0 {
+                        out.push(',');
+                    }
+                    item.write(out);
+                }
+                out.push(']');
+            }
+            Self::Object(pairs) => {
+                out.push('{');
+                for (i, (k, v)) in pairs.iter().enumerate() {
+                    if i > 0 {
+                        out.push(',');
+                    }
+                    write_json_string(k, out);
+                    out.push(':');
+                    v.write(out);
+                }
+                out.push('}');
+            }
+        }
+    }
+}
+
+/// Write a JSON string literal, escaped so it is also inert inside `<script>`.
+///
+/// Beyond the escapes JSON requires, `<`, `>` and `&` become `\u003c`, `\u003e`
+/// and `\u0026`. All three are valid JSON escapes, so a parser sees the original
+/// characters — but the literal text `</script>` can no longer appear in the
+/// output, which is what stops a caller-supplied string from closing the script
+/// element that carries it. See the module docs.
+fn write_json_string(s: &str, out: &mut String) {
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{8}' => out.push_str("\\b"),
+            '\u{c}' => out.push_str("\\f"),
+            '<' => out.push_str("\\u003c"),
+            '>' => out.push_str("\\u003e"),
+            '&' => out.push_str("\\u0026"),
+            // U+2028 and U+2029 are legal in JSON strings and illegal in
+            // JavaScript source. A JSON-LD block is parsed as JSON, but the same
+            // string reaching a `<script>` of another type would break it.
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            c if (c as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+}
+
+/// One Schema.org node: an `@type` plus its properties.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SchemaOrg {
+    /// The `@type` value, e.g. `JobPosting`.
+    pub ty: String,
+    /// Everything else, in order.
+    pub properties: Vec<(String, Json)>,
+}
+
+impl SchemaOrg {
+    /// A node of the given type with no properties yet.
+    #[must_use]
+    pub fn new(ty: impl Into<String>) -> Self {
+        Self {
+            ty: ty.into(),
+            properties: Vec::new(),
+        }
+    }
+
+    /// Add a property, builder style.
+    #[must_use]
+    pub fn with(mut self, key: impl Into<String>, value: Json) -> Self {
+        self.properties.push((key.into(), value));
+        self
+    }
+
+    /// Add a property only when the option is `Some`, mirroring the `.ts`
+    /// spread-if-present idiom.
+    #[must_use]
+    pub fn with_opt(self, key: impl Into<String>, value: Option<Json>) -> Self {
+        match value {
+            Some(v) => self.with(key, v),
+            None => self,
+        }
+    }
+
+    fn to_json(&self, with_context: bool) -> Json {
+        let mut pairs: Vec<(String, Json)> = Vec::with_capacity(self.properties.len() + 2);
+        if with_context {
+            pairs.push(("@context".to_owned(), Json::s("https://schema.org")));
+        }
+        pairs.push(("@type".to_owned(), Json::s(self.ty.clone())));
+        pairs.extend(self.properties.iter().cloned());
+        Json::Object(pairs)
+    }
+}
+
+/// Serialise one or more Schema.org nodes as a JSON-LD document.
+///
+/// One node yields that node with `@context`. Several yield a single `@context`
+/// and an `@graph`.
+///
+/// # Divergence from the TypeScript
+///
+/// The `.ts` puts `@context` on the wrapper AND on every member of `@graph`. A
+/// `@graph` inherits the enclosing context, so the repeats are redundant — this
+/// emits it once, which is the canonical form. No consumer sees a different
+/// graph; it is the same document with less in it.
+#[must_use]
+pub fn generate_schema_ld(schema: &[SchemaOrg]) -> String {
+    let mut out = String::new();
+    match schema {
+        [] => {
+            // The `.ts` cannot reach this: its parameter is one node or a
+            // non-empty array in practice. An empty slice is expressible here,
+            // and an empty JSON-LD block is the only honest answer — a `@graph`
+            // of nothing would claim a structure that is not there.
+            Json::Object(vec![("@context".to_owned(), Json::s("https://schema.org"))])
+                .write(&mut out);
+        }
+        [only] => only.to_json(true).write(&mut out),
+        many => {
+            let graph = many.iter().map(|n| n.to_json(false)).collect::<Vec<_>>();
+            Json::Object(vec![
+                ("@context".to_owned(), Json::s("https://schema.org")),
+                ("@graph".to_owned(), Json::Arr(graph)),
+            ])
+            .write(&mut out);
+        }
+    }
+    out
+}
+
+/// A pay range on a [`job_posting`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct Salary {
+    /// Lower bound.
+    pub min: f64,
+    /// Upper bound.
+    pub max: f64,
+    /// ISO 4217 code.
+    pub currency: String,
+}
+
+/// A `JobPosting` node.
+#[must_use]
+pub fn job_posting(
+    title: &str,
+    company: &str,
+    location: &str,
+    description: &str,
+    date_posted: &str,
+    salary: Option<&Salary>,
+) -> SchemaOrg {
+    SchemaOrg::new("JobPosting")
+        .with("title", Json::s(title))
+        .with(
+            "hiringOrganization",
+            Json::obj([
+                ("@type", Json::s("Organization")),
+                ("name", Json::s(company)),
+            ]),
+        )
+        .with(
+            "jobLocation",
+            Json::obj([("@type", Json::s("Place")), ("address", Json::s(location))]),
+        )
+        .with("description", Json::s(description))
+        .with("datePosted", Json::s(date_posted))
+        .with_opt(
+            "baseSalary",
+            salary.map(|s| {
+                Json::obj([
+                    ("@type", Json::s("MonetaryAmount")),
+                    ("currency", Json::s(s.currency.clone())),
+                    (
+                        "value",
+                        Json::obj([
+                            ("@type", Json::s("QuantitativeValue")),
+                            ("minValue", Json::Num(s.min)),
+                            ("maxValue", Json::Num(s.max)),
+                            ("unitText", Json::s("MONTH")),
+                        ]),
+                    ),
+                ])
+            }),
+        )
+}
+
+/// An `Article` node.
+#[must_use]
+pub fn article(title: &str, author: &str, date_published: &str, image: Option<&str>) -> SchemaOrg {
+    SchemaOrg::new("Article")
+        .with("headline", Json::s(title))
+        .with(
+            "author",
+            Json::obj([("@type", Json::s("Person")), ("name", Json::s(author))]),
+        )
+        .with("datePublished", Json::s(date_published))
+        .with_opt("image", image.map(Json::s))
+}
+
+/// An `Event` node.
+#[must_use]
+pub fn event(
+    name: &str,
+    start_date: &str,
+    end_date: Option<&str>,
+    location: &str,
+    description: Option<&str>,
+) -> SchemaOrg {
+    SchemaOrg::new("Event")
+        .with("name", Json::s(name))
+        .with("startDate", Json::s(start_date))
+        .with_opt("endDate", end_date.map(Json::s))
+        .with(
+            "location",
+            Json::obj([("@type", Json::s("Place")), ("name", Json::s(location))]),
+        )
+        .with_opt("description", description.map(Json::s))
+}
+
+/// A `Product` node.
+#[must_use]
+pub fn product(
+    name: &str,
+    price: f64,
+    currency: &str,
+    image: Option<&str>,
+    description: Option<&str>,
+) -> SchemaOrg {
+    SchemaOrg::new("Product")
+        .with("name", Json::s(name))
+        .with_opt("description", description.map(Json::s))
+        .with_opt("image", image.map(Json::s))
+        .with(
+            "offers",
+            Json::obj([
+                ("@type", Json::s("Offer")),
+                ("price", Json::Num(price)),
+                ("priceCurrency", Json::s(currency)),
+                ("availability", Json::s("https://schema.org/InStock")),
+            ]),
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(title: &str) -> SeoConfig {
+        SeoConfig {
+            title: title.to_owned(),
+            ..SeoConfig::default()
+        }
+    }
+
+    #[test]
+    fn title_is_suffixed_and_alt_text_is_not() {
+        let m = generate_metadata(&cfg("Jobs"));
+        assert_eq!(m.title, "Jobs — Mukoko");
+        assert_eq!(m.image_alt, "Jobs");
+    }
+
+    #[test]
+    fn defaults_match_the_typescript() {
+        let m = generate_metadata(&cfg("x"));
+        assert_eq!(m.og_type, OgType::Website);
+        assert_eq!(m.twitter_card, TwitterCard::SummaryLargeImage);
+        assert_eq!(m.locale, "en");
+        assert_eq!(m.image, DEFAULT_OG_IMAGE);
+        assert!(!m.no_index);
+        assert!(m.canonical.is_none());
+    }
+
+    #[test]
+    fn empty_og_image_falls_back_like_the_ts_or_operator() {
+        let m = generate_metadata(&SeoConfig {
+            og_image: Some(String::new()),
+            ..cfg("x")
+        });
+        assert_eq!(m.image, DEFAULT_OG_IMAGE);
+    }
+
+    #[test]
+    fn canonical_and_alternates_are_absolute() {
+        let m = generate_metadata(&SeoConfig {
+            canonical_url: Some("/jobs/1".to_owned()),
+            alternate_locales: vec!["sn".to_owned(), "nd".to_owned()],
+            ..cfg("x")
+        });
+        assert_eq!(m.canonical.as_deref(), Some("https://mukoko.com/jobs/1"));
+        assert_eq!(m.alternates[0].url, "https://mukoko.com/sn/jobs/1");
+        assert_eq!(m.alternates[1].url, "https://mukoko.com/nd/jobs/1");
+    }
+
+    #[test]
+    fn product_emits_its_true_og_type_once() {
+        let m = generate_metadata(&SeoConfig {
+            og_type: OgType::Product,
+            ..cfg("Sofa")
+        });
+        let html = m.to_head_html();
+        assert!(html.contains(r#"<meta property="og:type" content="product">"#));
+        assert!(!html.contains(r#"content="website""#));
+        assert_eq!(html.matches("og:type").count(), 1);
+    }
+
+    #[test]
+    fn head_html_escapes_attribute_values() {
+        let m = generate_metadata(&cfg(r#"Bolt " & <b>"#));
+        let html = m.to_head_html();
+        assert!(!html.contains("<b>"));
+        assert!(html.contains("&lt;b&gt;"));
+        assert!(html.contains("&quot;"));
+        assert!(html.contains("&amp;"));
+    }
+
+    #[test]
+    fn no_index_emits_robots() {
+        let m = generate_metadata(&SeoConfig {
+            no_index: true,
+            ..cfg("x")
+        });
+        assert!(
+            m.to_head_html()
+                .contains(r#"name="robots" content="noindex, nofollow""#)
+        );
+    }
+
+    #[test]
+    fn single_node_carries_the_context() {
+        let json = generate_schema_ld(&[article("T", "A", "2026-01-01", None)]);
+        assert!(json.starts_with(r#"{"@context":"https://schema.org","@type":"Article""#));
+        assert!(!json.contains("@graph"));
+    }
+
+    #[test]
+    fn graph_carries_the_context_exactly_once() {
+        let json = generate_schema_ld(&[
+            article("T", "A", "2026-01-01", None),
+            event("E", "2026-02-01", None, "Harare", None),
+        ]);
+        assert_eq!(
+            json.matches("@context").count(),
+            1,
+            "the .ts repeats it per member"
+        );
+        assert!(json.contains("@graph"));
+    }
+
+    #[test]
+    fn script_closing_sequence_cannot_survive_into_the_document() {
+        // The defect this file fixes: a caller-supplied string ending the script
+        // element that carries it.
+        let json = generate_schema_ld(&[article(
+            "Great deal</script><script>alert(1)</script>",
+            "A",
+            "2026-01-01",
+            None,
+        )]);
+        assert!(!json.contains("</script>"));
+        assert!(!json.contains('<'));
+        assert!(json.contains("\\u003c/script\\u003e"));
+    }
+
+    #[test]
+    fn optional_fields_are_omitted_not_nulled() {
+        let json = generate_schema_ld(&[product("Sofa", 100.0, "USD", None, None)]);
+        assert!(!json.contains("image"));
+        assert!(!json.contains("description"));
+        assert!(json.contains(r#""price":100"#));
+    }
+
+    #[test]
+    fn salary_nests_a_quantitative_value() {
+        let s = Salary {
+            min: 500.0,
+            max: 900.0,
+            currency: "USD".to_owned(),
+        };
+        let json = generate_schema_ld(&[job_posting(
+            "Dev",
+            "Nyuchi",
+            "Harare",
+            "d",
+            "2026-01-01",
+            Some(&s),
+        )]);
+        assert!(json.contains(r#""@type":"MonetaryAmount""#));
+        assert!(json.contains(r#""minValue":500"#));
+        assert!(json.contains(r#""unitText":"MONTH""#));
+    }
+
+    #[test]
+    fn non_finite_numbers_become_null_like_json_stringify() {
+        let json = generate_schema_ld(&[product("x", f64::NAN, "USD", None, None)]);
+        assert!(json.contains(r#""price":null"#));
+    }
+
+    #[test]
+    fn empty_slice_yields_a_bare_context_not_an_empty_graph() {
+        let json = generate_schema_ld(&[]);
+        assert_eq!(json, r#"{"@context":"https://schema.org"}"#);
+    }
+}

--- a/mzizi-rs/Cargo.lock
+++ b/mzizi-rs/Cargo.lock
@@ -476,6 +476,14 @@ name = "mzizi-assurance"
 version = "0.1.0"
 
 [[package]]
+name = "mzizi-discovery"
+version = "0.1.0"
+
+[[package]]
+name = "mzizi-docs"
+version = "0.1.0"
+
+[[package]]
 name = "mzizi-fundi"
 version = "0.1.0"
 

--- a/mzizi-rs/Cargo.toml
+++ b/mzizi-rs/Cargo.toml
@@ -24,7 +24,14 @@
 
 [workspace]
 resolver = "3"
-members = ["crates/mzizi-tokens", "crates/mzizi-ui", "crates/mzizi-assurance", "crates/mzizi-fundi"]
+members = [
+  "crates/mzizi-tokens",
+  "crates/mzizi-ui",
+  "crates/mzizi-assurance",
+  "crates/mzizi-fundi",
+  "crates/mzizi-discovery",
+  "crates/mzizi-docs",
+]
 
 [workspace.package]
 version = "0.1.0"

--- a/mzizi-rs/crates/mzizi-discovery/Cargo.toml
+++ b/mzizi-rs/crates/mzizi-discovery/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "mzizi-discovery"
+description = "Mzizi N11 discovery — the machine-visibility rung: page metadata and Schema.org JSON-LD."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[lints]
+workspace = true
+
+# No dependencies, matching N8 and N9.
+#
+# `serde_json` is the reflexive one and it is declined for the reason N8 states:
+# these components compile into every consumer, and JSON-LD is a small, fully
+# specified shape. The escaping this node needs is stricter than serde's default
+# anyway — `<`, `>` and `&` must become \u escapes so a caller-supplied string
+# cannot close the <script> element carrying it.
+[dependencies]

--- a/mzizi-rs/crates/mzizi-discovery/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-discovery/src/lib.rs
@@ -1,0 +1,19 @@
+//! Mzizi N11 discovery for Rust — "if the machine can't see it, it doesn't exist."
+//!
+//! # Where the components are
+//!
+//! Not in this crate's `src/`. Each is a file under
+//! `components/registry/n11-discovery/<name>.rs`, beside the `.ts` implementing
+//! the same contract for a JavaScript host, and this module `#[path]`-includes
+//! it.
+//!
+//! # What is here
+//!
+//! The rung that makes a page legible to a machine: resolved page metadata and
+//! Schema.org JSON-LD. The `.ts` returns a Next.js `Metadata` object; there is no
+//! Next.js here, so the Rust side returns a plain resolved struct and can render
+//! the `<head>` elements itself. Same division as N8, which builds an OTLP
+//! request and lets the host send it.
+
+#[path = "../../../../components/registry/n11-discovery/nyuchi-seo.rs"]
+pub mod nyuchi_seo;

--- a/mzizi-rs/crates/mzizi-docs/Cargo.toml
+++ b/mzizi-rs/crates/mzizi-docs/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mzizi-docs"
+description = "Mzizi N10 documentation — the self-describing rung: the system explaining itself."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[lints]
+workspace = true
+
+# No dependencies, matching N8, N9 and N11.
+[dependencies]

--- a/mzizi-rs/crates/mzizi-docs/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-docs/src/lib.rs
@@ -1,0 +1,19 @@
+//! Mzizi N10 documentation for Rust — "the system describes itself."
+//!
+//! # Where the components are
+//!
+//! Not in this crate's `src/`. Each is a file under
+//! `components/registry/n10-documentation/<name>.rs`, beside the `.ts`/`.tsx`
+//! implementing the same contract for a JavaScript host, and this module
+//! `#[path]`-includes it.
+//!
+//! # A theme across this node
+//!
+//! N10's components describe the ecosystem, so a stale literal here does not
+//! merely go out of date — it becomes what the system TELLS people about itself.
+//! `nyuchi-ai-context` is the sharp case: it opens by forbidding hardcoded counts
+//! and then hardcodes the entire node list, which duly went stale at N10 while
+//! the node set ran on to N12. Each port turns those literals into parameters.
+
+#[path = "../../../../components/registry/n10-documentation/nyuchi-ai-context.rs"]
+pub mod nyuchi_ai_context;

--- a/mzizi-rs/crates/mzizi-docs/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-docs/src/lib.rs
@@ -17,3 +17,6 @@
 
 #[path = "../../../../components/registry/n10-documentation/nyuchi-ai-context.rs"]
 pub mod nyuchi_ai_context;
+
+#[path = "../../../../components/registry/n10-documentation/nyuchi-docs-api.rs"]
+pub mod nyuchi_docs_api;


### PR DESCRIPTION
## Summary

First increment of the backwards Rust build-out (#52). Two new crates, three components:

| crate | component | tests |
| --- | --- | --- |
| `mzizi-discovery` (N11) | `nyuchi-seo` | 14 |
| `mzizi-docs` (N10) | `nyuchi-ai-context` | 11 |
| `mzizi-docs` (N10) | `nyuchi-docs-api` | 13 |

**N11 is now complete.** N10 is 3 of 4 — the two remaining are `.tsx` renderers needing
Dioxus, which is a different kind of port and is not in this PR.

Workspace: **234 tests**, `clippy -D warnings` clean, `fmt --check` clean. CI's Rust job is
`--workspace`, so both crates are gated from the commit that adds them.

All three are dependency-free, matching N8 and N9.

## ⚠️ Three security defects found while porting

All three are in **components consumers install**, and **none is fixed by this PR** — the
`.ts` siblings still carry them. Flagging rather than fixing, because changing published
component behaviour is a separate call.

**1. `nyuchi-seo` — script-element breakout in JSON-LD.** `generateSchemaLD` returns
`JSON.stringify(...)` and its own doc comment tells you to inject the result with
`dangerouslySetInnerHTML`. JSON escaping does not escape `<`, so any schema field containing
`</script` closes the element early and the rest is parsed as HTML. All four templates take
caller-supplied strings — a job title, a product name, an article headline — and a marketplace
listing is user input.

**2. `nyuchi-docs-api` — PostgREST filter-structure injection.**

```ts
.or(`name.eq.${identifier},target.eq.${identifier}`)
```

`identifier` is the URL path segment, unescaped. PostgREST reads `,` as a disjunction
separator and `.` as the operator separator, so `GET /ai-instructions/x,status.eq.draft` does
not look up `x` — it adds a condition, widening which rows the `or` matches past the
`status = active` the route intends. This is the same class `lib/db`'s `searchComponents`
carries a comment about having removed. **The app was fixed; the published component was not.**

**3. `nyuchi-docs-api` — a service-role credential in a publicly installable component.** It
reads `SUPABASE_SERVICE_ROLE_KEY`, so `shadcn add nyuchi-docs-api` hands a consumer a function
that bypasses RLS — for a read layer over *published* documentation. Its own header states
this and calls it out of scope.

In the Rust, 2 and 3 are **structurally impossible** rather than merely fixed: the identifier
is a bound parameter on `DocsStore::ai_instruction_by_name_or_target` with no filter string to
become part of, and the module holds no client and reads no environment — the host implements
the trait, and an anon client under RLS satisfies it completely.

## Other defects fixed in the ports

- **`nyuchi-docs-api` leaked schema through errors.** `err.message` from PostgREST was returned
  with a 500, naming relations and columns. `handle` now returns the detail separately for the
  host to log; the caller gets a fixed string.
- **`parseInt("abc")` is `NaN`**, `Math.min(NaN, 100)` is `NaN`, and `NaN` reached the database
  as a page size. An unparseable limit takes the default; a negative offset is unrepresentable
  because the type is `u32`.
- **`nyuchi-ai-context` contradicted itself.** It opens, in capitals, with *"This lib never
  hardcodes counts. Counts drift as the ecosystem evolves"* — then hardcodes the whole node set
  as a literal: ten rows, N1–N10, under the retired horizontal/vertical/depth/outlier axis
  model. Both had drifted; the node set runs to N12. A hardcoded node **list** rots exactly like
  a hardcoded node **count**. The node map is now a parameter defaulting to the current twelve,
  so a caller reading `/api/v1/architecture` gets one that cannot go stale. The repo slug is
  corrected too — the `.ts` says `nyuchi/design-portal`, and an assistant given a wrong slug
  reports the code does not exist.

## Preserved rather than "fixed"

Rule 8's "48px minimum" in `nyuchi-ai-context` is reproduced as written, not reconciled with
what the primitives ship. That is doctrine text owned by N10, and quietly editing what the
system tells an assistant about itself is not a porting decision.

## Type

- [x] New feature
- [x] Security / dependency update

## Pre-commit Gate

- [x] `pnpm typecheck` — zero errors
- [x] `pnpm audit` — no known vulnerabilities
- [x] `cargo test --workspace` — 234 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

## Registry

- [x] `registry:validate`, `registry:verify`, `registry:paths:check` green — no manifest change
      needed, since a `.rs` sibling joins an existing item's `sources` map by name

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_