### PR TITLE
fix(security): repair the vulnerability disclosure path, which led nowhere

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
   "homepage": "https://mzizi.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nyuchi/design-portal"
+    "url": "https://github.com/nyuchi/mzizi"
   },
   "author": {
     "name": "Bundu Foundation"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Discussions — Questions & Ideas
-    url: https://github.com/nyuchi/design-portal/discussions
+    url: https://github.com/nyuchi/mzizi/discussions
     about: Ask questions, share ideas, show what you've built with the design system.
   - name: Component Registry
     url: https://mzizi.dev/components
@@ -10,5 +10,5 @@ contact_links:
     url: https://mzizi.dev/mcp
     about: Connect Claude Code and AI assistants directly to the component registry.
   - name: Security Vulnerabilities
-    url: https://github.com/nyuchi/design-portal/security/advisories/new
+    url: https://github.com/nyuchi/mzizi/security/advisories/new
     about: Report security issues privately via GitHub Security Advisories.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            Review this PR (or respond to this comment/review) for the design-portal project.
+            Review this PR (or respond to this comment/review) for the mzizi project.
 
             On PR open / synchronize: review the full diff.
             On a comment or review: read the comment and either answer the question directly or take the action the commenter is asking for (review the surrounding code, propose a patch, etc.). Tie the response back to the conversation thread — don't repeat a full PR review unless asked.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Mzizi
 
-Thank you for your interest in contributing to **Mzizi** — the open component registry, brand system, and DNA-helix architecture portal for the bundu ecosystem (the `design-portal` repository).
+Thank you for your interest in contributing to **Mzizi** — the open component registry, brand system, and DNA-helix architecture portal for the bundu ecosystem (the `mzizi` repository).
 
 This guide covers everything you need to get started, from setting up your environment to opening a pull request.
 
@@ -12,8 +12,8 @@ This guide covers everything you need to get started, from setting up your envir
 
 ```bash
 # Fork via GitHub, then clone your fork
-git clone https://github.com/<your-username>/design-portal.git
-cd design-portal
+git clone https://github.com/<your-username>/mzizi.git
+cd mzizi
 ```
 
 ### 2. Install dependencies

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 > An open-architecture project of the Bundu Foundation — the canonical component registry, brand system, DNA-helix frontend architecture, and AI-native developer portal for the bundu ecosystem. Operated and developed by Nyuchi.
 
-[![CI](https://github.com/nyuchi/design-portal/actions/workflows/ci.yml/badge.svg)](https://github.com/nyuchi/design-portal/actions/workflows/ci.yml)
-[![Release](https://github.com/nyuchi/design-portal/actions/workflows/release.yml/badge.svg)](https://github.com/nyuchi/design-portal/actions/workflows/release.yml)
-[![CodeQL](https://github.com/nyuchi/design-portal/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/nyuchi/design-portal/security/code-scanning)
+[![CI](https://github.com/nyuchi/mzizi/actions/workflows/ci.yml/badge.svg)](https://github.com/nyuchi/mzizi/actions/workflows/ci.yml)
+[![Release](https://github.com/nyuchi/mzizi/actions/workflows/release.yml/badge.svg)](https://github.com/nyuchi/mzizi/actions/workflows/release.yml)
+[![CodeQL](https://github.com/nyuchi/mzizi/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/nyuchi/mzizi/security/code-scanning)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 **Version:** 1.0.0 | **Live:** [mzizi.dev](https://mzizi.dev) | **Product docs:** [docs.bundu.org](https://docs.bundu.org) | **Engineering docs:** [docs.nyuchi.com](https://docs.nyuchi.com) | **Observability:** [mzizi.dev/observability](https://mzizi.dev/observability)
@@ -210,8 +210,8 @@ If `pnpm check` is green, CI will be too.
 ## Local Development
 
 ```bash
-git clone https://github.com/nyuchi/design-portal.git
-cd design-portal
+git clone https://github.com/nyuchi/mzizi.git
+cd mzizi
 pnpm install
 
 cp .env.example .env.local
@@ -229,7 +229,7 @@ pnpm dev
 
 | Repository                                                               | URL                                                | Role                                                                                                        |
 | ------------------------------------------------------------------------ | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| **[design-portal](https://github.com/nyuchi/design-portal)** (this repo) | [mzizi.dev](https://mzizi.dev)                     | Mzizi portal — registry, brand, DNA-helix architecture, document-route MCP                                  |
+| **[mzizi](https://github.com/nyuchi/mzizi)** (this repo) | [mzizi.dev](https://mzizi.dev)                     | Mzizi portal — registry, brand, DNA-helix architecture, document-route MCP                                  |
 | **[nyuchi/mzizi-tools](https://github.com/nyuchi/mzizi-tools)**          | npm packages                                       | Mzizi tooling — `mzizi-mcp` worker, `mzizi-sdk` (with the Fundi agent), `mzizi-skills`, `mzizi-console-app` |
 | **[nyuchi/mukoko-platform](https://github.com/nyuchi/mukoko-platform)**  | [platform.nyuchi.com](https://platform.nyuchi.com) | Nyuchi Console — B2B platform (will be renamed `nyuchi-console`)                                            |
 | **[nyuchi/bundu-docs](https://github.com/nyuchi/bundu-docs)**            | [docs.bundu.org](https://docs.bundu.org)           | Outward-facing product documentation (Astro Starlight)                                                      |
@@ -254,7 +254,7 @@ The version-bump propagation surfaces are listed in [`CLAUDE.md`](CLAUDE.md) §1
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines, code standards, and the PR process. For questions and ideas, use [GitHub Discussions](https://github.com/nyuchi/design-portal/discussions).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines, code standards, and the PR process. For questions and ideas, use [GitHub Discussions](https://github.com/nyuchi/mzizi/discussions).
 
 ## Code of Conduct
 
@@ -262,7 +262,7 @@ See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). Built on Ubuntu: _umuntu ngumuntu 
 
 ## Security
 
-See [SECURITY.md](SECURITY.md) or report privately via [GitHub Security Advisories](https://github.com/nyuchi/design-portal/security/advisories/new).
+See [SECURITY.md](SECURITY.md) or report privately via [GitHub Security Advisories](https://github.com/nyuchi/mzizi/security/advisories/new).
 
 ## Governance & License
 

--- a/README.md
+++ b/README.md
@@ -227,20 +227,20 @@ pnpm dev
 
 ## Ecosystem
 
-| Repository                                                               | URL                                                | Role                                                                                                        |
-| ------------------------------------------------------------------------ | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| **[mzizi](https://github.com/nyuchi/mzizi)** (this repo) | [mzizi.dev](https://mzizi.dev)                     | Mzizi portal — registry, brand, DNA-helix architecture, document-route MCP                                  |
-| **[nyuchi/mzizi-tools](https://github.com/nyuchi/mzizi-tools)**          | npm packages                                       | Mzizi tooling — `mzizi-mcp` worker, `mzizi-sdk` (with the Fundi agent), `mzizi-skills`, `mzizi-console-app` |
-| **[nyuchi/mukoko-platform](https://github.com/nyuchi/mukoko-platform)**  | [platform.nyuchi.com](https://platform.nyuchi.com) | Nyuchi Console — B2B platform (will be renamed `nyuchi-console`)                                            |
-| **[nyuchi/bundu-docs](https://github.com/nyuchi/bundu-docs)**            | [docs.bundu.org](https://docs.bundu.org)           | Outward-facing product documentation (Astro Starlight)                                                      |
-| **[nyuchi/nyuchi-docs](https://github.com/nyuchi/nyuchi-docs)**          | [docs.nyuchi.com](https://docs.nyuchi.com)         | Engineering / how-things-are-done docs (Astro Starlight)                                                    |
-| mukoko                                                                   | [mukoko.com](https://mukoko.com)                   | Africa's super app                                                                                          |
-| mukoko weather                                                           | [weather.mukoko.com](https://weather.mukoko.com)   | Hyperlocal forecasts, farming intelligence                                                                  |
-| mukoko news                                                              | [news.mukoko.com](https://news.mukoko.com)         | Pan-African news aggregation                                                                                |
-| nhimbe                                                                   | [nhimbe.com](https://nhimbe.com)                   | Events and cultural gatherings                                                                              |
-| shamwari                                                                 | [shamwari.ai](https://shamwari.ai)                 | Sovereign AI companion                                                                                      |
-| nyuchi                                                                   | [nyuchi.com](https://nyuchi.com)                   | Enterprise layer                                                                                            |
-| bundu                                                                    | [bundu.family](https://bundu.family)               | The ecosystem                                                                                               |
+| Repository                                                              | URL                                                | Role                                                                                                        |
+| ----------------------------------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **[mzizi](https://github.com/nyuchi/mzizi)** (this repo)                | [mzizi.dev](https://mzizi.dev)                     | Mzizi portal — registry, brand, DNA-helix architecture, document-route MCP                                  |
+| **[nyuchi/mzizi-tools](https://github.com/nyuchi/mzizi-tools)**         | npm packages                                       | Mzizi tooling — `mzizi-mcp` worker, `mzizi-sdk` (with the Fundi agent), `mzizi-skills`, `mzizi-console-app` |
+| **[nyuchi/mukoko-platform](https://github.com/nyuchi/mukoko-platform)** | [platform.nyuchi.com](https://platform.nyuchi.com) | Nyuchi Console — B2B platform (will be renamed `nyuchi-console`)                                            |
+| **[nyuchi/bundu-docs](https://github.com/nyuchi/bundu-docs)**           | [docs.bundu.org](https://docs.bundu.org)           | Outward-facing product documentation (Astro Starlight)                                                      |
+| **[nyuchi/nyuchi-docs](https://github.com/nyuchi/nyuchi-docs)**         | [docs.nyuchi.com](https://docs.nyuchi.com)         | Engineering / how-things-are-done docs (Astro Starlight)                                                    |
+| mukoko                                                                  | [mukoko.com](https://mukoko.com)                   | Africa's super app                                                                                          |
+| mukoko weather                                                          | [weather.mukoko.com](https://weather.mukoko.com)   | Hyperlocal forecasts, farming intelligence                                                                  |
+| mukoko news                                                             | [news.mukoko.com](https://news.mukoko.com)         | Pan-African news aggregation                                                                                |
+| nhimbe                                                                  | [nhimbe.com](https://nhimbe.com)                   | Events and cultural gatherings                                                                              |
+| shamwari                                                                | [shamwari.ai](https://shamwari.ai)                 | Sovereign AI companion                                                                                      |
+| nyuchi                                                                  | [nyuchi.com](https://nyuchi.com)                   | Enterprise layer                                                                                            |
+| bundu                                                                   | [bundu.family](https://bundu.family)               | The ecosystem                                                                                               |
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -111,10 +111,10 @@ This chains every CI gate — `format:check`, `lint`, `lint:colors`, `lint:md`, 
 
 CI workflows that gate merge to `main`:
 
-| Workflow                                                                 | Security-relevant jobs                                                                                                             |
-| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
-| [`ci.yml`](.github/workflows/ci.yml)                                     | `Security Audit` (pnpm audit, fails on moderate+), `Lint`, `Type Check`, `Test`, `Build`                                           |
-| [`lint.yml`](.github/workflows/lint.yml)                                 | `lint / actionlint` (workflow YAML lint), `lint / yamllint`, `lint / JSON validity`, `lint / prettier`, `lint / markdownlint`      |
+| Workflow                                                         | Security-relevant jobs                                                                                                             |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| [`ci.yml`](.github/workflows/ci.yml)                             | `Security Audit` (pnpm audit, fails on moderate+), `Lint`, `Type Check`, `Test`, `Build`                                           |
+| [`lint.yml`](.github/workflows/lint.yml)                         | `lint / actionlint` (workflow YAML lint), `lint / yamllint`, `lint / JSON validity`, `lint / prettier`, `lint / markdownlint`      |
 | [CodeQL](https://github.com/nyuchi/mzizi/security/code-scanning) | `Analyze (actions)` and `Analyze (javascript-typescript)` — autocatches `actions/missing-workflow-permissions`, common JS/TS sinks |
 
 Every job in every workflow declares an explicit `permissions:` block (`contents: read` by default) — required by the org-wide `actions/missing-workflow-permissions` CodeQL rule.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ The authoritative current version is served live at `GET /api/v1/changelog` (fir
 
 Use GitHub's private security advisory flow so we can investigate and ship a fix before disclosure:
 
-1. Go to <https://github.com/nyuchi/design-portal/security/advisories/new>
+1. Go to <https://github.com/nyuchi/mzizi/security/advisories/new>
 2. Fill in: a clear title, a description, steps to reproduce, affected version / endpoint, impact (confidentiality / integrity / availability), and any suggested mitigation
 3. Submit — the maintainers are notified privately
 
@@ -115,7 +115,7 @@ CI workflows that gate merge to `main`:
 | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
 | [`ci.yml`](.github/workflows/ci.yml)                                     | `Security Audit` (pnpm audit, fails on moderate+), `Lint`, `Type Check`, `Test`, `Build`                                           |
 | [`lint.yml`](.github/workflows/lint.yml)                                 | `lint / actionlint` (workflow YAML lint), `lint / yamllint`, `lint / JSON validity`, `lint / prettier`, `lint / markdownlint`      |
-| [CodeQL](https://github.com/nyuchi/design-portal/security/code-scanning) | `Analyze (actions)` and `Analyze (javascript-typescript)` — autocatches `actions/missing-workflow-permissions`, common JS/TS sinks |
+| [CodeQL](https://github.com/nyuchi/mzizi/security/code-scanning) | `Analyze (actions)` and `Analyze (javascript-typescript)` — autocatches `actions/missing-workflow-permissions`, common JS/TS sinks |
 
 Every job in every workflow declares an explicit `permissions:` block (`contents: read` by default) — required by the org-wide `actions/missing-workflow-permissions` CodeQL rule.
 
@@ -125,7 +125,7 @@ Per `CLAUDE.md` §15 rule 22, **security findings from any review/audit (`/secur
 
 ## Contact
 
-- Primary: GitHub security advisories — <https://github.com/nyuchi/design-portal/security/advisories/new>
+- Primary: GitHub security advisories — <https://github.com/nyuchi/mzizi/security/advisories/new>
 - Fallback: `security@nyuchi.com`
 
 Thank you for helping keep the bundu ecosystem safe.

--- a/__tests__/api/security-txt.test.ts
+++ b/__tests__/api/security-txt.test.ts
@@ -1,0 +1,98 @@
+/**
+ * `/.well-known/security.txt` — the one file read exclusively by someone trying to report a
+ * vulnerability responsibly.
+ *
+ * It shipped for months advertising three URLs that did not resolve: a `Contact` pointing at
+ * `nyuchi/design-portal` (403 — the repo was renamed to `nyuchi/mzizi` and this reference was
+ * not), a `Policy` at `mzizi.dev/security` (404) and an `Acknowledgments` at
+ * `mzizi.dev/security/acknowledgments` (404). Every other gate was green the whole time,
+ * because nothing had ever opened the file.
+ *
+ * These assertions are OFFLINE and structural — they cannot dial a URL, so they cannot prove
+ * a link resolves. What they can do is stop the two mistakes that actually happened: naming a
+ * repository that is not this one, and pointing at a path this app does not serve. A reviewer
+ * still has to check a genuinely new external URL by hand.
+ */
+import { describe, expect, it } from "vitest"
+
+vi.mock("next/server", () => ({
+  NextResponse: class {
+    constructor(
+      public body: string,
+      public init?: { status?: number; headers?: Record<string, string> }
+    ) {}
+  },
+}))
+
+import { vi } from "vitest"
+import { GET } from "@/app/.well-known/security.txt/route"
+
+async function body(): Promise<string> {
+  const res = (await GET()) as unknown as { body: string }
+  return res.body
+}
+
+function fields(text: string): Map<string, string[]> {
+  const out = new Map<string, string[]>()
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue
+    const [key, ...rest] = line.split(":")
+    const value = rest.join(":").trim()
+    out.set(key, [...(out.get(key) ?? []), value])
+  }
+  return out
+}
+
+describe("/.well-known/security.txt", () => {
+  it("carries the two fields RFC 9116 requires", async () => {
+    const f = fields(await body())
+    expect(f.get("Contact")?.length).toBeGreaterThan(0)
+    expect(f.get("Expires")?.length).toBe(1)
+  })
+
+  it("expires in the future", async () => {
+    const f = fields(await body())
+    const expires = new Date(f.get("Expires")![0])
+    expect(expires.getTime()).toBeGreaterThan(Date.now())
+  })
+
+  it("names this repository, never the pre-rename one", async () => {
+    // github.com/nyuchi/design-portal answers 403. A reporter following it cannot file.
+    const text = await body()
+    expect(text).not.toContain("design-portal")
+    for (const url of text.matchAll(/https:\/\/github\.com\/([\w-]+\/[\w-]+)/g)) {
+      expect(url[1]).toBe("nyuchi/mzizi")
+    }
+  })
+
+  it("only points at mzizi.dev paths this app actually serves", async () => {
+    // The failure was `Policy: https://mzizi.dev/security` and an `Acknowledgments` beside
+    // it, neither of which is a route. Anything on our own origin has to be a path we ship —
+    // and today that is the canonical location of this very file, nothing else.
+    const text = await body()
+    const ours = [...text.matchAll(/https:\/\/mzizi\.dev(\/\S*)?/g)].map((m) => m[1] ?? "/")
+    for (const path of ours) {
+      expect(path).toBe("/.well-known/security.txt")
+    }
+  })
+
+  it("declares itself canonical at the location it is served from", async () => {
+    const f = fields(await body())
+    expect(f.get("Canonical")).toEqual(["https://mzizi.dev/.well-known/security.txt"])
+  })
+
+  it("has no Acknowledgments field while there is no acknowledgments page", async () => {
+    // Absent is honest. A link to a 404 advertises a process that does not exist, which is
+    // worse than saying nothing — remove this test when the page ships.
+    const f = fields(await body())
+    expect(f.has("Acknowledgments")).toBe(false)
+  })
+
+  it("serves as plain text, not as a download or as HTML", async () => {
+    const res = (await GET()) as unknown as {
+      init?: { status?: number; headers?: Record<string, string> }
+    }
+    expect(res.init?.status).toBe(200)
+    expect(res.init?.headers?.["Content-Type"]).toContain("text/plain")
+  })
+})

--- a/app/.well-known/security.txt/route.ts
+++ b/app/.well-known/security.txt/route.ts
@@ -5,6 +5,25 @@ import { NextResponse } from "next/server"
  *
  * RFC 9116 security contact disclosure.
  * https://securitytxt.org/
+ *
+ * EVERY URL HERE IS TESTED, because this file previously advertised three that were not:
+ *
+ *   Contact          github.com/nyuchi/design-portal/security/advisories/new   403 — wrong repo
+ *   Policy           mzizi.dev/security                                        404
+ *   Acknowledgments  mzizi.dev/security/acknowledgments                        404
+ *
+ * A security.txt is read by exactly one kind of person: someone who has found a
+ * vulnerability and is trying to tell us before they tell anyone else. Sending them to a
+ * 404 spends the goodwill that got them here, and it advertises a disclosure process that
+ * does not exist — which is worse than publishing no file at all, because a missing file
+ * reads as "not set up yet" while a broken one reads as "set up and ignored".
+ *
+ * `Policy` now points at SECURITY.md in the repository, which exists and is the actual
+ * policy. `Acknowledgments` is REMOVED rather than repointed: there is no acknowledgments
+ * page, and RFC 9116 makes the field optional. Absent is honest; a link to nothing is not.
+ *
+ * `__tests__/api/security-txt.test.ts` asserts the shape offline, and every URL was checked
+ * by hand against production before this landed.
  */
 export async function GET() {
   // Expires: 1 year from build time — update on each release
@@ -12,11 +31,10 @@ export async function GET() {
   expires.setFullYear(expires.getFullYear() + 1)
 
   const body = `Contact: mailto:security@nyuchi.com
-Contact: https://github.com/nyuchi/design-portal/security/advisories/new
+Contact: https://github.com/nyuchi/mzizi/security/advisories/new
 Expires: ${expires.toISOString()}
-Acknowledgments: https://mzizi.dev/security/acknowledgments
 Canonical: https://mzizi.dev/.well-known/security.txt
-Policy: https://mzizi.dev/security
+Policy: https://github.com/nyuchi/mzizi/blob/main/SECURITY.md
 Preferred-Languages: en
 `
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -109,7 +109,7 @@ const jsonLd = {
       name: "Bundu Foundation",
       description:
         "The Bundu Foundation governs Mzizi, an open-architecture project operated and developed by Nyuchi.",
-      sameAs: ["https://github.com/nyuchi/design-portal"],
+      sameAs: ["https://github.com/nyuchi/mzizi"],
     },
     {
       "@type": "SoftwareApplication",

--- a/components/registry/n10-documentation/nyuchi-ai-context.ts
+++ b/components/registry/n10-documentation/nyuchi-ai-context.ts
@@ -87,9 +87,9 @@ export function generateAIContext(options: AIContextOptions = {}): string {
         `Live counts: ${counts.totalComponents} components total, ` +
           `${counts.totalStable} stable, across ${counts.totalNodes} nodes.`
       )
-      parts.push("Source: mzizi.dev | GitHub: nyuchi/design-portal")
+      parts.push("Source: mzizi.dev | GitHub: nyuchi/mzizi")
     } else {
-      parts.push("Source: mzizi.dev | GitHub: nyuchi/design-portal")
+      parts.push("Source: mzizi.dev | GitHub: nyuchi/mzizi")
       parts.push("For live counts: SELECT * FROM get_system_counts();")
     }
 

--- a/components/registry/n9-fundi/nyuchi-fundi-reporter.ts
+++ b/components/registry/n9-fundi/nyuchi-fundi-reporter.ts
@@ -3,7 +3,7 @@
 /**
  * Where a fundi report becomes an issue.
  *
- * This said `nyuchi/design-portal`, the repo's name before the Mzizi rename —
+ * This said `nyuchi/mzizi`, the repo's name before the Mzizi rename —
  * it is `nyuchi/mzizi` now. GitHub redirects API calls for a renamed repo, so
  * this kept working and had no symptom, which is exactly why it survived: a
  * stale constant that still functions is invisible until the redirect is

--- a/docs/n8-telemetry.md
+++ b/docs/n8-telemetry.md
@@ -181,7 +181,7 @@ Route `onCritical` to N9 and `onError` to OTLP. Sending every error to N9 opens
 an issue per render failure; emitting only to OTLP means nothing gets fixed
 unless somebody happens to be watching a dashboard.
 
-The reporter's issue destination was a hardcoded `nyuchi/design-portal` — this
+The reporter's issue destination was a hardcoded `nyuchi/mzizi` — this
 repo's name before the Mzizi rename. GitHub redirects API calls for a renamed
 repo, so it kept working and had no symptom, which is exactly why it survived.
 A stale constant that still functions is invisible until the redirect is

--- a/lib/db/seed-data/ubuntu.ts
+++ b/lib/db/seed-data/ubuntu.ts
@@ -1,7 +1,7 @@
 /**
  * Ubuntu Pillars and Principles — seed data mirror.
  *
- * Issue nyuchi/design-portal#45. The production `ubuntu_pillars` and
+ * Issue nyuchi/mzizi#45. The production `ubuntu_pillars` and
  * `ubuntu_principles` tables on `grjsboqkaywpwatvrzmy` were seeded
  * out-of-band on 2026-04-22. This module mirrors those rows verbatim
  * for branch databases — local Supabase stacks, ephemeral preview

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -994,7 +994,7 @@ export interface UbuntuPrincipleInsert {
 //
 // The /observability dashboard reads from four public tables (and the
 // `get_system_counts()` RPC). All rows are public-read via RLS — see
-// nyuchi/design-portal#82.
+// nyuchi/mzizi#82.
 
 export interface FundiIssueRow {
   id: number


### PR DESCRIPTION
## Summary

From the Cloudflare Security Insights export. Most of its 318 findings are zone
configuration a repo cannot reach — this is the part that was ours, and it turned out worse
than the report said.

**Every URL in the live `security.txt` except the mailto was dead.** Checked by hand against
production:

| field | URL | |
| --- | --- | --- |
| `Contact` | `github.com/nyuchi/design-portal/security/advisories/new` | **403** |
| `Policy` | `mzizi.dev/security` | **404** |
| `Acknowledgments` | `mzizi.dev/security/acknowledgments` | **404** |

`security.txt` is read by exactly one kind of person: someone who has found a vulnerability
and is trying to tell us before they tell anyone else. Sending them to a 404 spends the
goodwill that got them there, and advertises a disclosure process that does not exist —
which is worse than publishing nothing, because a missing file reads as *"not set up yet"*
while a broken one reads as *"set up and ignored"*.

`SECURITY.md` sent reporters to the same dead advisory URL, and so did
`.github/ISSUE_TEMPLATE/config.yml`. **All three entry points to the private reporting flow
were broken at once.**

## The cause: a rename that was never finished

`nyuchi/design-portal` → `nyuchi/mzizi` happened, and **35 references did not**.
`github.com/nyuchi/design-portal` answers 403; `nyuchi/mzizi` answers 200. The dead slug was
in the README's three CI badges, the clone instructions, CONTRIBUTING's fork URL, the plugin
manifest, `layout.tsx`'s schema.org `sameAs`, and **two registry components published to
consumers**.

## Changes

- All **live** references repointed at `nyuchi/mzizi` — 12 files.
- `Policy` now points at `SECURITY.md` in the repository, which exists and is the actual
  policy.
- `Acknowledgments` **removed** rather than repointed. There is no acknowledgments page, RFC
  9116 makes the field optional, and absent is honest where a link to nothing is not.
- `__tests__/api/security-txt.test.ts` — 7 assertions.

### Deliberately not touched

- `CHANGELOG.md` entries and the two dated MUKOKO amendments — they record what the repo was
  called at the time. History, not links.
- `lib/db/client.ts`'s `"design-portal-cache"` key — internal, and changing it would only
  bust caches.

## The test, and what it cannot do

It is offline and structural, so it **cannot dial a URL** and cannot prove a link resolves. A
genuinely new external URL still needs a reviewer to check it by hand. What it does stop is
the two mistakes that actually happened: naming a repository that is not this one, and
pointing at a path this app does not serve.

Nothing had ever opened this file before — which is exactly why it rotted while every other
gate stayed green.

## Type

- [x] Security / dependency update
- [x] Bug fix
- [x] Documentation

## Pre-commit Gate

- [x] `pnpm lint` — zero warnings
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm test` — 211 pass (7 new)

## Not fixable from a repo — needs the Cloudflare dashboard

The other 300+ findings, for whoever picks them up: 63 DMARC record errors, 43 domains
without `security.txt`, 35 + 33 bot/AI-crawler settings, 23 without HSTS, 23 unproxied
CNAMEs, 20 without "Always Use HTTPS", 14 unproxied A records, 8 missing TLS, 4 SPF errors.

**And 8 Critical "Exposed RDP Servers"** on `api.nyuchi.com`, `auth.nyuchi.com`,
`fundi.nyuchi.com` and `couch.mukoko.com` — see the PR discussion; those need someone with
infrastructure access, not a code change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_