### PR TITLE
feat(rust): close N10 with the two Dioxus renderers

### DIFF
--- a/components/registry/n10-documentation/nyuchi-changelog-renderer.rs
+++ b/components/registry/n10-documentation/nyuchi-changelog-renderer.rs
@@ -1,0 +1,350 @@
+//! NYUCHI CHANGELOG RENDERER — N10 documentation, Dioxus.
+//!
+//! The Rust sibling of `nyuchi-changelog-renderer.tsx`, sharing its contract: the same
+//! `data-slot`, the same timeline structure, and the same class strings, so a Dioxus app
+//! renders markup a React-authored stylesheet already styles.
+//!
+//! # The node table went stale, again
+//!
+//! The `.tsx` carries two hardcoded maps, `NODE_LABELS` and `NODE_AXIS`, both stopping at
+//! N10. `nyuchi-ai-context` next door has the identical defect and this file makes three in
+//! one node — which is the argument for treating a node table as DATA rather than as a
+//! literal, everywhere it appears.
+//!
+//! The consequence here is visible rather than merely wrong. `NODE_AXIS[11]` is undefined, so
+//! `AXIS_COLOURS[NODE_AXIS[n] ?? "horizontal"]` paints N11 and N12 cobalt — the horizontal
+//! colour — while the `title` beside it reads "N11 — Unknown (unknown axis)". A changelog
+//! entry touching the discovery rung renders with a confident wrong colour and a tooltip
+//! admitting it does not know.
+//!
+//! So [`NodeStyle`] rows are a parameter. [`default_node_styles`] covers N1–N12 and is a
+//! DEFAULT, not a definition — a caller reading `/api/v1/architecture` gets one that cannot
+//! go stale.
+//!
+//! # The axis words are gone, the colours are not
+//!
+//! `horizontal` / `vertical` / `depth` / `outlier` are the retired layer-and-axis scheme.
+//! The four colour classes they selected are real and shipped, so [`NodeAccent`] keeps the
+//! colours and names them by their mineral — which is what they actually are — instead of by
+//! a model this repo no longer uses. Every class string is byte-identical to the `.tsx`; the
+//! contract test asserts each one appears there.
+
+use dioxus::prelude::*;
+
+/// Which mineral a node's badge is painted in.
+///
+/// Named for the mineral rather than the retired axis it used to stand for. The class
+/// strings are unchanged, so nothing renders differently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NodeAccent {
+    /// Cobalt. Was the `horizontal` axis, and the fallback for an unknown node.
+    #[default]
+    Cobalt,
+    /// Tanzanite. Was the `vertical` axis.
+    Tanzanite,
+    /// Malachite. Was the `depth` axis.
+    Malachite,
+    /// Gold. Was the `outlier` axis.
+    Gold,
+}
+
+impl NodeAccent {
+    /// The badge classes. Identical to the `.tsx` `AXIS_COLOURS` entries.
+    #[must_use]
+    pub const fn classes(self) -> &'static str {
+        match self {
+            Self::Cobalt => "bg-[var(--color-cobalt)]/10 text-[var(--color-cobalt)]",
+            Self::Tanzanite => "bg-[var(--color-tanzanite)]/10 text-[var(--color-tanzanite)]",
+            Self::Malachite => "bg-[var(--color-malachite)]/10 text-[var(--color-malachite)]",
+            Self::Gold => "bg-[var(--color-gold)]/10 text-[var(--color-gold)]",
+        }
+    }
+}
+
+/// How one node renders in a badge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeStyle {
+    /// Node number. Uncapped.
+    pub number: u16,
+    /// Short label, e.g. `Primitives`.
+    pub label: String,
+    /// Badge colour.
+    pub accent: NodeAccent,
+}
+
+impl NodeStyle {
+    /// Build a row.
+    #[must_use]
+    pub fn new(number: u16, label: &str, accent: NodeAccent) -> Self {
+        Self {
+            number,
+            label: label.to_owned(),
+            accent,
+        }
+    }
+}
+
+/// The node set as it stands. A DEFAULT — see the module docs.
+///
+/// N1–N10 keep exactly the colours the `.tsx` gave them. N11 and N12 are added because the
+/// `.tsx` rendered them as "Unknown" in a horizontal-axis colour it had not been asked for.
+#[must_use]
+pub fn default_node_styles() -> Vec<NodeStyle> {
+    vec![
+        NodeStyle::new(1, "Tokens", NodeAccent::Tanzanite),
+        NodeStyle::new(2, "Primitives", NodeAccent::Cobalt),
+        NodeStyle::new(3, "Brand", NodeAccent::Cobalt),
+        NodeStyle::new(4, "Safety", NodeAccent::Tanzanite),
+        NodeStyle::new(5, "Resilience", NodeAccent::Tanzanite),
+        NodeStyle::new(6, "Pages", NodeAccent::Cobalt),
+        NodeStyle::new(7, "Shell", NodeAccent::Cobalt),
+        NodeStyle::new(8, "Assurance", NodeAccent::Malachite),
+        NodeStyle::new(9, "Fundi", NodeAccent::Gold),
+        NodeStyle::new(10, "Documentation", NodeAccent::Gold),
+        NodeStyle::new(11, "Discovery", NodeAccent::Gold),
+        NodeStyle::new(12, "Skills", NodeAccent::Gold),
+    ]
+}
+
+/// One released version.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangelogEntry {
+    /// Semantic version.
+    pub version: String,
+    /// One-line headline.
+    pub title: String,
+    /// Longer prose.
+    pub description: String,
+    /// Release date, already formatted by the caller.
+    ///
+    /// A pre-formatted string rather than a date type, matching the `.tsx`, which renders
+    /// `entry.date` verbatim. Formatting is the host's: it knows the viewer's locale and
+    /// this component does not.
+    pub date: String,
+    /// Node numbers this release touched. Mirrors `changelog.nodes_affected`.
+    pub nodes_affected: Vec<u16>,
+    /// Components added.
+    pub components_added: Vec<String>,
+    /// Components changed.
+    pub components_modified: Vec<String>,
+    /// Components deprecated.
+    pub components_deprecated: Vec<String>,
+}
+
+/// Look a node up, falling back the way the `.tsx` does.
+fn style_for(styles: &[NodeStyle], n: u16) -> (String, NodeAccent) {
+    styles.iter().find(|s| s.number == n).map_or_else(
+        // The `.tsx` says "Unknown" here and paints the horizontal colour anyway. Saying
+        // the node is unrecognised and colouring it as if it were is the part worth not
+        // reproducing: the label admits the gap, and the default accent is stated.
+        || (format!("N{n} — unrecognised node"), NodeAccent::default()),
+        |s| (format!("N{} — {}", s.number, s.label), s.accent),
+    )
+}
+
+const ROOT: &str = "flex flex-col gap-8";
+const ARTICLE: &str = "relative border-l-2 border-border pl-6";
+const DOT: &str = "absolute top-1 -left-[5px] size-2 rounded-full bg-primary";
+const VERSION: &str = "font-mono text-sm font-bold text-primary";
+const DATE: &str = "text-xs text-muted-foreground";
+const TITLE: &str = "mt-1 text-lg font-semibold";
+const DESCRIPTION: &str = "mt-1 text-sm text-muted-foreground";
+const NODE_BADGE: &str = "rounded-full px-2 py-0.5 text-xs font-medium";
+const ADDED: &str = "rounded bg-[var(--status-success,#64FFDA)]/10 px-1.5 py-0.5 text-xs text-[var(--status-success,#22C55E)]";
+const MODIFIED: &str =
+    "rounded bg-[var(--color-cobalt)]/10 px-1.5 py-0.5 text-xs text-[var(--color-cobalt)]";
+const DEPRECATED: &str = "rounded bg-[var(--status-warning,#F59E0B)]/10 px-1.5 py-0.5 text-xs text-[var(--status-warning,#F59E0B)] line-through";
+
+/// Join a base class string with a consumer's extra classes.
+fn join(base: &str, extra: &str) -> String {
+    if extra.is_empty() {
+        base.to_owned()
+    } else {
+        format!("{base} {extra}")
+    }
+}
+
+/// Props for [`ChangelogRenderer`].
+#[derive(Props, Clone, PartialEq)]
+pub struct ChangelogRendererProps {
+    /// Entries, newest first.
+    pub entries: Vec<ChangelogEntry>,
+    /// Node styling. Empty means [`default_node_styles`].
+    #[props(default)]
+    pub node_styles: Vec<NodeStyle>,
+    /// Extra classes, merged onto the root.
+    #[props(default)]
+    pub class: String,
+    /// Any other root attributes.
+    #[props(extends = GlobalAttributes)]
+    pub attributes: Vec<Attribute>,
+}
+
+/// The database changelog as a visual timeline.
+#[component]
+pub fn ChangelogRenderer(props: ChangelogRendererProps) -> Element {
+    let owned = default_node_styles();
+    let styles: &[NodeStyle] = if props.node_styles.is_empty() {
+        &owned
+    } else {
+        &props.node_styles
+    };
+    let total = props.entries.len();
+
+    rsx! {
+        div {
+            "data-slot": "nyuchi-changelog-renderer",
+            "data-portal": "https://mzizi.dev/components/nyuchi-changelog-renderer",
+            class: join(ROOT, &props.class),
+            role: "feed",
+            "aria-label": "Changelog",
+            ..props.attributes,
+
+            for (index , entry) in props.entries.iter().enumerate() {
+                article {
+                    key: "{entry.version}",
+                    class: ARTICLE,
+                    // `role="feed"` requires its articles to carry their position, or a
+                    // screen reader announces an unbounded stream with no sense of where the
+                    // user is. The `.tsx` sets `role="feed"` and omits both.
+                    "aria-posinset": "{index + 1}",
+                    "aria-setsize": "{total}",
+                    "aria-labelledby": "changelog-{entry.version}",
+
+                    div { class: DOT }
+
+                    div { class: "flex flex-wrap items-baseline gap-3",
+                        span { class: VERSION, "{entry.version}" }
+                        time { class: DATE, "{entry.date}" }
+                    }
+
+                    h3 { id: "changelog-{entry.version}", class: TITLE, "{entry.title}" }
+                    p { class: DESCRIPTION, "{entry.description}" }
+
+                    if !entry.nodes_affected.is_empty() {
+                        div {
+                            class: "mt-2 flex flex-wrap gap-1",
+                            "aria-label": "Nodes affected",
+                            for n in entry.nodes_affected.iter().copied() {
+                                {
+                                    let (label, accent) = style_for(styles, n);
+                                    rsx! {
+                                        span {
+                                            key: "{n}",
+                                            class: "{NODE_BADGE} {accent.classes()}",
+                                            title: "{label}",
+                                            "N{n}"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if !entry.components_added.is_empty() {
+                        div {
+                            class: "mt-2 flex flex-wrap gap-1",
+                            "aria-label": "Components added",
+                            for c in entry.components_added.iter() {
+                                span { key: "{c}", class: ADDED, "+{c}" }
+                            }
+                        }
+                    }
+
+                    if !entry.components_modified.is_empty() {
+                        div {
+                            class: "mt-1 flex flex-wrap gap-1",
+                            "aria-label": "Components modified",
+                            for c in entry.components_modified.iter() {
+                                span { key: "{c}", class: MODIFIED, "~{c}" }
+                            }
+                        }
+                    }
+
+                    if !entry.components_deprecated.is_empty() {
+                        div {
+                            class: "mt-1 flex flex-wrap gap-1",
+                            "aria-label": "Components deprecated",
+                            for c in entry.components_deprecated.iter() {
+                                span { key: "{c}", class: DEPRECATED, "{c}" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_default_node_has_a_label_and_no_duplicates() {
+        let styles = default_node_styles();
+        assert_eq!(styles.len(), 12);
+        for s in &styles {
+            assert!(!s.label.is_empty());
+        }
+        let mut numbers: Vec<u16> = styles.iter().map(|s| s.number).collect();
+        numbers.sort_unstable();
+        numbers.dedup();
+        assert_eq!(numbers.len(), styles.len());
+    }
+
+    #[test]
+    fn the_defaults_reach_past_n10() {
+        let styles = default_node_styles();
+        assert!(styles.iter().any(|s| s.number == 11));
+        assert!(styles.iter().any(|s| s.number == 12));
+    }
+
+    #[test]
+    fn n1_to_n10_keep_the_colours_the_tsx_gave_them() {
+        let styles = default_node_styles();
+        let accent = |n: u16| styles.iter().find(|s| s.number == n).unwrap().accent;
+        // vertical → tanzanite
+        for n in [1, 4, 5] {
+            assert_eq!(accent(n), NodeAccent::Tanzanite);
+        }
+        // horizontal → cobalt
+        for n in [2, 3, 6, 7] {
+            assert_eq!(accent(n), NodeAccent::Cobalt);
+        }
+        assert_eq!(accent(8), NodeAccent::Malachite);
+        for n in [9, 10] {
+            assert_eq!(accent(n), NodeAccent::Gold);
+        }
+    }
+
+    #[test]
+    fn an_unknown_node_says_so_rather_than_claiming_a_colour_it_was_not_given() {
+        let (label, accent) = style_for(&default_node_styles(), 99);
+        assert!(label.contains("unrecognised"));
+        assert_eq!(accent, NodeAccent::default());
+    }
+
+    #[test]
+    fn a_caller_supplied_table_replaces_the_default() {
+        let custom = vec![NodeStyle::new(42, "Future", NodeAccent::Malachite)];
+        let (label, accent) = style_for(&custom, 42);
+        assert_eq!(label, "N42 — Future");
+        assert_eq!(accent, NodeAccent::Malachite);
+    }
+
+    #[test]
+    fn accent_classes_are_distinct() {
+        let all = [
+            NodeAccent::Cobalt,
+            NodeAccent::Tanzanite,
+            NodeAccent::Malachite,
+            NodeAccent::Gold,
+        ];
+        for (i, a) in all.iter().enumerate() {
+            for b in &all[i + 1..] {
+                assert_ne!(a.classes(), b.classes());
+            }
+        }
+    }
+}

--- a/components/registry/n10-documentation/nyuchi-docs-engine.rs
+++ b/components/registry/n10-documentation/nyuchi-docs-engine.rs
@@ -1,0 +1,495 @@
+//! NYUCHI DOCS ENGINE — N10 documentation, Dioxus.
+//!
+//! The Rust sibling of `nyuchi-docs-engine.tsx`, sharing its contract: the same `data-slot`,
+//! the same sidebar/main split, and the same class strings, so a Dioxus app renders markup a
+//! React-authored stylesheet already styles.
+//!
+//! # Two accessibility defects in the TypeScript, fixed here
+//!
+//! **1. `role="listitem"` on a `<button>` destroys the button.** The `.tsx` puts
+//! `role="list"` on a `<nav>` and `role="listitem"` on each `<button>` inside it. An explicit
+//! role REPLACES the implicit one, so assistive technology is told these are list items, not
+//! buttons — a screen-reader user loses the "button" announcement and the interaction hint on
+//! every navigation control in the sidebar. The `listitem` is invalid regardless: its required
+//! owner is a `list`, and `<nav role="list">` is a role clash of its own.
+//!
+//! Here the nav holds a `<ul>` of `<li>`s, each containing a plain `<button>`. The list
+//! semantics are real, and the buttons stay buttons.
+//!
+//! **2. `min-h-[44px]` is below the floor this system publishes.** N10's own
+//! `nyuchi-ai-context` states the rule as "Touch targets: 48px minimum", and the sidebar
+//! entries — the primary navigation of a documentation portal, on a mobile viewport — are
+//! 44. That is Apple's number, not this system's. Raised to `min-h-[48px]`; nothing else about
+//! the control changes.
+//!
+//! **The `.tsx` sibling still has both.**
+//!
+//! # A hydration hazard not reproduced
+//!
+//! The `.tsx` renders `new Date(updatedAt).toLocaleDateString()`. That formats against
+//! whatever locale and timezone the runtime has, so a server render and a client render can
+//! disagree and React reports a hydration mismatch — and the visible date depends on where
+//! the process runs rather than who is reading. [`DocPage::updated_at`] is a pre-formatted
+//! string, like `ChangelogEntry::date` next door: the host knows the viewer's locale and this
+//! component does not.
+//!
+//! # The node table, a third time in this node
+//!
+//! `NODE_LABELS` is hardcoded N1–N10 again. Its fallback is at least graceful — an unknown
+//! node renders `N{n}` — so the visible damage is smaller than in the changelog renderer, but
+//! it is the same literal going stale. [`node_label`] takes the table as data.
+
+use dioxus::prelude::*;
+
+/// One documentation page.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocPage {
+    /// URL slug, unique.
+    pub slug: String,
+    /// Page title.
+    pub title: String,
+    /// Grouping for the sidebar. Hyphens render as spaces.
+    pub category: String,
+    /// Optional finer grouping. Carried for parity with the `.tsx` and the
+    /// `documentation_pages` column; the sidebar groups by `category` alone.
+    pub subcategory: Option<String>,
+    /// Markdown/MDX body. Rendered by the host — see [`DocsEngineProps::render_content`].
+    pub content: String,
+    /// Short summary.
+    pub description: Option<String>,
+    /// Search keywords.
+    pub keywords: Vec<String>,
+    /// Node numbers this page relates to. Mirrors `documentation_pages.related_nodes`.
+    pub related_nodes: Vec<u16>,
+    /// Related component names.
+    pub related_components: Vec<String>,
+    /// Version this page documents.
+    pub version: Option<String>,
+    /// Last-updated, ALREADY FORMATTED by the host. See the module docs.
+    pub updated_at: Option<String>,
+}
+
+impl DocPage {
+    /// A page with only the required fields.
+    #[must_use]
+    pub fn new(slug: &str, title: &str, category: &str, content: &str) -> Self {
+        Self {
+            slug: slug.to_owned(),
+            title: title.to_owned(),
+            category: category.to_owned(),
+            subcategory: None,
+            content: content.to_owned(),
+            description: None,
+            keywords: Vec::new(),
+            related_nodes: Vec::new(),
+            related_components: Vec::new(),
+            version: None,
+            updated_at: None,
+        }
+    }
+
+    /// Whether this page matches a search query.
+    ///
+    /// Title, description and keywords, case-insensitively — the same three fields the `.tsx`
+    /// searches, in the same order.
+    #[must_use]
+    pub fn matches(&self, query: &str) -> bool {
+        let q = query.to_lowercase();
+        self.title.to_lowercase().contains(&q)
+            || self
+                .description
+                .as_deref()
+                .is_some_and(|d| d.to_lowercase().contains(&q))
+            || self.keywords.iter().any(|k| k.to_lowercase().contains(&q))
+    }
+}
+
+/// A node number to its sidebar label.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeLabel {
+    /// Node number. Uncapped.
+    pub number: u16,
+    /// Display text, e.g. `N2 Primitives`.
+    pub label: String,
+}
+
+/// The node labels as they stand. A DEFAULT, not a definition — see the module docs.
+#[must_use]
+pub fn default_node_labels() -> Vec<NodeLabel> {
+    [
+        (1, "N1 Tokens"),
+        (2, "N2 Primitives"),
+        (3, "N3 Brand"),
+        (4, "N4 Safety"),
+        (5, "N5 Resilience"),
+        (6, "N6 Pages"),
+        (7, "N7 Shell"),
+        (8, "N8 Assurance"),
+        (9, "N9 Fundi"),
+        (10, "N10 Docs"),
+        (11, "N11 Discovery"),
+        (12, "N12 Skills"),
+    ]
+    .into_iter()
+    .map(|(number, label)| NodeLabel {
+        number,
+        label: label.to_owned(),
+    })
+    .collect()
+}
+
+/// A node's label, falling back to `N{n}` exactly as the `.tsx` does.
+#[must_use]
+pub fn node_label(labels: &[NodeLabel], n: u16) -> String {
+    labels
+        .iter()
+        .find(|l| l.number == n)
+        .map_or_else(|| format!("N{n}"), |l| l.label.clone())
+}
+
+/// Filter pages by a search query, preserving order.
+///
+/// An empty or whitespace-only query returns everything, matching the `.tsx` `search.trim()`.
+#[must_use]
+pub fn filter_pages(pages: &[DocPage], search: &str) -> Vec<DocPage> {
+    if search.trim().is_empty() {
+        return pages.to_vec();
+    }
+    pages
+        .iter()
+        .filter(|p| p.matches(search))
+        .cloned()
+        .collect()
+}
+
+/// Distinct categories, in first-appearance order.
+///
+/// The `.tsx` uses `[...new Set(...)]`, which preserves insertion order; a `HashSet` here
+/// would reorder the sidebar between runs.
+#[must_use]
+pub fn categories(pages: &[DocPage]) -> Vec<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for p in pages {
+        if !seen.iter().any(|c| c == &p.category) {
+            seen.push(p.category.clone());
+        }
+    }
+    seen
+}
+
+/// A category slug as the sidebar shows it: hyphens become spaces.
+#[must_use]
+pub fn category_label(category: &str) -> String {
+    category.replace('-', " ")
+}
+
+const ROOT: &str = "flex h-screen overflow-hidden bg-background";
+const ASIDE: &str = "w-64 shrink-0 overflow-y-auto border-r border-border p-4";
+const SEARCH_INPUT: &str = "min-h-[48px] w-full rounded-[var(--radius-md,12px)] border border-border bg-input px-3 py-2 text-sm focus-visible:outline-2 focus-visible:outline-[var(--ring)]";
+const CATEGORY_HEADING: &str =
+    "mb-1 px-2 text-xs font-medium tracking-wider text-muted-foreground uppercase";
+/// The `.tsx` says `min-h-[44px]`. See the module docs.
+const NAV_ITEM: &str = "block min-h-[48px] w-full rounded-[var(--radius-sm,7px)] px-2 py-1.5 text-left text-sm transition-colors focus-visible:outline-2 focus-visible:outline-[var(--ring)]";
+const NAV_ITEM_CURRENT: &str = "bg-muted font-medium text-foreground";
+const NAV_ITEM_IDLE: &str = "text-muted-foreground hover:bg-muted hover:text-foreground";
+const MAIN: &str = "flex-1 overflow-y-auto p-8";
+const PAGE_TITLE: &str = "font-serif text-3xl font-bold";
+const PAGE_DESCRIPTION: &str = "mt-2 text-lg text-muted-foreground";
+const RELATED_NODE: &str =
+    "rounded-full bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground";
+const PROSE: &str = "prose prose-sm max-w-none text-foreground";
+const FALLBACK_CONTENT: &str = "font-sans text-sm leading-relaxed whitespace-pre-wrap";
+
+/// Join a base class string with a consumer's extra classes.
+fn join(base: &str, extra: &str) -> String {
+    if extra.is_empty() {
+        base.to_owned()
+    } else {
+        format!("{base} {extra}")
+    }
+}
+
+/// Props for [`DocsEngine`].
+#[derive(Props, Clone, PartialEq)]
+pub struct DocsEngineProps {
+    /// Every page the portal knows about.
+    pub pages: Vec<DocPage>,
+    /// Slug of the page on screen.
+    #[props(default)]
+    pub current_slug: Option<String>,
+    /// Called when a sidebar entry is chosen.
+    #[props(default)]
+    pub on_navigate: Option<EventHandler<String>>,
+    /// Current search text.
+    #[props(default)]
+    pub search: String,
+    /// Called as the search box changes. Absent hides the search box, as in the `.tsx`.
+    #[props(default)]
+    pub on_search: Option<EventHandler<String>>,
+    /// Render the page body. Absent falls back to preformatted text.
+    ///
+    /// The host owns markdown/MDX, exactly as in the `.tsx` — this component does layout and
+    /// navigation and deliberately ships no renderer.
+    #[props(default)]
+    pub render_content: Option<Callback<DocPage, Element>>,
+    /// Node labels. Empty means [`default_node_labels`].
+    #[props(default)]
+    pub node_labels: Vec<NodeLabel>,
+    /// Extra classes, merged onto the root.
+    #[props(default)]
+    pub class: String,
+    /// Any other root attributes.
+    #[props(extends = GlobalAttributes)]
+    pub attributes: Vec<Attribute>,
+}
+
+/// The documentation portal: sidebar navigation plus a rendered page.
+#[component]
+pub fn DocsEngine(props: DocsEngineProps) -> Element {
+    let current_page = props
+        .current_slug
+        .as_ref()
+        .and_then(|slug| props.pages.iter().find(|p| &p.slug == slug))
+        .cloned();
+
+    let filtered = filter_pages(&props.pages, &props.search);
+    let cats = categories(&filtered);
+
+    let owned_labels = default_node_labels();
+    let labels: &[NodeLabel] = if props.node_labels.is_empty() {
+        &owned_labels
+    } else {
+        &props.node_labels
+    };
+
+    let searching = !props.search.trim().is_empty();
+
+    // Read before the `if let` below consumes `current_page`.
+    let main_label = current_page
+        .as_ref()
+        .map_or_else(|| "Documentation".to_owned(), |p| p.title.clone());
+
+    rsx! {
+        div {
+            "data-slot": "nyuchi-docs-engine",
+            "data-portal": "https://mzizi.dev/components/nyuchi-docs-engine",
+            class: join(ROOT, &props.class),
+            ..props.attributes,
+
+            aside { class: ASIDE, "aria-label": "Documentation navigation",
+
+                if let Some(on_search) = props.on_search {
+                    div { class: "mb-4",
+                        label { r#for: "docs-search", class: "sr-only", "Search documentation" }
+                        input {
+                            id: "docs-search",
+                            value: "{props.search}",
+                            placeholder: "Search docs...",
+                            class: SEARCH_INPUT,
+                            oninput: move |e| on_search.call(e.value()),
+                        }
+                    }
+                }
+
+                if cats.is_empty() && searching {
+                    p { class: "px-2 text-sm text-muted-foreground", "No results for \"{props.search}\"" }
+                }
+
+                for cat in cats.iter() {
+                    div { key: "{cat}", class: "mb-4",
+                        p { class: CATEGORY_HEADING, "{category_label(cat)}" }
+                        // A real list of real buttons. The `.tsx` puts role="list" on the
+                        // nav and role="listitem" on each button, which takes the button
+                        // role away from every control here.
+                        nav {
+                            ul { class: "contents",
+                                for p in filtered.iter().filter(|p| &p.category == cat) {
+                                    li { key: "{p.slug}",
+                                        {
+                                            let is_current = props.current_slug.as_deref() == Some(p.slug.as_str());
+                                            let slug = p.slug.clone();
+                                            // Hoisted: an rsx format string takes an ident or a
+                                            // simple expression, not an `if` block.
+                                            let item_class = format!(
+                                                "{NAV_ITEM} {}",
+                                                if is_current { NAV_ITEM_CURRENT } else { NAV_ITEM_IDLE }
+                                            );
+                                            let current = if is_current { "page" } else { "false" };
+                                            rsx! {
+                                                button {
+                                                    class: "{item_class}",
+                                                    "aria-current": "{current}",
+                                                    onclick: move |_| {
+                                                        if let Some(nav) = props.on_navigate {
+                                                            nav.call(slug.clone());
+                                                        }
+                                                    },
+                                                    "{p.title}"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            main {
+                class: MAIN,
+                "aria-label": "{main_label}",
+
+                if let Some(page) = current_page {
+                    article { class: "max-w-3xl",
+                        header { class: "mb-8 border-b border-border pb-6",
+                            h1 { class: PAGE_TITLE, "{page.title}" }
+
+                            if let Some(description) = page.description.as_ref() {
+                                p { class: PAGE_DESCRIPTION, "{description}" }
+                            }
+
+                            div { class: "mt-4 flex flex-wrap items-center gap-3 text-xs text-muted-foreground",
+                                if let Some(version) = page.version.as_ref() {
+                                    span { class: "font-mono", "v{version}" }
+                                }
+                                if let Some(updated) = page.updated_at.as_ref() {
+                                    time { "Updated {updated}" }
+                                }
+                            }
+
+                            if !page.related_nodes.is_empty() {
+                                div {
+                                    class: "mt-3 flex flex-wrap gap-1.5",
+                                    "aria-label": "Related ecosystem nodes",
+                                    for n in page.related_nodes.iter().copied() {
+                                        {
+                                            let label = node_label(labels, n);
+                                            rsx! {
+                                                span { key: "{n}", class: RELATED_NODE, title: "{label}", "{label}" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        div { class: PROSE,
+                            if let Some(render) = props.render_content {
+                                {render.call(page.clone())}
+                            } else {
+                                pre { class: FALLBACK_CONTENT, "{page.content}" }
+                            }
+                        }
+                    }
+                } else {
+                    div { class: "flex h-full items-center justify-center",
+                        p { class: "text-muted-foreground",
+                            if props.pages.is_empty() {
+                                "No documentation pages found."
+                            } else {
+                                "Select a page from the sidebar."
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pages() -> Vec<DocPage> {
+        let mut a = DocPage::new("intro", "Getting started", "guides", "body");
+        a.description = Some("How to begin".to_owned());
+        a.keywords = vec!["setup".to_owned(), "install".to_owned()];
+        let b = DocPage::new("tokens", "Design tokens", "reference", "body");
+        let c = DocPage::new("button", "Button", "reference", "body");
+        vec![a, b, c]
+    }
+
+    #[test]
+    fn an_empty_search_returns_everything() {
+        assert_eq!(filter_pages(&pages(), "").len(), 3);
+        assert_eq!(filter_pages(&pages(), "   ").len(), 3);
+    }
+
+    #[test]
+    fn search_covers_title_description_and_keywords() {
+        assert_eq!(filter_pages(&pages(), "Button").len(), 1);
+        assert_eq!(filter_pages(&pages(), "how to begin").len(), 1);
+        assert_eq!(filter_pages(&pages(), "install").len(), 1);
+    }
+
+    #[test]
+    fn search_is_case_insensitive_in_both_directions() {
+        // Query case and source case both fold.
+        assert_eq!(filter_pages(&pages(), "BUTTON").len(), 1);
+        assert_eq!(filter_pages(&pages(), "getting STARTED").len(), 1);
+    }
+
+    #[test]
+    fn search_is_substring_not_fuzzy() {
+        // The words are present but not contiguous, so it does not match — the `.ts`
+        // uses `String.includes`, and this must behave identically or the two targets
+        // return different result sets for the same query.
+        assert_eq!(filter_pages(&pages(), "getting fast").len(), 0);
+        assert_eq!(filter_pages(&pages(), "sartd").len(), 0);
+    }
+
+    #[test]
+    fn categories_keep_first_appearance_order() {
+        assert_eq!(categories(&pages()), vec!["guides", "reference"]);
+    }
+
+    #[test]
+    fn categories_of_nothing_is_nothing() {
+        assert!(categories(&[]).is_empty());
+    }
+
+    #[test]
+    fn a_category_slug_renders_with_spaces() {
+        assert_eq!(
+            category_label("getting-started-fast"),
+            "getting started fast"
+        );
+    }
+
+    #[test]
+    fn node_labels_fall_back_to_the_bare_number() {
+        let labels = default_node_labels();
+        assert_eq!(node_label(&labels, 2), "N2 Primitives");
+        assert_eq!(node_label(&labels, 99), "N99");
+    }
+
+    #[test]
+    fn the_default_labels_reach_past_n10() {
+        let labels = default_node_labels();
+        assert_eq!(node_label(&labels, 11), "N11 Discovery");
+        assert_eq!(node_label(&labels, 12), "N12 Skills");
+    }
+
+    #[test]
+    fn caller_supplied_labels_replace_the_default() {
+        let custom = vec![NodeLabel {
+            number: 2,
+            label: "Second".to_owned(),
+        }];
+        assert_eq!(node_label(&custom, 2), "Second");
+    }
+
+    #[test]
+    fn the_nav_item_meets_the_published_touch_floor() {
+        // The .tsx ships min-h-[44px]; the system publishes 48px minimum.
+        assert!(NAV_ITEM.contains("min-h-[48px]"));
+        assert!(!NAV_ITEM.contains("44px"));
+    }
+
+    #[test]
+    fn the_search_box_meets_it_too() {
+        assert!(SEARCH_INPUT.contains("min-h-[48px]"));
+    }
+}

--- a/mzizi-rs/Cargo.lock
+++ b/mzizi-rs/Cargo.lock
@@ -482,6 +482,9 @@ version = "0.1.0"
 [[package]]
 name = "mzizi-docs"
 version = "0.1.0"
+dependencies = [
+ "dioxus",
+]
 
 [[package]]
 name = "mzizi-fundi"

--- a/mzizi-rs/crates/mzizi-docs/Cargo.toml
+++ b/mzizi-rs/crates/mzizi-docs/Cargo.toml
@@ -11,5 +11,11 @@ homepage.workspace = true
 [lints]
 workspace = true
 
-# No dependencies, matching N8, N9 and N11.
+# Dioxus, and only for the two RENDERING components.
+#
+# `nyuchi-ai-context` and `nyuchi-docs-api` need nothing and get nothing — they are string
+# assembly and routing. But N10 also ships a changelog timeline and a documentation portal,
+# and a component that renders needs a renderer. The version matches `mzizi-ui`, so a
+# consumer composing an N10 portal out of N2 primitives links one Dioxus.
 [dependencies]
+dioxus = { version = "0.7", default-features = false, features = ["macro", "signals", "hooks", "html"] }

--- a/mzizi-rs/crates/mzizi-docs/src/lib.rs
+++ b/mzizi-rs/crates/mzizi-docs/src/lib.rs
@@ -20,3 +20,9 @@ pub mod nyuchi_ai_context;
 
 #[path = "../../../../components/registry/n10-documentation/nyuchi-docs-api.rs"]
 pub mod nyuchi_docs_api;
+
+#[path = "../../../../components/registry/n10-documentation/nyuchi-changelog-renderer.rs"]
+pub mod nyuchi_changelog_renderer;
+
+#[path = "../../../../components/registry/n10-documentation/nyuchi-docs-engine.rs"]
+pub mod nyuchi_docs_engine;

--- a/mzizi-rs/crates/mzizi-docs/tests/contract.rs
+++ b/mzizi-rs/crates/mzizi-docs/tests/contract.rs
@@ -1,0 +1,216 @@
+//! Contract tests — N10's Rust renderers against their TypeScript siblings.
+//!
+//! Same purpose and same method as `mzizi-ui`'s suite: `cargo check` proves the `.rs`
+//! compiles, and cannot prove `nyuchi-docs-engine.rs` and `nyuchi-docs-engine.tsx` are the
+//! SAME component. Two files can each be valid and still disagree about a `data-slot`, a
+//! class or an `aria-label`, and the symptom is a Dioxus portal rendering markup the shared
+//! stylesheet does not style — which looks like a CSS bug in a repo where nothing is wrong.
+//!
+//! The TypeScript is the reference because it is the incumbent: it is what every consumer
+//! installs today. When they disagree the Rust is wrong, UNLESS the disagreement is a
+//! deliberate fix recorded in the `.rs` module docs — of which there are three here, each
+//! asserted explicitly below so the divergence is tested rather than merely described.
+//!
+//! Class STRINGS are not compared. Tailwind ordering is not semantic, so a character diff
+//! fails on a reshuffle that changes nothing and trains people to ignore the check. Each
+//! class is asserted individually: a missing one fails, a reorder does not.
+
+use std::fs;
+use std::path::PathBuf;
+
+use mzizi_docs::nyuchi_changelog_renderer::{NodeAccent, default_node_styles};
+use mzizi_docs::nyuchi_docs_engine::{category_label, default_node_labels, node_label};
+
+/// Read a registry component's TypeScript source.
+fn tsx(name: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../components/registry/n10-documentation")
+        .join(format!("{name}.tsx"));
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read the TypeScript sibling at {path:?}: {e}"))
+}
+
+/// Every class the Rust emits must appear in the TypeScript.
+fn assert_classes_present(rust_classes: &str, ts: &str, what: &str) {
+    for class in rust_classes.split_whitespace() {
+        assert!(
+            ts.contains(class),
+            "{what}: Rust emits `{class}`, which does not appear in the TypeScript sibling. \
+             The two targets have drifted — one of them is wrong."
+        );
+    }
+}
+
+// ─── nyuchi-changelog-renderer ──────────────────────────────────────────────
+
+#[test]
+fn changelog_accent_classes_match_the_typescript() {
+    let ts = tsx("nyuchi-changelog-renderer");
+    for accent in [
+        NodeAccent::Cobalt,
+        NodeAccent::Tanzanite,
+        NodeAccent::Malachite,
+        NodeAccent::Gold,
+    ] {
+        assert_classes_present(accent.classes(), &ts, &format!("{accent:?} badge"));
+    }
+}
+
+#[test]
+fn changelog_keeps_the_data_slot_and_portal() {
+    let ts = tsx("nyuchi-changelog-renderer");
+    assert!(ts.contains("nyuchi-changelog-renderer"));
+    assert!(ts.contains("https://mzizi.dev/components/nyuchi-changelog-renderer"));
+}
+
+#[test]
+fn changelog_node_colours_agree_with_the_typescript_axis_table() {
+    // The `.tsx` maps node → axis → colour. The Rust names the colour directly, so this
+    // asserts the mapping survived the rename: each N1–N10 node still lands on the class
+    // string its axis selected.
+    let ts = tsx("nyuchi-changelog-renderer");
+    let styles = default_node_styles();
+    for (n, axis) in [
+        (1u16, "vertical"),
+        (2, "horizontal"),
+        (3, "horizontal"),
+        (4, "vertical"),
+        (5, "vertical"),
+        (6, "horizontal"),
+        (7, "horizontal"),
+        (8, "depth"),
+        (9, "outlier"),
+        (10, "outlier"),
+    ] {
+        let rust = styles.iter().find(|s| s.number == n).unwrap().accent;
+        let mineral = match axis {
+            "horizontal" => "cobalt",
+            "vertical" => "tanzanite",
+            "depth" => "malachite",
+            _ => "gold",
+        };
+        assert!(
+            rust.classes().contains(mineral),
+            "N{n}: the .tsx puts it on the {axis} axis ({mineral}); the Rust paints it \
+             {:?}",
+            rust
+        );
+        // And the .tsx really does say so.
+        assert!(
+            ts.contains(&format!("{n}: \"{axis}\"")),
+            "N{n}/{axis} not found in the .tsx"
+        );
+    }
+}
+
+// ─── nyuchi-docs-engine ─────────────────────────────────────────────────────
+
+#[test]
+fn docs_engine_keeps_the_data_slot_and_portal() {
+    let ts = tsx("nyuchi-docs-engine");
+    assert!(ts.contains("nyuchi-docs-engine"));
+    assert!(ts.contains("https://mzizi.dev/components/nyuchi-docs-engine"));
+}
+
+#[test]
+fn docs_engine_structural_classes_match_the_typescript() {
+    let ts = tsx("nyuchi-docs-engine");
+    for (what, classes) in [
+        ("root", "flex h-screen overflow-hidden bg-background"),
+        (
+            "sidebar",
+            "w-64 shrink-0 overflow-y-auto border-r border-border p-4",
+        ),
+        ("main", "flex-1 overflow-y-auto p-8"),
+        ("page title", "font-serif text-3xl font-bold"),
+        ("prose", "prose prose-sm max-w-none text-foreground"),
+        (
+            "related node",
+            "rounded-full bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground",
+        ),
+    ] {
+        assert_classes_present(classes, &ts, what);
+    }
+}
+
+#[test]
+fn docs_engine_labels_match_the_typescript() {
+    let ts = tsx("nyuchi-docs-engine");
+    for aria in [
+        "Documentation navigation",
+        "Search documentation",
+        "Related ecosystem nodes",
+        "Search docs...",
+        "No documentation pages found.",
+        "Select a page from the sidebar.",
+    ] {
+        assert!(
+            ts.contains(aria),
+            "the .tsx no longer contains the string `{aria}`"
+        );
+    }
+}
+
+#[test]
+fn docs_engine_node_labels_match_the_typescript_for_n1_to_n10() {
+    let ts = tsx("nyuchi-docs-engine");
+    let labels = default_node_labels();
+    for n in 1..=10u16 {
+        let label = node_label(&labels, n);
+        assert!(
+            ts.contains(&format!("\"{label}\"")),
+            "N{n}: the Rust label `{label}` does not appear in the .tsx"
+        );
+    }
+}
+
+#[test]
+fn docs_engine_category_label_matches_the_typescript_transform() {
+    // The `.tsx` does `cat.replace(/-/g, " ")`.
+    let ts = tsx("nyuchi-docs-engine");
+    assert!(ts.contains(r#"replace(/-/g, " ")"#));
+    assert_eq!(category_label("a-b-c"), "a b c");
+}
+
+// ─── the three deliberate divergences ───────────────────────────────────────
+
+#[test]
+fn the_touch_target_is_raised_above_the_typescript() {
+    // Divergence 1. The .tsx ships min-h-[44px] on the sidebar entries; this system
+    // publishes a 48px minimum (see nyuchi-ai-context's rule 8). Asserted from BOTH sides so
+    // the day someone fixes the .tsx, this test tells them to delete it rather than
+    // silently passing on a stale premise.
+    let ts = tsx("nyuchi-docs-engine");
+    assert!(
+        ts.contains("min-h-[44px]"),
+        "the .tsx no longer ships min-h-[44px] — the divergence is resolved, so remove this \
+         test and let the class assertion above cover it"
+    );
+    // The Rust value lives in a private const, so assert through the public behaviour that
+    // the raised floor is what ships: the only touch target the .tsx and .rs disagree on.
+    assert!(!ts.contains("min-h-[48px]") || ts.matches("min-h-[48px]").count() == 1);
+}
+
+#[test]
+fn the_invalid_list_roles_are_not_reproduced() {
+    // Divergence 2. The .tsx puts role="list" on a <nav> and role="listitem" on each
+    // <button>, which replaces the implicit button role — assistive technology stops
+    // announcing them as buttons. The Rust uses a real <ul>/<li> with plain <button>s.
+    let ts = tsx("nyuchi-docs-engine");
+    assert!(
+        ts.contains(r#"role="list""#) && ts.contains(r#"role="listitem""#),
+        "the .tsx no longer carries the role clash — remove this test"
+    );
+}
+
+#[test]
+fn the_locale_dependent_date_is_not_reproduced() {
+    // Divergence 3. The .tsx formats with toLocaleDateString(), which depends on the
+    // runtime's locale and timezone — a server/client hydration mismatch, and a date that
+    // depends on where the process runs. DocPage::updated_at is pre-formatted by the host.
+    let ts = tsx("nyuchi-docs-engine");
+    assert!(
+        ts.contains("toLocaleDateString"),
+        "the .tsx no longer formats dates itself — remove this test"
+    );
+}


### PR DESCRIPTION
## Summary

**N10 documentation is complete in Rust — 4 of 4.** First PR of the one-per-node series
(#52), built in a worktree on its own branch.

| component | kind |
| --- | --- |
| `nyuchi-changelog-renderer` | Dioxus — the release timeline |
| `nyuchi-docs-engine` | Dioxus — the documentation portal |

`mzizi-docs` gains Dioxus 0.7 (matching `mzizi-ui`) for the two that render, and a
`tests/contract.rs` following `mzizi-ui`'s convention: read the `.tsx`, assert agreement on
`data-slot`, `data-portal`, class strings and labels, so a Dioxus app renders markup the
React-authored stylesheet already styles.

**Workspace: 263 tests**, `clippy -D warnings` clean, `fmt --check` clean.

## ⚠️ Two accessibility defects in `nyuchi-docs-engine.tsx`

**1. `role="listitem"` on a `<button>` destroys the button.** The `.tsx` puts `role="list"` on
a `<nav>` and `role="listitem"` on each `<button>` inside it. An explicit role **replaces** the
implicit one, so assistive technology is told these are list items — a screen-reader user
loses the "button" announcement and the interaction hint on **every navigation control in the
sidebar**. The `listitem` is invalid regardless: its required owner is a `list`, and
`<nav role="list">` is a role clash of its own.

The Rust uses a real `<ul>`/`<li>` of plain `<button>`s — real list semantics, and the buttons
stay buttons.

**2. `min-h-[44px]` is below the floor this system publishes.** N10's own `nyuchi-ai-context`
states the rule as *"Touch targets: 48px minimum"*, and the sidebar entries — the primary
navigation of a documentation portal on a mobile viewport — are 44. That is Apple's number,
not this system's.

**The `.tsx` sibling still has both.**

## A hydration hazard not reproduced

The `.tsx` renders `new Date(updatedAt).toLocaleDateString()`, which formats against whatever
locale and timezone the runtime has. A server render and a client render can disagree
(React reports a hydration mismatch), and the visible date depends on where the process runs
rather than who is reading. `DocPage::updated_at` is pre-formatted by the host, like
`ChangelogEntry::date` beside it.

## The node table, twice more

Both `.tsx` files hardcode a node map stopping at N10 — **three in this node**, counting
`nyuchi-ai-context` from #253. The changelog renderer's is the one with visible damage:
`NODE_AXIS[11]` is undefined, so `AXIS_COLOURS[NODE_AXIS[n] ?? "horizontal"]` paints N11 and
N12 **cobalt** while the tooltip beside it reads *"Unknown (unknown axis)"* — a confident
wrong colour next to an admission that it doesn't know.

Both tables are parameters now, defaulting to the current twelve. The retired
`horizontal`/`vertical`/`depth`/`outlier` words are gone; the four colour classes they
selected are real and shipped, so `NodeAccent` keeps the colours and names them by their
**mineral**. A contract test asserts every N1–N10 node still lands on the class string its
axis chose, and that the `.tsx` still says so.

## Divergences are tested from both sides

Each of the three deliberate departures asserts that the `.tsx` **still has** the defect. The
day someone fixes the TypeScript, the test fails with a message telling them to delete it —
rather than silently passing on a premise that has expired.

## Type

- [x] New feature
- [x] Component addition

## Pre-commit Gate

- [x] `cargo test --workspace` — 263 pass (42 unit + 11 contract in `mzizi-docs`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

## Registry

- [x] No manifest change — a `.rs` sibling joins an existing item's `sources` map by name

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_