### PR TITLE
feat(site): rebuild all content around the agentic-web framework

### DIFF
--- a/app/architecture/nodes/[n]/page.tsx
+++ b/app/architecture/nodes/[n]/page.tsx
@@ -6,7 +6,11 @@ import type { HelixNode } from "@/lib/db/types"
 
 export const revalidate = 3600
 
-// NODE DETAIL — one element of the Mzizi DNA double helix.
+// NODE DETAIL — one slice of the Phase 0 benchmark corpus.
+//
+// Under the framework reframing, N1–N12 are the taxonomy of the corpus the
+// Mzizi language is measured against: each node is a fixed, known-ground-truth
+// set of components with reference implementations and behavior contracts.
 //
 // Replaces the axis-era `/architecture/layers/[n]`, which read
 // `get_layer_detail()` and printed `L{n} · {sub_label} · {axis_name}` for
@@ -73,7 +77,7 @@ export default async function NodeDetailPage({ params }: { params: Promise<{ n: 
       <article className="mx-auto max-w-3xl py-12">
         <h1 className="font-serif text-3xl font-bold">N{parsed}</h1>
         <p className="mt-4 text-sm text-muted-foreground">
-          Supabase is not configured. Every element of the helix is read live from{" "}
+          Supabase is not configured. Every slice of the benchmark corpus is read live from{" "}
           <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
             component_documents
           </code>{" "}
@@ -98,7 +102,7 @@ export default async function NodeDetailPage({ params }: { params: Promise<{ n: 
         href="/architecture"
         className="mb-6 inline-flex items-center gap-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
       >
-        <ArrowLeft className="size-3" /> The whole helix
+        <ArrowLeft className="size-3" /> The whole corpus
       </Link>
 
       <header className="mb-8">
@@ -138,6 +142,20 @@ export default async function NodeDetailPage({ params }: { params: Promise<{ n: 
         </section>
       ) : null}
 
+      <section className="mb-10 rounded-2xl border border-border bg-muted/10 p-6">
+        <p className="mb-2 font-mono text-[10px] tracking-widest text-muted-foreground uppercase">
+          Role in the Phase 0 benchmark
+        </p>
+        <p className="text-sm leading-relaxed text-muted-foreground">
+          This {element.type} is one slice of the fixed benchmark corpus the Mzizi framework is
+          measured against. Each component here has a reference implementation read from disk and a
+          behavior contract; when the benchmark agent re-authors it in Mzizi syntax (versus raw
+          Dioxus and Leptos), the run is scored on tokens consumed, iterations to a clean compile,
+          and defect rate — a defect being code that compiles cleanly but fails the contract. No
+          benchmark has been run yet; the corpus is the ground truth being prepared for it.
+        </p>
+      </section>
+
       {element.stakeholder ? (
         <section className="mb-10">
           <h2 className="mb-3 font-serif text-xl font-semibold">Stakeholder</h2>
@@ -163,7 +181,9 @@ export default async function NodeDetailPage({ params }: { params: Promise<{ n: 
 
       <section className="mb-10">
         <header className="mb-2 flex items-baseline justify-between gap-3">
-          <h2 className="font-serif text-xl font-semibold">Components on this {element.type}</h2>
+          <h2 className="font-serif text-xl font-semibold">
+            Corpus components on this {element.type}
+          </h2>
           <span className="font-mono text-xs text-muted-foreground">
             {element.component_count} {element.component_count === 1 ? "component" : "components"}
           </span>

--- a/app/architecture/page.tsx
+++ b/app/architecture/page.tsx
@@ -8,9 +8,9 @@ import { ArchitectureExplorer } from "@/components/landing/architecture-explorer
 export const revalidate = 3600
 
 export const metadata = {
-  title: "Architecture — the DNA double helix",
+  title: "Architecture — a Rust framework for the agentic web",
   description:
-    "The Mzizi DNA double helix — two entwined backbones (engineering + meaning) held by cross-cutting rungs. Nodes on strands, no axes, no outliers. Every count read live from Supabase.",
+    "The research architecture of the Mzizi framework: a novel syntax, type system, and compiler feedback loop designed for machine authorship, with Dioxus rendering interop, Candle ML, and an edge-first WASM artifact. Phase 0: language design + benchmark.",
 }
 
 const STRAND_BADGE: Record<string, string> = {
@@ -26,6 +26,114 @@ const RUNG_BADGE = "bg-[var(--color-gold)]/10 text-[var(--color-gold)]"
 function strandBadge(strand: string): string {
   return STRAND_BADGE[strand] ?? "bg-muted text-muted-foreground"
 }
+
+// ── Static charter content ─────────────────────────────────────────────
+// The framework is in Phase 0: the language is being designed now. These
+// tables state the charter — goals, layers, phases, non-goals — and never
+// invent syntax, benchmark numbers, or shipped features.
+
+const DESIGN_GOALS = [
+  {
+    label: "G1 · Low syntactic ambiguity",
+    body: "Every construct should have one obvious spelling. An agent that has to guess between equivalent forms burns iterations; a grammar with fewer valid ways to say the same thing converges faster.",
+  },
+  {
+    label: "G2 · High-signal compiler errors",
+    body: "Errors are written for a machine reader: dense, structured, and pointing at the fix — not prose for a human skimming a terminal. The compiler is the agent's pair programmer, and its output is the feedback channel.",
+  },
+  {
+    label: "G3 · Fast incremental compilation",
+    body: "An agent iterates against the compiler hundreds or thousands of times per task. Compile latency multiplies through every loop, so incremental build speed is a first-order success metric, not a nice-to-have.",
+  },
+  {
+    label: "G4 · Token-efficient representation",
+    body: "More logic per context-window token. The denser the language, the more of a program an agent can hold, read, and rewrite inside one context window.",
+  },
+] as const
+
+const LAYERS = [
+  {
+    layer: "Syntax · type system · compiler",
+    posture: "Novel — the research",
+    detail:
+      "The part Mzizi actually builds: a language and compiler feedback loop designed for machine authorship, measured against the four goals.",
+    accent: "text-[var(--color-gold)]",
+  },
+  {
+    layer: "Rendering",
+    posture: "Interop — Dioxus",
+    detail:
+      "Mzizi does not build a renderer. Components compile to Dioxus for rendering; no native renderer in Phase 0/1.",
+    accent: "text-[var(--color-cobalt)]",
+  },
+  {
+    layer: "Machine learning",
+    posture: "Interop — Candle",
+    detail:
+      "ML workloads go through Candle. Building a competing tensor runtime is an explicit non-goal.",
+    accent: "text-[var(--color-tanzanite)]",
+  },
+  {
+    layer: "Runtime",
+    posture: "Edge-first — Cloudflare Workers / workers-rs",
+    detail:
+      "The default deployment target is the edge; the runtime story is workers-rs, not a bespoke server.",
+    accent: "text-[var(--color-malachite)]",
+  },
+  {
+    layer: "Artifact",
+    posture: "WASM (+ native desktop)",
+    detail:
+      "The compiled artifact is WASM, standalone and embeddable, with native desktop as the second target.",
+    accent: "text-[var(--color-copper)]",
+  },
+  {
+    layer: "Host frameworks",
+    posture: "Thin optional adapters",
+    detail:
+      "Astro and other frameworks get adapters that embed the artifact. Adapters stay thin and optional — the artifact is the product of compilation, not a plugin.",
+    accent: "text-[var(--color-sodalite)]",
+  },
+  {
+    layer: "Cryptography",
+    posture: "Deferred",
+    detail: "Post-quantum crypto is acknowledged and explicitly deferred. Not a Phase 0–4 concern.",
+    accent: "text-[var(--color-terracotta)]",
+  },
+] as const
+
+const PHASES = [
+  {
+    phase: "Phase 0",
+    title: "Compiler & syntax prototype + benchmark",
+    status: "now",
+    body: "Design the language; prototype the compiler feedback loop; run the benchmark. An agent authors Mzizi's own component corpus in Mzizi syntax versus raw Dioxus and Leptos, measured on tokens consumed, iterations to a clean compile, and defect rate — where a defect is code that compiles cleanly but is behaviorally wrong.",
+  },
+  {
+    phase: "Phase 1",
+    title: "Dioxus interop → standalone artifact",
+    status: "planned",
+    body: "Components render through Dioxus and compile to a standalone WASM / native artifact, embeddable anywhere.",
+  },
+  {
+    phase: "Phase 2",
+    title: "Edge",
+    status: "planned",
+    body: "First-class deployment to Cloudflare Workers via workers-rs — edge-first, not edge-eventually.",
+  },
+  {
+    phase: "Phase 3",
+    title: "Candle ML",
+    status: "planned",
+    body: "ML integration through Candle, so agent-authored components can carry inference without leaving Rust.",
+  },
+  {
+    phase: "Phase 4",
+    title: "Adapters",
+    status: "planned",
+    body: "Thin optional adapters for Astro and other host frameworks that want to embed compiled Mzizi artifacts.",
+  },
+] as const
 
 function NodeCard({ node }: { node: HelixNode }) {
   return (
@@ -163,7 +271,7 @@ export default async function ArchitecturePage() {
           <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
             NEXT_PUBLIC_SUPABASE_ANON_KEY
           </code>{" "}
-          to render the live DNA-helix model.
+          to render the live benchmark-corpus taxonomy.
         </p>
       </article>
     )
@@ -185,38 +293,33 @@ export default async function ArchitecturePage() {
     <article data-mdx className="mx-auto max-w-5xl py-8">
       <header className="mb-8">
         <p className="mb-3 font-mono text-[11px] tracking-widest text-muted-foreground sm:text-xs">
-          DNA DOUBLE HELIX
+          RESEARCH ARCHITECTURE · BUNDU FOUNDATION
         </p>
         <h1 className="mb-4 font-serif text-3xl font-bold tracking-tight text-foreground sm:text-4xl md:text-5xl">
-          Two backbones. Cross-cutting rungs. No axes.
+          A Rust framework designed for machine authorship.
         </h1>
         <p className="max-w-2xl text-base leading-relaxed text-muted-foreground">
-          Most component libraries are flat: primitives at the bottom, composed components above,
-          pages on top. Mzizi is a <span className="text-foreground">double helix</span>. Two
-          entwined backbones run through it — an{" "}
-          <span className="text-foreground">engineering</span> backbone that builds the product and
-          a <span className="text-foreground">meaning</span> backbone that carries the doctrine —
-          held together by cross-cutting <span className="text-foreground">rungs</span>. Nodes sit
-          on strands; rungs bridge both. The node numbers are labels, not a sequence — there is no
-          highest one and more will come — and nothing lives &ldquo;outside.&rdquo;
+          Every existing web framework assumes a human is typing. Mzizi assumes the opposite: the
+          primary author is{" "}
+          <span className="text-foreground">an agent iterating against a compiler</span>, thousands
+          of times, and the framework&apos;s syntax, type system, and compiler feedback loop are
+          designed for that reader. It is a{" "}
+          <span className="text-foreground">Bundu Foundation research project</span>, currently in{" "}
+          <span className="text-foreground">Phase 0</span>: the language is being designed now.
+          Nothing on this page is shipped syntax or a measured result — it is the charter the
+          research is held to.
         </p>
         <p className="mt-4 max-w-2xl text-sm leading-relaxed text-muted-foreground">
-          Every element and count below is read live from{" "}
-          <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
-            component_documents
-          </code>{" "}
-          (
-          <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
-            documentation-architecture-&#123;nodes,strands&#125;
-          </code>
-          ) — the single source of truth the MCP serves — never hardcoded. Click any bead or strand
-          chip in the model for its covenant and rules, or any node name below for its own page.
+          The research is measured, not asserted. Phase 0 ends in a benchmark: an agent authors the
+          framework&apos;s own component corpus — the {totalComponents}-component set catalogued
+          below — in Mzizi syntax versus raw Dioxus and Leptos, scored on tokens consumed,
+          iterations to a clean compile, and defect rate.
         </p>
 
         <dl className="mt-6 grid grid-cols-2 gap-4 border-y border-border py-4 text-sm sm:grid-cols-4">
           <div>
             <dt className="font-mono text-[10px] tracking-widest text-muted-foreground uppercase">
-              Nodes
+              Corpus nodes
             </dt>
             <dd className="font-serif text-2xl font-semibold text-foreground">
               {model.nodes.length}
@@ -240,71 +343,218 @@ export default async function ArchitecturePage() {
           </div>
           <div>
             <dt className="font-mono text-[10px] tracking-widest text-muted-foreground uppercase">
-              Components
+              Corpus components
             </dt>
             <dd className="font-serif text-2xl font-semibold text-foreground">{totalComponents}</dd>
           </div>
         </dl>
       </header>
 
-      {/* Interactive double-helix explorer */}
-      <div className="mb-12 overflow-hidden">
-        <Suspense
-          fallback={
-            <Skeleton className="h-[340px] w-full rounded-2xl border border-border sm:h-[440px]" />
-          }
-        >
-          <ArchitectureExplorer />
-        </Suspense>
-      </div>
-
-      <div className="space-y-12">
-        <BackboneSection
-          title="Engineering backbone"
-          blurb="The strands that build the product. Core guarantees travel unchanged; shipped components come in the box but evolve; swappable seams are the only defined fork points; the spine pre-wires it all."
-          strands={engineeringStrands}
-          nodesByStrand={nodesByStrand}
-        />
-        <BackboneSection
-          title="Meaning backbone"
-          blurb="The strands that carry the doctrine. The genetic code is the Ubuntu + Bundu sequence everything is read from; transcription stores every convention and decision as queryable data — not tribal knowledge."
-          strands={meaningStrands}
-          nodesByStrand={nodesByStrand}
-        />
-
-        {model.rungs.length > 0 && (
-          <section className="border-t border-border pt-10">
-            <header className="mb-6 flex flex-col gap-2">
-              <h2 className="font-serif text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
-                Cross-cutting rungs
-              </h2>
-              <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
-                The base pairs that bridge both backbones. Bound to no single strand, they keep the
-                system healing, documented, and discoverable.
+      {/* ── The four design goals ───────────────────────────────────── */}
+      <section className="mb-12">
+        <header className="mb-6 flex flex-col gap-2">
+          <h2 className="font-serif text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+            Four measurable design goals
+          </h2>
+          <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
+            The thesis, made falsifiable. Every language and compiler decision is judged against
+            these four, and the Phase 0 benchmark exists to score them.
+          </p>
+        </header>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {DESIGN_GOALS.map((goal) => (
+            <article
+              key={goal.label}
+              className="flex flex-col gap-2 rounded-xl border border-border bg-background p-5"
+            >
+              <p className="font-mono text-[10px] tracking-widest text-[var(--color-gold)] uppercase">
+                {goal.label}
               </p>
-            </header>
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {model.rungs
-                .slice()
-                .sort((a, b) => a.node_number - b.node_number)
-                .map((rung) => (
-                  <RungCard key={rung.node_number} rung={rung} />
-                ))}
-            </div>
-          </section>
-        )}
-      </div>
+              <p className="text-sm leading-relaxed text-muted-foreground">{goal.body}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      {/* ── Layer table ─────────────────────────────────────────────── */}
+      <section className="mb-12 border-t border-border pt-10">
+        <header className="mb-6 flex flex-col gap-2">
+          <h2 className="font-serif text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+            Build one layer, borrow the rest
+          </h2>
+          <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
+            The novelty budget is spent in exactly one place — the language and its compiler. Every
+            other layer interops with the best existing Rust work rather than competing with it.
+          </p>
+        </header>
+        <div className="overflow-x-auto rounded-2xl border border-border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border bg-muted/20 text-left">
+                <th className="px-4 py-3 font-mono text-[10px] tracking-widest text-muted-foreground uppercase">
+                  Layer
+                </th>
+                <th className="px-4 py-3 font-mono text-[10px] tracking-widest text-muted-foreground uppercase">
+                  Posture
+                </th>
+                <th className="hidden px-4 py-3 font-mono text-[10px] tracking-widest text-muted-foreground uppercase sm:table-cell">
+                  Why
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {LAYERS.map((row) => (
+                <tr key={row.layer} className="border-b border-border/50 last:border-0">
+                  <td className="px-4 py-3 font-medium text-foreground">{row.layer}</td>
+                  <td className={`px-4 py-3 font-mono text-xs ${row.accent}`}>{row.posture}</td>
+                  <td className="hidden px-4 py-3 leading-relaxed text-muted-foreground sm:table-cell">
+                    {row.detail}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* ── Roadmap ─────────────────────────────────────────────────── */}
+      <section className="mb-12 border-t border-border pt-10">
+        <header className="mb-6 flex flex-col gap-2">
+          <h2 className="font-serif text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+            Phases 0–4
+          </h2>
+          <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
+            Sequenced so that each phase has a shippable artifact and the benchmark comes first —
+            the framework earns its later phases by measuring well in Phase 0.
+          </p>
+        </header>
+        <ol className="space-y-4">
+          {PHASES.map((p) => (
+            <li
+              key={p.phase}
+              className="flex flex-col gap-2 rounded-xl border border-border bg-background p-5"
+            >
+              <div className="flex flex-wrap items-baseline gap-3">
+                <span className="font-mono text-[10px] tracking-widest text-muted-foreground uppercase">
+                  {p.phase}
+                </span>
+                <h3 className="font-serif text-lg font-semibold text-foreground">{p.title}</h3>
+                <span
+                  className={`rounded-full px-2 py-0.5 font-mono text-[10px] font-medium tracking-widest uppercase ${
+                    p.status === "now"
+                      ? "bg-[var(--color-gold)]/10 text-[var(--color-gold)]"
+                      : "bg-muted text-muted-foreground"
+                  }`}
+                >
+                  {p.status}
+                </span>
+              </div>
+              <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground">{p.body}</p>
+            </li>
+          ))}
+        </ol>
+        <div className="mt-6 rounded-2xl border border-border bg-muted/10 p-5 text-sm leading-relaxed text-muted-foreground">
+          <p className="mb-2 font-mono text-[10px] tracking-widest text-foreground uppercase">
+            Explicit non-goals
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>No competing tensor runtime — ML is Candle&apos;s job.</li>
+            <li>No native renderer in Phase 0/1 — rendering is Dioxus&apos;s job.</li>
+            <li>Post-quantum cryptography is deferred, deliberately.</li>
+          </ul>
+          <p className="mt-3">
+            Ownership: the framework IP is held by the{" "}
+            <span className="text-foreground">Bundu Foundation</span> and published under{" "}
+            <code className="rounded bg-background px-1 py-0.5 font-mono text-xs">@bundu</code>;
+            Nyuchi owns the Fundi console that operates around it.
+          </p>
+        </div>
+      </section>
+
+      {/* ── The benchmark corpus ────────────────────────────────────── */}
+      <section className="border-t border-border pt-10">
+        <header className="mb-6 flex flex-col gap-2">
+          <h2 className="font-serif text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+            The Phase 0 benchmark corpus
+          </h2>
+          <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
+            The component registry Mzizi began life as is not the product any more — it is the{" "}
+            <span className="text-foreground">measuring instrument</span>. A fixed,
+            known-ground-truth set of components the framework is benchmarked against: each has a
+            reference implementation read from disk and a behavior contract, and a defect is code
+            that compiles cleanly but fails that contract. The taxonomy below — nodes on strands,
+            bridged by rungs — is how the corpus is organized, read live from{" "}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
+              component_documents
+            </code>{" "}
+            (
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
+              documentation-architecture-&#123;nodes,strands&#125;
+            </code>
+            ), never hardcoded. Click any node for its slice of the corpus.
+          </p>
+        </header>
+
+        {/* Interactive corpus explorer */}
+        <div className="mb-12 overflow-hidden">
+          <Suspense
+            fallback={
+              <Skeleton className="h-[340px] w-full rounded-2xl border border-border sm:h-[440px]" />
+            }
+          >
+            <ArchitectureExplorer />
+          </Suspense>
+        </div>
+
+        <div className="space-y-12">
+          <BackboneSection
+            title="Engineering backbone"
+            blurb="The corpus slices that exercise the framework's engineering surface: primitives, shipped compositions, swappable seams, and the spine that wires them — each one a distinct kind of authoring task for the benchmark agent."
+            strands={engineeringStrands}
+            nodesByStrand={nodesByStrand}
+          />
+          <BackboneSection
+            title="Meaning backbone"
+            blurb="The strands that carry the doctrine behind the corpus: the Ubuntu + Bundu genetic code the research is read from, and the transcription layer that stores every convention and decision as queryable data — not tribal knowledge."
+            strands={meaningStrands}
+            nodesByStrand={nodesByStrand}
+          />
+
+          {model.rungs.length > 0 && (
+            <section className="border-t border-border pt-10">
+              <header className="mb-6 flex flex-col gap-2">
+                <h2 className="font-serif text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+                  Cross-cutting rungs
+                </h2>
+                <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
+                  Corpus slices bound to no single strand — they keep the whole set documented,
+                  discoverable, and verifiable, which is what makes it usable as ground truth.
+                </p>
+              </header>
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {model.rungs
+                  .slice()
+                  .sort((a, b) => a.node_number - b.node_number)
+                  .map((rung) => (
+                    <RungCard key={rung.node_number} rung={rung} />
+                  ))}
+              </div>
+            </section>
+          )}
+        </div>
+      </section>
 
       <footer className="mt-16 rounded-2xl border border-border bg-muted/20 p-6 text-sm leading-relaxed text-muted-foreground">
         <p className="mb-3 font-mono text-[10px] tracking-widest text-foreground uppercase">
-          Source of truth
+          Status honesty
         </p>
         <p>
-          The doctrine is the data. Node covenants, strand groupings, and rung classifications live
-          in Supabase as documents — relabel one with an{" "}
-          <code className="rounded bg-background px-1 py-0.5 font-mono text-xs">UPDATE</code> and
+          Mzizi is in Phase 0. The syntax is being designed; no benchmark has been run; nothing
+          above is a shipped feature or a measured number. The corpus taxonomy — node covenants,
+          strand groupings, rung classifications — is live data in Supabase: relabel a document with
+          an <code className="rounded bg-background px-1 py-0.5 font-mono text-xs">UPDATE</code> and
           every consumer (this page, the MCP server, AI assistants) sees the new shape on the next
-          read. No migration. No drift.
+          read.
         </p>
       </footer>
     </article>

--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -18,7 +18,7 @@ export const revalidate = 3600
 export const metadata: Metadata = {
   title: "Changelog",
   description:
-    "Release notes for the Mzizi component registry — each entry tagged with the nodes and rungs of the DNA double helix it touched.",
+    "The corpus record — every change to the Mzizi benchmark corpus, each entry tagged with the nodes and rungs of the DNA double helix it touched.",
 }
 
 function formatDate(iso: string | null | undefined): string {
@@ -39,7 +39,7 @@ export default async function ChangelogPage() {
             Changelog
           </h1>
           <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
-            Release notes for the Mzizi component registry.
+            The corpus record — every change to the benchmark corpus, versioned.
           </p>
         </header>
         <p className="rounded-xl border border-border bg-muted/30 p-6 text-sm text-muted-foreground">
@@ -65,15 +65,16 @@ export default async function ChangelogPage() {
           Changelog
         </h1>
         <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
-          Every Mzizi release, newest first. Each entry is tagged with the nodes and rungs of the
-          DNA double helix it touched — colour-coded by helix classification: cobalt for a core
+          The corpus record — every change to the benchmark corpus, newest first. Ground truth only
+          counts if its history is auditable, so each entry is tagged with the nodes and rungs of
+          the DNA double helix it touched — colour-coded by helix classification: cobalt for a core
           guarantee, tanzanite for shipped, malachite for swappable, gold for a cross-cutting rung.
         </p>
       </header>
 
       {entries.length === 0 ? (
         <p className="rounded-xl border border-border bg-muted/30 p-6 text-sm text-muted-foreground">
-          No changelog entries available yet.
+          The corpus record has no entries yet.
         </p>
       ) : (
         <ol

--- a/app/cli/page.tsx
+++ b/app/cli/page.tsx
@@ -5,8 +5,9 @@ import { CopyCommand } from "@/components/landing/copy-command"
 
 // CLI INSTRUCTIONS — mzizi.dev/cli
 //
-// The public instruction surface for @nyuchi/mzizi-cli — the fundi agent.
-// The package lives in nyuchi/mzizi-tools (`mzizi-cli/`); this page is its
+// The public instruction surface for @nyuchi/mzizi-cli — the fundi agent,
+// the Nyuchi-owned console over the Mzizi research program. The package
+// lives in nyuchi/mzizi-tools (`mzizi-cli/`); this page is its
 // human-readable manual so consumers do not have to read the monorepo to get
 // started.
 //
@@ -17,7 +18,7 @@ import { CopyCommand } from "@/components/landing/copy-command"
 export const metadata: Metadata = {
   title: "CLI",
   description:
-    "@nyuchi/mzizi-cli — the fundi agent. Explore a project, plan a change against the Mzizi registry, and apply it. Install, configure, and command reference.",
+    "@nyuchi/mzizi-cli — the fundi agent, the command-line surface of the Mzizi research program. Explore a project, plan a change against the Phase 0 corpus, and apply it. Install, configure, and command reference.",
 }
 
 export default function CliPage() {
@@ -31,8 +32,10 @@ export default function CliPage() {
         <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
           <code className="font-mono text-xs">@nyuchi/mzizi-cli</code> ships{" "}
           <strong className="font-semibold text-foreground">fundi</strong>: an agent that reads your
-          project off disk, plans a change against the live registry, and applies it only when you
-          tell it to. The SDK and the CLI are one package.
+          project off disk, plans a change against the live registry — the Phase 0 benchmark corpus
+          of the Mzizi research program — and applies it only when you tell it to. The SDK and the
+          CLI are one package. It is the command-line surface of the program today, and the natural
+          home of the compiler toolchain as the Mzizi language lands.
         </p>
       </header>
 
@@ -75,7 +78,7 @@ export default function CliPage() {
               fundi plan &lt;goal&gt;
             </h3>
             <p className="text-sm leading-relaxed text-muted-foreground">
-              Plans the work against the live registry and returns the steps. The planner runs
+              Plans the work against the live corpus and returns the steps. The planner runs
               read-only — it can read files, list directories, and fetch skills and components, but
               writing and shelling out are blocked at this stage. A plan is inert until applied, so
               read it first.
@@ -181,7 +184,7 @@ export default function CliPage() {
           Use it with the rest
         </h2>
         <p className="text-sm leading-relaxed text-muted-foreground">
-          The CLI is one of three surfaces over the same registry. Pair it with the{" "}
+          The CLI is one of three agent-facing surfaces over the same corpus. Pair it with the{" "}
           <Link className="underline hover:text-foreground" href="/skills">
             skills bundle
           </Link>{" "}

--- a/app/components/page.tsx
+++ b/app/components/page.tsx
@@ -4,7 +4,7 @@ import { ComponentGallery } from "@/components/playground/component-gallery"
 export const metadata: Metadata = {
   title: "Components",
   description:
-    "Browse the full Mzizi component library. Each component has a live preview, source code, and an API tester.",
+    "The Mzizi benchmark corpus — 571 components across 12 nodes, the fixed ground truth the framework is measured against. Live preview, source code, and an API tester for each.",
 }
 
 export const revalidate = 300
@@ -17,8 +17,10 @@ export default function ComponentsPage() {
           Components
         </h1>
         <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
-          Browse the full component library. Each component has a live preview, full source code,
-          and an API tester to fetch it programmatically.
+          The benchmark corpus — 571 components across 12 nodes, each with a TypeScript reference
+          and a growing set of Rust siblings, the fixed ground truth the Mzizi framework is measured
+          against. Every component has a live preview, full source code, and an API tester to fetch
+          it programmatically — and remains installable as a working component.
         </p>
         <pre className="overflow-x-auto rounded-lg border border-border bg-muted/40 p-3 font-mono text-xs">
           <code>npx shadcn@latest add https://mzizi.dev/api/v1/ui/&lt;component-name&gt;</code>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ const fontMono = JetBrains_Mono({
 const SITE_URL = "https://mzizi.dev"
 const SITE_NAME = "Mzizi"
 const SITE_DESCRIPTION =
-  "Mzizi — an open-architecture project of the Bundu Foundation. An open DNA-helix frontend architecture, component registry, MCP server, and AI-native developer tooling built on the Seven African Minerals palette. Operated and developed by Nyuchi. Install directly into your project with the shadcn CLI."
+  "Mzizi — a Rust framework for the agentic web, a Bundu Foundation research project. A syntax, type system, and compiler feedback loop designed for machine authorship: low ambiguity, dense compiler errors, fast incremental builds, token-efficient code. Rendering via Dioxus, ML via Candle, edge-first on Cloudflare Workers — proven against Mzizi's own component corpus."
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
@@ -28,19 +28,21 @@ export const metadata: Metadata = {
   applicationName: SITE_NAME,
   authors: [{ name: "Bundu Foundation" }, { name: "Nyuchi", url: "https://nyuchi.com" }],
   keywords: [
-    "open architecture",
-    "design system",
-    "component library",
-    "shadcn",
+    "Rust framework",
+    "agentic web",
+    "machine authorship",
+    "LLM code generation",
+    "compiler design",
+    "Dioxus",
+    "Candle",
+    "WASM",
+    "Cloudflare Workers",
+    "edge computing",
     "Africa",
-    "React",
-    "Next.js",
-    "Tailwind CSS",
-    "Seven African Minerals",
     "mzizi",
     "bundu",
-    "UI components",
-    "TypeScript",
+    "Bundu Foundation",
+    "benchmark corpus",
   ],
   creator: "Bundu Foundation",
   publisher: "Bundu Foundation",
@@ -108,7 +110,7 @@ const jsonLd = {
       "@id": `${SITE_URL}/#organization`,
       name: "Bundu Foundation",
       description:
-        "The Bundu Foundation governs Mzizi, an open-architecture project operated and developed by Nyuchi.",
+        "The Bundu Foundation owns and governs Mzizi, a Rust framework for the agentic web. The Fundi console and active testing are operated by Nyuchi.",
       sameAs: ["https://github.com/nyuchi/mzizi"],
     },
     {

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -18,7 +18,7 @@ export default function manifest(): MetadataRoute.Manifest {
     name: "mzizi",
     short_name: "mzizi",
     description:
-      "The Mzizi design system — component registry, brand, and the DNA-helix frontend architecture. An open-architecture project of the Bundu Foundation.",
+      "Mzizi — a Rust framework for the agentic web. Syntax, type system, and compiler feedback loop designed for machine authorship. A Bundu Foundation research project.",
     start_url: "/",
     display: "standalone",
     background_color: "#faf9f5",

--- a/app/observability/page.tsx
+++ b/app/observability/page.tsx
@@ -1,41 +1,17 @@
 import type { Metadata } from "next"
-import {
-  Activity,
-  AlertTriangle,
-  BarChart2,
-  Boxes,
-  CheckCircle,
-  Clock,
-  Code,
-  ExternalLink,
-  FlaskConical,
-  ShieldCheck,
-  Stethoscope,
-  TrendingDown,
-  TrendingUp,
-  Wrench,
-  Zap,
-} from "lucide-react"
+import { Activity, BarChart2, Boxes, Clock, Code, FlaskConical, Zap } from "lucide-react"
 import { getUsageStats } from "@/lib/metrics"
-import {
-  getRegistryCounts,
-  getFundiIssues,
-  getChaosEvents,
-  getSystemCounts,
-  getHelixModel,
-  helixClassOf,
-  isSupabaseConfigured,
-} from "@/lib/db"
-import { ObservabilityCharts, NodeDistributionChart, HELIX_CLASS_COLOR } from "./charts"
+import { getHelixModel, helixClassOf, isSupabaseConfigured } from "@/lib/db"
+import { NodeDistributionChart, HELIX_CLASS_COLOR } from "./charts"
 
 export const metadata: Metadata = {
-  title: "Observability",
+  title: "Measurement",
   description:
-    "Public API, MCP, Fundi, chaos, and registry telemetry for Mzizi — open data for the community.",
+    "The measurement discipline of the Mzizi research program: the Phase 0 benchmark metrics (tokens, iterations to clean compile, defect rate), the contract-test verification pattern, and the live composition of the benchmark corpus.",
 }
 
 // ISR per issue #84: revalidate every 5 minutes. Long enough to keep
-// the dashboard cheap; short enough that open data stays fresh.
+// the page cheap; short enough that open data stays fresh.
 export const revalidate = 300
 
 function fmt(n: number): string {
@@ -44,75 +20,41 @@ function fmt(n: number): string {
   return `${n}`
 }
 
-function errorRateColor(rate: number): string {
-  if (rate === 0) return "text-[var(--color-malachite)]"
-  if (rate < 1) return "text-[var(--color-gold)]"
-  return "text-destructive"
-}
+// ── Static charter content ─────────────────────────────────────────────
+// Mzizi is a research program, and a research program is only as honest as
+// its measurement. These are the Phase 0 benchmark's metrics — defined now,
+// scored when the benchmark runs. No numbers appear here until they exist.
 
-function uptimePct(errorRate: number): string {
-  return `${(100 - errorRate).toFixed(1)}%`
-}
-
-function relTime(iso: string): string {
-  const then = new Date(iso).getTime()
-  if (Number.isNaN(then)) return ""
-  const diffSec = Math.max(0, Math.floor((Date.now() - then) / 1000))
-  if (diffSec < 60) return `${diffSec}s ago`
-  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`
-  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`
-  return `${Math.floor(diffSec / 86400)}d ago`
-}
-
-function severityColor(severity: string | null): string {
-  switch ((severity ?? "").toLowerCase()) {
-    case "critical":
-    case "high":
-      return "text-destructive"
-    case "medium":
-      return "text-[var(--color-gold)]"
-    case "low":
-      return "text-[var(--color-malachite)]"
-    default:
-      return "text-muted-foreground"
-  }
-}
-
-function statusColor(status: string | null): string {
-  switch ((status ?? "").toLowerCase()) {
-    case "resolved":
-    case "healed":
-      return "text-[var(--color-malachite)]"
-    case "open":
-    case "investigating":
-      return "text-[var(--color-gold)]"
-    case "failed":
-    case "escalated":
-      return "text-destructive"
-    default:
-      return "text-muted-foreground"
-  }
-}
+const BENCHMARK_METRICS = [
+  {
+    label: "M1 · Tokens consumed",
+    body: "Total context-window tokens the benchmark agent spends authoring a component — reading, writing, and re-reading. Scores design goal G4: more logic per token means fewer tokens per finished component.",
+  },
+  {
+    label: "M2 · Iterations to clean compile",
+    body: "How many compile-fix loops the agent needs before the compiler accepts the code. Scores G1 and G2: an unambiguous grammar plus dense, machine-aimed errors should converge in fewer rounds.",
+  },
+  {
+    label: "M3 · Defect rate",
+    body: "The fraction of components that compile cleanly but are behaviorally wrong — they fail the behavior contract despite satisfying the type system. The metric that keeps the other two honest: fast, cheap, and wrong is not a result.",
+  },
+] as const
 
 export default async function ObservabilityPage() {
   // Short-circuit to a graceful empty-state shell when Supabase env vars
-  // are missing — every panel below depends on the public-read tables.
+  // are missing — the live panels below depend on the public-read tables.
   if (!isSupabaseConfigured()) {
     return <UnconfiguredState />
   }
 
-  const [stats30, stats7, counts, fundiIssues, chaosEvents, sysCounts, helix] = await Promise.all([
+  const [stats30, stats7, helix] = await Promise.all([
     getUsageStats(30).catch(() => null),
     getUsageStats(7).catch(() => null),
-    getRegistryCounts().catch(() => ({ total: 0, ui: 0, blocks: 0, hooks: 0, lib: 0 })),
-    getFundiIssues(8).catch(() => []),
-    getChaosEvents(10).catch(() => []),
-    getSystemCounts().catch(() => null),
     getHelixModel().catch(() => ({ nodes: [], rungs: [], strands: [] })),
   ])
 
-  // One bar per element of the helix — nodes then rungs, each carrying its
-  // own classification so the chart, the node badge, and the architecture
+  // One bar per element of the corpus taxonomy — nodes then rungs, each
+  // carrying its own classification so this chart and the architecture
   // explorer colour the same node the same way. Read straight off
   // `documentation-architecture-nodes`; nothing is capped and nothing is
   // keyed on a retired axis label.
@@ -123,6 +65,7 @@ export default async function ObservabilityPage() {
     helix_class: helixClassOf(element),
     component_count: element.component_count,
   }))
+  const corpusTotal = nodeDistribution.reduce((sum, d) => sum + d.component_count, 0)
 
   // Only legend entries actually present in the data — a fixed list would
   // re-introduce a hardcoded model.
@@ -131,81 +74,115 @@ export default async function ObservabilityPage() {
   const s = stats30
   const s7 = stats7
   const totalCalls = (s?.total_api_calls ?? 0) + (s?.total_mcp_calls ?? 0)
-  const errorRate = s?.overall_error_rate ?? 0
   const avgMs = s?.avg_duration_ms ?? 0
-  const totalNodes = sysCounts?.total_nodes ?? 0
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-12 sm:px-6 sm:py-16">
       {/* Header */}
       <div className="mb-10">
         <div className="mb-2 flex items-center gap-2">
-          <Activity className="size-5 text-[var(--color-cobalt)]" />
+          <FlaskConical className="size-5 text-[var(--color-gold)]" />
           <span className="font-mono text-xs font-medium tracking-widest text-muted-foreground uppercase">
-            Open Data
+            Measurement · Phase 0
           </span>
         </div>
         <h1 className="font-serif text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-          Observability
+          Measurement
         </h1>
         <p className="mt-3 max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
-          Live API usage, MCP tool calls, Fundi self-healing activity, chaos test feed, and
-          component distribution by <span className="font-mono">ecosystem_node</span> — public by
-          design, aligned with the open data philosophy of the bundu ecosystem.
+          A research program is only as honest as its measurement. This page states how the Mzizi
+          framework will be measured — the Phase 0 benchmark metrics and the contract-test pattern
+          that verifies them — and shows the live composition of the benchmark corpus. No benchmark
+          has been run yet; when results exist they will be published here as open data, not
+          summarized in prose.
         </p>
-        <div className="mt-4 flex flex-wrap gap-3">
-          <a
-            href="/api/v1/stats"
-            className="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1 font-mono text-xs text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <Code className="size-3" />
-            GET /api/v1/stats
-          </a>
-          <a
-            href="/api/v1/stats?days=7"
-            className="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1 font-mono text-xs text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <Code className="size-3" />
-            GET /api/v1/stats?days=7
-          </a>
-        </div>
       </div>
 
-      {/* ── Health banner ─────────────────────────────────────────────── */}
-      <div
-        className={`mb-8 flex items-center gap-3 rounded-[var(--radius-xl)] border px-5 py-4 ${
-          errorRate === 0
-            ? "border-[var(--color-malachite)]/30 bg-[var(--color-malachite)]/5"
-            : errorRate < 2
-              ? "border-[var(--color-gold)]/30 bg-[var(--color-gold)]/5"
-              : "border-destructive/30 bg-destructive/5"
-        }`}
-      >
-        {errorRate === 0 ? (
-          <CheckCircle className="size-5 shrink-0 text-[var(--color-malachite)]" />
-        ) : (
-          <AlertTriangle className="size-5 shrink-0 text-[var(--color-gold)]" />
-        )}
-        <div>
-          <p className="text-sm font-semibold text-foreground">
-            {errorRate === 0
-              ? "All systems operational"
-              : errorRate < 2
-                ? "Elevated error rate — monitoring"
-                : "Degraded — investigating"}
-          </p>
-          <p className="text-xs text-muted-foreground">
-            {uptimePct(errorRate)} uptime over the last 30 days · {fmt(totalCalls)} total requests
-          </p>
-        </div>
-      </div>
-
-      {/* ── Good metrics ──────────────────────────────────────────────── */}
-      <div className="mb-4">
+      {/* ── The three benchmark metrics ─────────────────────────────────── */}
+      <div className="mb-8">
         <div className="mb-3 flex items-center gap-2">
-          <TrendingUp className="size-4 text-[var(--color-malachite)]" />
-          <h2 className="text-sm font-semibold text-foreground">Positive signals</h2>
+          <BarChart2 className="size-4 text-[var(--color-gold)]" />
+          <h2 className="text-sm font-semibold text-foreground">The Phase 0 benchmark metrics</h2>
         </div>
+        <p className="mb-4 max-w-2xl text-xs leading-relaxed text-muted-foreground">
+          One task, three arms: an agent authors the benchmark corpus in Mzizi syntax versus raw
+          Dioxus and Leptos. Every arm is scored on the same three metrics.
+        </p>
+        <div className="grid gap-4 sm:grid-cols-3">
+          {BENCHMARK_METRICS.map((m) => (
+            <div
+              key={m.label}
+              className="flex flex-col gap-2 rounded-[var(--radius-xl)] border border-border bg-card p-5"
+            >
+              <span className="font-mono text-[10px] tracking-widest text-[var(--color-gold)] uppercase">
+                {m.label}
+              </span>
+              <p className="text-xs leading-relaxed text-muted-foreground">{m.body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ── The contract-test pattern ───────────────────────────────────── */}
+      <div className="mb-8 rounded-[var(--radius-xl)] border border-border bg-card p-5">
+        <h3 className="mb-2 text-sm font-semibold text-foreground">
+          How a defect is caught: the contract test
+        </h3>
+        <p className="max-w-2xl text-xs leading-relaxed text-muted-foreground">
+          The corpus is fixed, known ground truth. Each component has a{" "}
+          <span className="text-foreground">reference implementation read from disk</span> and a
+          behavior contract derived from it. After the agent&apos;s output compiles, it runs against
+          the contract; anything that{" "}
+          <span className="text-foreground">compiles cleanly but fails the behavior contract</span>{" "}
+          is recorded as a defect. The compiler judges form; the contract judges behavior — a
+          benchmark that stopped at &ldquo;it compiles&rdquo; would reward exactly the failure mode
+          the research is trying to eliminate.
+        </p>
+      </div>
+
+      {/* ── Corpus composition ──────────────────────────────────────────── */}
+      {nodeDistribution.length > 0 && (
+        <div className="mb-8 rounded-[var(--radius-xl)] border border-border bg-card p-5">
+          <div className="mb-1 flex items-center gap-2">
+            <Boxes className="size-4 text-[var(--color-cobalt)]" />
+            <h3 className="text-sm font-semibold text-foreground">
+              Benchmark corpus composition ({fmt(corpusTotal)} components)
+            </h3>
+          </div>
+          <p className="mb-4 text-xs text-muted-foreground">
+            Every node and rung of the corpus taxonomy, read live from{" "}
+            <span className="font-mono">documentation-architecture-nodes</span> and counted by{" "}
+            <span className="font-mono">get_node_counts()</span>. This is the fixed component set
+            all three benchmark arms author against.
+          </p>
+          <NodeDistributionChart data={nodeDistribution} />
+          <div className="mt-3 flex flex-wrap gap-3 text-[10px] text-muted-foreground">
+            {legendClasses.map((helixClass) => (
+              <span key={helixClass} className="inline-flex items-center gap-1.5">
+                <span
+                  className="size-2 rounded-full"
+                  style={{
+                    background: HELIX_CLASS_COLOR[helixClass] ?? "var(--color-terracotta)",
+                  }}
+                />
+                <span className="font-mono">{helixClass}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── Corpus infrastructure telemetry ─────────────────────────────── */}
+      <div className="mb-8">
+        <div className="mb-3 flex items-center gap-2">
+          <Activity className="size-4 text-[var(--color-malachite)]" />
+          <h2 className="text-sm font-semibold text-foreground">Corpus infrastructure telemetry</h2>
+        </div>
+        <p className="mb-4 max-w-2xl text-xs leading-relaxed text-muted-foreground">
+          The corpus is served through a public API and MCP server so agents and researchers can
+          read the ground truth directly. This is telemetry for that infrastructure — not benchmark
+          results.
+        </p>
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           {[
             {
@@ -225,19 +202,14 @@ export default async function ObservabilityPage() {
             {
               label: "Avg response",
               value: avgMs > 0 ? `${avgMs}ms` : "—",
-              sub: avgMs < 200 ? "fast" : avgMs < 500 ? "good" : "needs work",
+              sub: avgMs > 0 ? "across API + MCP" : undefined,
               icon: Clock,
               accent: "text-[var(--color-malachite)]",
             },
             {
-              label: "Registry items",
-              value: counts.total > 0 ? fmt(counts.total) : "—",
-              sub:
-                totalNodes > 0
-                  ? `${counts.ui} UI · ${totalNodes} ecosystem_node`
-                  : counts.ui > 0
-                    ? `${counts.ui} UI · ${counts.blocks} blocks`
-                    : undefined,
+              label: "Error rate (30d)",
+              value: `${s?.overall_error_rate ?? 0}%`,
+              sub: s ? `${fmt(s.total_errors)} errors` : undefined,
               icon: Activity,
               accent: "text-[var(--color-gold)]",
             },
@@ -255,351 +227,22 @@ export default async function ObservabilityPage() {
             </div>
           ))}
         </div>
-      </div>
-
-      {/* ── Most popular components ───────────────────────────────────── */}
-      {(s?.top_components?.length ?? 0) > 0 && (
-        <div className="mb-8 rounded-[var(--radius-xl)] border border-border bg-card p-5">
-          <h3 className="mb-4 text-sm font-semibold text-foreground">Most requested components</h3>
-          <div className="space-y-2">
-            {s!.top_components.slice(0, 8).map((c, i) => {
-              const max = s!.top_components[0].total_calls
-              const pct = max > 0 ? (c.total_calls / max) * 100 : 0
-              return (
-                <div key={c.component_name} className="flex items-center gap-3">
-                  <span className="w-4 shrink-0 text-right font-mono text-xs text-muted-foreground">
-                    {i + 1}
-                  </span>
-                  <a
-                    href={`/components/${c.component_name}`}
-                    className="w-32 shrink-0 truncate font-mono text-xs text-foreground hover:text-[var(--color-cobalt)]"
-                  >
-                    {c.component_name}
-                  </a>
-                  <div className="min-w-0 flex-1 rounded-full bg-muted">
-                    <div
-                      className="h-1.5 rounded-full bg-[var(--color-cobalt)]"
-                      style={{ width: `${pct}%` }}
-                    />
-                  </div>
-                  <span className="w-10 shrink-0 text-right font-mono text-xs text-muted-foreground">
-                    {fmt(c.total_calls)}
-                  </span>
-                </div>
-              )
-            })}
-          </div>
-        </div>
-      )}
-
-      {/* ── Top MCP tools ─────────────────────────────────────────────── */}
-      {(s?.top_mcp_tools?.length ?? 0) > 0 && (
-        <div className="mb-8 rounded-[var(--radius-xl)] border border-border bg-card p-5">
-          <h3 className="mb-4 text-sm font-semibold text-foreground">Top MCP tools</h3>
-          <div className="grid gap-2 sm:grid-cols-2">
-            {s!.top_mcp_tools.slice(0, 6).map((t) => (
-              <div
-                key={t.tool_name}
-                className="flex items-center justify-between rounded-[var(--radius-md)] bg-muted/50 px-3 py-2"
-              >
-                <span className="font-mono text-xs text-foreground">{t.tool_name}</span>
-                <div className="flex items-center gap-3">
-                  {t.avg_duration_ms > 0 && (
-                    <span className="font-mono text-xs text-muted-foreground">
-                      {t.avg_duration_ms}ms avg
-                    </span>
-                  )}
-                  <span className="font-mono text-xs font-semibold text-foreground">
-                    {fmt(t.total_calls)}
-                  </span>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* ── Bad metrics ───────────────────────────────────────────────── */}
-      <div className="mb-8">
-        <div className="mb-3 flex items-center gap-2">
-          <TrendingDown className="size-4 text-destructive" />
-          <h2 className="text-sm font-semibold text-foreground">Error signals</h2>
-        </div>
-        <div className="grid gap-4 sm:grid-cols-3">
-          {[
-            {
-              label: "Total errors (30d)",
-              value: fmt(s?.total_errors ?? 0),
-              sub: "4xx + 5xx responses",
-              bad: (s?.total_errors ?? 0) > 0,
-            },
-            {
-              label: "Error rate",
-              value: `${s?.overall_error_rate ?? 0}%`,
-              sub: "% of all requests",
-              bad: (s?.overall_error_rate ?? 0) >= 1,
-            },
-            {
-              label: "Errors this week",
-              value: fmt(s7?.total_errors ?? 0),
-              sub: s7 ? `${s7.overall_error_rate}% of week traffic` : undefined,
-              bad: (s7?.total_errors ?? 0) > 0,
-            },
-          ].map((card) => (
-            <div
-              key={card.label}
-              className={`flex flex-col gap-2 rounded-[var(--radius-xl)] border bg-card p-5 ${
-                card.bad ? "border-destructive/30" : "border-border"
-              }`}
-            >
-              <span className="text-xs text-muted-foreground">{card.label}</span>
-              <span
-                className={`font-mono text-2xl font-semibold ${
-                  card.bad ? "text-destructive" : errorRateColor(0)
-                }`}
-              >
-                {card.value}
-              </span>
-              {card.sub && <span className="text-xs text-muted-foreground">{card.sub}</span>}
-            </div>
-          ))}
-        </div>
-      </div>
-
-      {/* ── Endpoint error breakdown ───────────────────────────────────── */}
-      {(s?.top_endpoints?.filter((e) => e.error_calls > 0).length ?? 0) > 0 && (
-        <div className="mb-8 rounded-[var(--radius-xl)] border border-destructive/20 bg-card p-5">
-          <h3 className="mb-4 text-sm font-semibold text-foreground">Endpoints with errors</h3>
-          <div className="space-y-2">
-            {s!.top_endpoints
-              .filter((e) => e.error_calls > 0)
-              .sort((a, b) => b.error_rate - a.error_rate)
-              .map((e) => (
-                <div key={e.endpoint} className="flex flex-wrap items-center gap-2 text-xs">
-                  <span className="min-w-0 flex-1 truncate font-mono text-foreground">
-                    {e.endpoint}
-                  </span>
-                  <span className="shrink-0 text-muted-foreground">{fmt(e.total_calls)} calls</span>
-                  <span className="shrink-0 text-destructive">{e.error_rate}% errors</span>
-                  <span className="shrink-0 text-muted-foreground">{e.p95_duration_ms}ms p95</span>
-                </div>
-              ))}
-          </div>
-        </div>
-      )}
-
-      {/* ── All endpoints table ────────────────────────────────────────── */}
-      {(s?.top_endpoints?.length ?? 0) > 0 && (
-        <div className="mb-8 rounded-[var(--radius-xl)] border border-border bg-card p-5">
-          <h3 className="mb-4 text-sm font-semibold text-foreground">All endpoints (30d)</h3>
-          <div className="overflow-x-auto">
-            <table className="w-full text-xs">
-              <thead>
-                <tr className="border-b border-border text-left">
-                  <th className="pr-4 pb-2 font-medium text-muted-foreground">Endpoint</th>
-                  <th className="pr-4 pb-2 text-right font-medium text-muted-foreground">Calls</th>
-                  <th className="pr-4 pb-2 text-right font-medium text-muted-foreground">Errors</th>
-                  <th className="pr-4 pb-2 text-right font-medium text-muted-foreground">Avg ms</th>
-                  <th className="pb-2 text-right font-medium text-muted-foreground">p95 ms</th>
-                </tr>
-              </thead>
-              <tbody>
-                {s!.top_endpoints.map((e) => (
-                  <tr key={e.endpoint} className="border-b border-border/50 last:border-0">
-                    <td className="py-2 pr-4 font-mono text-foreground">{e.endpoint}</td>
-                    <td className="py-2 pr-4 text-right font-mono text-foreground">
-                      {fmt(e.total_calls)}
-                    </td>
-                    <td
-                      className={`py-2 pr-4 text-right font-mono ${e.error_calls > 0 ? "text-destructive" : "text-[var(--color-malachite)]"}`}
-                    >
-                      {e.error_calls > 0 ? fmt(e.error_calls) : "0"}
-                    </td>
-                    <td className="py-2 pr-4 text-right font-mono text-muted-foreground">
-                      {e.avg_duration_ms}
-                    </td>
-                    <td className="py-2 text-right font-mono text-muted-foreground">
-                      {e.p95_duration_ms}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      )}
-
-      {/* ── Trend chart ────────────────────────────────────────────────── */}
-      {(s?.calls_by_day?.length ?? 0) > 0 && (
-        <div className="mb-8 rounded-[var(--radius-xl)] border border-border bg-card p-5">
-          <h3 className="mb-1 text-sm font-semibold text-foreground">API usage trend (30d)</h3>
-          <p className="mb-4 text-xs text-muted-foreground">
-            API calls · MCP tool calls · Errors — daily breakdown from{" "}
-            <span className="font-mono">usage_events</span>
-          </p>
-          <ObservabilityCharts data={s!.calls_by_day} />
-        </div>
-      )}
-
-      {/* ── Component distribution by ecosystem_node ───────────────────── */}
-      {nodeDistribution.length > 0 && (
-        <div className="mb-8 rounded-[var(--radius-xl)] border border-border bg-card p-5">
-          <div className="mb-1 flex items-center gap-2">
-            <Boxes className="size-4 text-[var(--color-cobalt)]" />
-            <h3 className="text-sm font-semibold text-foreground">
-              Component distribution by node
-            </h3>
-          </div>
-          <p className="mb-4 text-xs text-muted-foreground">
-            Every node and rung of the DNA double helix, read live from{" "}
-            <span className="font-mono">documentation-architecture-nodes</span> and counted by{" "}
-            <span className="font-mono">get_node_counts()</span>. Coloured by helix classification.
-          </p>
-          <NodeDistributionChart data={nodeDistribution} />
-          <div className="mt-3 flex flex-wrap gap-3 text-[10px] text-muted-foreground">
-            {legendClasses.map((helixClass) => (
-              <span key={helixClass} className="inline-flex items-center gap-1.5">
-                <span
-                  className="size-2 rounded-full"
-                  style={{
-                    background: HELIX_CLASS_COLOR[helixClass] ?? "var(--color-terracotta)",
-                  }}
-                />
-                <span className="font-mono">{helixClass}</span>
-              </span>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* ── Fundi recent issues ────────────────────────────────────────── */}
-      <div className="mb-8 rounded-[var(--radius-xl)] border border-border bg-card p-5">
-        <div className="mb-1 flex items-center gap-2">
-          <Wrench className="size-4 text-[var(--color-tanzanite)]" />
-          <h3 className="text-sm font-semibold text-foreground">Fundi · recent issues</h3>
-        </div>
-        <p className="mb-4 text-xs text-muted-foreground">
-          Self-healing actor at{" "}
+        <div className="mt-4 flex flex-wrap gap-3">
           <a
-            href="https://fundi.nyuchi.dev"
-            className="inline-flex items-center gap-1 font-mono text-foreground hover:text-[var(--color-cobalt)]"
-            target="_blank"
-            rel="noreferrer"
+            href="/api/v1/stats"
+            className="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1 font-mono text-xs text-muted-foreground transition-colors hover:text-foreground"
           >
-            fundi.nyuchi.dev
-            <ExternalLink className="size-3" />
-          </a>{" "}
-          · reading <span className="font-mono">fundi_issues</span>
-        </p>
-        {fundiIssues.length > 0 ? (
-          <div className="overflow-x-auto">
-            <table className="w-full text-xs">
-              <thead>
-                <tr className="border-b border-border text-left">
-                  <th className="pr-3 pb-2 font-medium text-muted-foreground">When</th>
-                  <th className="pr-3 pb-2 font-medium text-muted-foreground">Component</th>
-                  <th className="pr-3 pb-2 font-medium text-muted-foreground">Severity</th>
-                  <th className="pr-3 pb-2 font-medium text-muted-foreground">Error</th>
-                  <th className="pb-2 font-medium text-muted-foreground">Status</th>
-                </tr>
-              </thead>
-              <tbody>
-                {fundiIssues.map((issue) => (
-                  <tr key={issue.id} className="border-b border-border/50 last:border-0">
-                    <td className="py-2 pr-3 font-mono text-muted-foreground">
-                      {relTime(issue.created_at)}
-                    </td>
-                    <td className="py-2 pr-3 font-mono text-foreground">
-                      {issue.component_name ?? "—"}
-                    </td>
-                    <td className={`py-2 pr-3 font-mono ${severityColor(issue.severity)}`}>
-                      {issue.severity ?? "—"}
-                    </td>
-                    <td className="py-2 pr-3 font-mono text-muted-foreground">
-                      {issue.error_type ?? "—"}
-                    </td>
-                    <td className={`py-2 font-mono ${statusColor(issue.status)}`}>
-                      {issue.github_issue_url ? (
-                        <a
-                          className="inline-flex items-center gap-1 hover:underline"
-                          href={issue.github_issue_url}
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          {issue.status ?? "open"}
-                          <ExternalLink className="size-3" />
-                        </a>
-                      ) : (
-                        (issue.status ?? "open")
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        ) : (
-          <div className="flex items-center gap-3 rounded-[var(--radius-md)] border border-[var(--color-malachite)]/30 bg-[var(--color-malachite)]/5 px-4 py-3">
-            <ShieldCheck className="size-4 shrink-0 text-[var(--color-malachite)]" />
-            <p className="text-xs text-muted-foreground">
-              No recent Fundi issues — every surface is healthy.
-            </p>
-          </div>
-        )}
-      </div>
-
-      {/* ── Chaos test feed ────────────────────────────────────────────── */}
-      <div className="mb-8 rounded-[var(--radius-xl)] border border-border bg-card p-5">
-        <div className="mb-1 flex items-center gap-2">
-          <FlaskConical className="size-4 text-[var(--color-gold)]" />
-          <h3 className="text-sm font-semibold text-foreground">Chaos test feed</h3>
+            <Code className="size-3" />
+            GET /api/v1/stats
+          </a>
+          <a
+            href="/api/v1/stats?days=7"
+            className="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1 font-mono text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <Code className="size-3" />
+            GET /api/v1/stats?days=7
+          </a>
         </div>
-        <p className="mb-4 text-xs text-muted-foreground">
-          Injected and blocked faults from <span className="font-mono">chaos_events</span>
-        </p>
-        {chaosEvents.length > 0 ? (
-          <div className="space-y-2">
-            {chaosEvents.map((ev) => (
-              <div
-                key={ev.id}
-                className="flex flex-wrap items-center gap-2 rounded-[var(--radius-md)] bg-muted/40 px-3 py-2 text-xs"
-              >
-                <span className="w-16 shrink-0 font-mono text-muted-foreground">
-                  {relTime(ev.created_at)}
-                </span>
-                <span
-                  className={`shrink-0 rounded-full px-2 py-0.5 font-mono text-[10px] ${
-                    ev.event_type === "blocked"
-                      ? "bg-[var(--color-malachite)]/10 text-[var(--color-malachite)]"
-                      : ev.event_type === "injected"
-                        ? "bg-[var(--color-gold)]/10 text-[var(--color-gold)]"
-                        : "bg-muted text-muted-foreground"
-                  }`}
-                >
-                  {ev.event_type}
-                </span>
-                <span className="shrink-0 font-mono text-foreground">
-                  {ev.injection_kind ?? "—"}
-                </span>
-                <span className="min-w-0 flex-1 truncate font-mono text-muted-foreground">
-                  {ev.component_name ?? ev.page_path ?? ev.domain ?? ""}
-                </span>
-                {typeof ev.duration_ms === "number" && (
-                  <span className="shrink-0 font-mono text-muted-foreground">
-                    {ev.duration_ms}ms
-                  </span>
-                )}
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="flex items-center gap-3 rounded-[var(--radius-md)] border border-border bg-muted/30 px-4 py-3">
-            <Stethoscope className="size-4 shrink-0 text-muted-foreground" />
-            <p className="text-xs text-muted-foreground">
-              No chaos events recorded in the lookback window.
-            </p>
-          </div>
-        )}
       </div>
 
       {/* ── Empty state when no data ────────────────────────────────────── */}
@@ -608,7 +251,7 @@ export default async function ObservabilityPage() {
           <Activity className="mx-auto mb-4 size-10 text-muted-foreground/40" />
           <p className="font-semibold text-foreground">No usage data yet</p>
           <p className="mt-1 text-sm text-muted-foreground">
-            Metrics are recorded as the API and MCP server receive requests.
+            Telemetry is recorded as the corpus API and MCP server receive requests.
           </p>
           <a
             href="/api/v1/stats"
@@ -625,7 +268,8 @@ export default async function ObservabilityPage() {
         <a href="/api/v1/stats" className="underline-offset-4 hover:underline">
           Raw JSON
         </a>{" "}
-        available under CC BY 4.0
+        available under CC BY 4.0 · Benchmark results will be published the same way when Phase 0
+        runs
       </p>
     </div>
   )
@@ -642,16 +286,17 @@ function UnconfiguredState() {
     <div className="mx-auto max-w-5xl px-4 py-12 sm:px-6 sm:py-16">
       <div className="mb-8">
         <div className="mb-2 flex items-center gap-2">
-          <Activity className="size-5 text-[var(--color-cobalt)]" />
+          <FlaskConical className="size-5 text-[var(--color-gold)]" />
           <span className="font-mono text-xs font-medium tracking-widest text-muted-foreground uppercase">
-            Open Data
+            Measurement · Phase 0
           </span>
         </div>
         <h1 className="font-serif text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-          Observability
+          Measurement
         </h1>
         <p className="mt-3 max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
-          Public usage, Fundi, chaos, and registry telemetry for the Mzizi ecosystem.
+          The measurement discipline of the Mzizi research program: benchmark metrics, the
+          contract-test pattern, and live corpus composition.
         </p>
       </div>
       <div className="rounded-[var(--radius-xl)] border border-border bg-card px-8 py-16 text-center">
@@ -659,10 +304,8 @@ function UnconfiguredState() {
         <p className="font-semibold text-foreground">Database not configured</p>
         <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
           Set <span className="font-mono">NEXT_PUBLIC_SUPABASE_URL</span> and{" "}
-          <span className="font-mono">NEXT_PUBLIC_SUPABASE_ANON_KEY</span> to load live data from
-          the open-data tables (<span className="font-mono">usage_events</span>,{" "}
-          <span className="font-mono">fundi_issues</span>,{" "}
-          <span className="font-mono">chaos_events</span>,{" "}
+          <span className="font-mono">NEXT_PUBLIC_SUPABASE_ANON_KEY</span> to load the live corpus
+          composition and infrastructure telemetry (<span className="font-mono">usage_events</span>,{" "}
           <span className="font-mono">observability_events</span>).
         </p>
       </div>

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -2,7 +2,7 @@ import { renderMziziOg, OG_SIZE, OG_CONTENT_TYPE } from "@/lib/og/mzizi-og"
 
 // Node runtime: the shared template reads the site-icon PNG off disk.
 export const runtime = "nodejs"
-export const alt = "mzizi — open architecture on the Seven African Minerals design system"
+export const alt = "mzizi — a Rust framework for the agentic web, a Bundu Foundation research project"
 export const size = OG_SIZE
 export const contentType = OG_CONTENT_TYPE
 

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -2,7 +2,8 @@ import { renderMziziOg, OG_SIZE, OG_CONTENT_TYPE } from "@/lib/og/mzizi-og"
 
 // Node runtime: the shared template reads the site-icon PNG off disk.
 export const runtime = "nodejs"
-export const alt = "mzizi — a Rust framework for the agentic web, a Bundu Foundation research project"
+export const alt =
+  "mzizi — a Rust framework for the agentic web, a Bundu Foundation research project"
 export const size = OG_SIZE
 export const contentType = OG_CONTENT_TYPE
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ import { ExploreSection } from "@/components/landing/explore-section"
 export const metadata: Metadata = {
   title: "Mzizi",
   description:
-    "An open-architecture project of the Bundu Foundation — components, brand, MCP server, and AI-native developer tooling. Operated and developed by Nyuchi.",
+    "A Rust framework for the agentic web — a Bundu Foundation research project. Syntax, type system, and compiler feedback loop designed for machine authorship, measured against a fixed benchmark corpus.",
 }
 
 export const revalidate = 300

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -16,7 +16,7 @@ import { ComponentGallery } from "@/components/playground/component-gallery"
 export const metadata: Metadata = {
   title: "Playground",
   description:
-    "Interactive playground for the Mzizi component registry — live preview, variants, props inspector, and an API tester for every stable component.",
+    "Explore the benchmark corpus's reference implementations — live preview, variants, props inspector, and an API tester for every stable component.",
 }
 
 export const revalidate = 300
@@ -29,8 +29,9 @@ export default function PlaygroundPage() {
           Playground
         </h1>
         <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
-          Interactive playground for the full Mzizi registry. Pick a component to open its live
-          preview, browse its variants, and call the registry API live to fetch its source.
+          Explore the corpus's reference implementations — the behaviour the Mzizi framework's
+          output is judged against. Pick a component to open its live preview, browse its variants,
+          and call the registry API live to fetch its source.
         </p>
         <pre className="overflow-x-auto rounded-lg border border-border bg-muted/40 p-3 font-mono text-xs">
           <code>npx shadcn@latest add https://mzizi.dev/api/v1/ui/&lt;component-name&gt;</code>

--- a/app/skills/page.tsx
+++ b/app/skills/page.tsx
@@ -21,7 +21,7 @@ export const revalidate = 3600
 export const metadata: Metadata = {
   title: "Skills",
   description:
-    "Mzizi agent skills for AI assistants: install the @nyuchi/mzizi-skills bundle, the mzizi Claude Code plugin, or read any skill over HTTP and MCP.",
+    "Mzizi agent skills for AI assistants — the doctrine of the Mzizi research program, loadable on demand. Install the @nyuchi/mzizi-skills bundle, the mzizi Claude Code plugin, or read any skill over HTTP and MCP.",
 }
 
 const NPM_PACKAGE = "@nyuchi/mzizi-skills"
@@ -39,9 +39,10 @@ export default async function SkillsPage() {
           Agent skills
         </h1>
         <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
-          Doctrine an AI assistant can load on demand — the design system, the brand constellation,
-          and the engineering patterns behind the bundu ecosystem. Install the bundle once and any
-          assistant working in the repo has the rules on hand instead of guessing at them.
+          Doctrine an AI assistant can load on demand — the Mzizi framework&rsquo;s architecture,
+          the Phase 0 benchmark corpus, and the engineering patterns behind the Bundu ecosystem.
+          Install the bundle once and any assistant working in the repo has the research
+          program&rsquo;s rules on hand instead of guessing at them.
         </p>
       </header>
 

--- a/app/tokens/page.tsx
+++ b/app/tokens/page.tsx
@@ -6,7 +6,7 @@ export const revalidate = 3600
 export const metadata: Metadata = {
   title: "Colour tokens",
   description:
-    "The seven minerals and seven heritage tones — the Mzizi colour system, grouped by family, every value sourced live from the design database.",
+    "The benchmark corpus's design-token substrate — seven minerals and seven heritage tones, grouped by family, every value sourced live from the design database.",
 }
 
 const FAMILIES: { id: MineralToken["family"]; label: string; blurb: string }[] = [
@@ -177,11 +177,13 @@ export default function TokensPage() {
           Seven Minerals &amp; Seven Heritage
         </h1>
         <p className="max-w-2xl text-base text-muted-foreground">
-          The Mzizi palette layers three systems. <strong>Surfaces</strong> set the ambient page
-          ground and elevation ladder; <strong>seven minerals</strong> carry brand meaning — each
-          with a role and family; and <strong>seven heritage tones</strong> are atmospheric anchors
-          for surfaces and mood. Every value here is sourced live from the design database and is
-          theme-adaptive across light and dark.
+          The benchmark corpus's design-token substrate — the fixed colour ground every reference
+          component (and every Rust sibling) is rendered and contract-tested against. It layers
+          three systems: <strong>surfaces</strong> set the ambient page ground and elevation ladder;{" "}
+          <strong>seven minerals</strong> carry brand meaning — each with a role and family; and{" "}
+          <strong>seven heritage tones</strong> are atmospheric anchors for surfaces and mood. Every
+          value here is sourced live from the design database and is theme-adaptive across light and
+          dark.
         </p>
       </header>
 

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -17,7 +17,7 @@ export const revalidate = 3600
 export const metadata: Metadata = {
   title: "Tools",
   description:
-    "Published Mzizi tools — MCP server, SDK, skills bundle, and CLI. Install via npm or npx.",
+    "Published Mzizi tools — the agent-facing surface of the research program: MCP server, SDK, skills bundle, and CLI. Install via npm or npx.",
 }
 
 interface ToolCardData {
@@ -31,28 +31,30 @@ interface ToolCardData {
 const KNOWN_TOOLS: ToolCardData[] = [
   {
     name: "mzizi-mcp",
-    description: "Model Context Protocol server exposing the Mzizi registry to AI assistants.",
+    description:
+      "Model Context Protocol server giving AI assistants live access to the Phase 0 corpus, skills, and doctrine.",
     category: "mcp",
     status: "stable",
     version: null,
   },
   {
     name: "mzizi-sdk",
-    description: "TypeScript SDK for the Mzizi API — fetch components, brand tokens, and skills.",
+    description:
+      "TypeScript SDK for the Mzizi API — fetch corpus components, brand tokens, and skills.",
     category: "sdk",
     status: "alpha",
     version: null,
   },
   {
     name: "mzizi-skills",
-    description: "Markdown bundle of design-system skills for any AI assistant.",
+    description: "Markdown bundle of Mzizi doctrine skills for any AI assistant.",
     category: "skills",
     status: "stable",
     version: null,
   },
   {
     name: "mzizi-cli",
-    description: "Bootstrap and maintain Bundu ecosystem apps from the registry.",
+    description: "Bootstrap and maintain Bundu ecosystem apps from the Phase 0 corpus.",
     category: "cli",
     status: "stable",
     version: null,
@@ -101,8 +103,11 @@ export default async function ToolsPage() {
           Published Mzizi tools
         </h1>
         <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
-          The Mzizi distribution surface — MCP server, SDK, skills bundle, and CLI. Each tool is
-          installable via npm or npx and lives in the bundu ecosystem GitHub org.
+          The agent-facing surface of the Mzizi research program — MCP server, SDK, skills bundle,
+          and CLI. This is how agents (and people) read the Phase 0 benchmark corpus, the
+          architecture, and the doctrine today, and where the compiler toolchain lands as Phase 0
+          ships. Each tool is installable via npm or npx and lives in the Bundu ecosystem GitHub
+          org.
         </p>
       </header>
 

--- a/app/ubuntu/page.tsx
+++ b/app/ubuntu/page.tsx
@@ -18,7 +18,7 @@ export const revalidate = 3600
 export const metadata = {
   title: "Ubuntu",
   description:
-    "The Ubuntu doctrine of the Mukoko platform: Five Pillars (where Ubuntu is situated), Five Principles (how Ubuntu is embodied), and the Five Questions (the product decision filter). African scholarship, sovereign derivation.",
+    "The research ethos of the Bundu Foundation: Five Pillars (where Ubuntu is situated), Five Principles (how Ubuntu is embodied), and the Five Questions (the decision filter for the Mzizi research program). African scholarship, sovereign derivation.",
 }
 
 function PillarCard({ pillar }: { pillar: UbuntuPillarRow }) {
@@ -46,7 +46,7 @@ function PillarCard({ pillar }: { pillar: UbuntuPillarRow }) {
           </div>
           <div>
             <dt className="font-mono text-[10px] tracking-widest text-muted-foreground uppercase">
-              Platform surface
+              Surface
             </dt>
             <dd className="mt-1 text-foreground">{pillar.platform_surface}</dd>
           </div>
@@ -81,7 +81,7 @@ function PrincipleCard({ principle }: { principle: UbuntuPrincipleRow }) {
         <dl className="space-y-2 border-t border-border pt-3">
           <div>
             <dt className="font-mono text-[10px] tracking-widest text-muted-foreground uppercase">
-              Platform expression
+              Expression
             </dt>
             <dd className="mt-1 text-foreground">{principle.expression}</dd>
           </div>
@@ -136,7 +136,7 @@ export default async function UbuntuPage() {
       {/* ── 1. Ubuntu intro ─────────────────────────────────────────── */}
       <header className="mb-12">
         <p className="mb-3 font-mono text-[11px] tracking-widest text-muted-foreground sm:text-xs">
-          UBUNTU DOCTRINE
+          RESEARCH ETHOS · BUNDU FOUNDATION
         </p>
         <h1 className="mb-4 font-serif text-3xl font-bold tracking-tight text-foreground sm:text-4xl md:text-5xl">
           Ubuntu
@@ -151,12 +151,18 @@ export default async function UbuntuPage() {
           carries the same shape: ndiri nekuti tiri.
         </p>
         <p className="mt-4 max-w-2xl text-base leading-relaxed text-muted-foreground">
-          Ubuntu is the philosophical substrate of the Mukoko platform. It does not live at one node
-          of the architecture — it is the genetic code the whole helix is read from. The doctrine
-          has three five-fold expressions: <strong className="text-foreground">Pillars</strong>{" "}
-          (where Ubuntu is situated), <strong className="text-foreground">Principles</strong> (how
-          Ubuntu is embodied), and <strong className="text-foreground">Questions</strong> (the
-          decision filter that evaluates whether a product change ships).
+          Ubuntu is why Mzizi is structured the way it is. A framework for the agentic web could be
+          a company&apos;s proprietary moat; instead it is{" "}
+          <strong className="text-foreground">Bundu Foundation research</strong> — the framework IP
+          held by the Foundation, published under{" "}
+          <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">@bundu</code>, its
+          benchmark corpus open as community ground truth, its results published rather than
+          claimed. &ldquo;I am because we are&rdquo; is the working method: research that only means
+          something when the community can run it, check it, and build on it. The ethos has three
+          five-fold expressions: <strong className="text-foreground">Pillars</strong> (where Ubuntu
+          is situated), <strong className="text-foreground">Principles</strong> (how Ubuntu is
+          embodied), and <strong className="text-foreground">Questions</strong> (the decision filter
+          every research and design decision passes through).
         </p>
       </header>
 
@@ -207,9 +213,10 @@ export default async function UbuntuPage() {
             The Five Principles
           </h2>
           <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
-            The behavioural virtues that translate Ubuntu into software. From Lovemore Mbigi&apos;s
-            Collective Fingers Theory — <em>chara chimwe hachitswanyi inda</em>, one finger cannot
-            crush a louse. Rendered live from{" "}
+            The behavioural virtues that translate Ubuntu into a way of doing research. From
+            Lovemore Mbigi&apos;s Collective Fingers Theory —{" "}
+            <em>chara chimwe hachitswanyi inda</em>, one finger cannot crush a louse. Rendered live
+            from{" "}
             <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
               ubuntu_principles
             </code>
@@ -248,8 +255,8 @@ export default async function UbuntuPage() {
           </h2>
           <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
             The Pillars name the spheres. The Principles name the virtues. The Questions evaluate
-            every product decision against both. A change that fails any one of these questions does
-            not ship. Stored in{" "}
+            every decision in the research program against both — a language feature, a benchmark
+            rule, a publication. A decision that fails any one of them does not proceed. Stored in{" "}
             <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
               brand_meta.philosophy.ubuntuQuestions
             </code>
@@ -337,7 +344,7 @@ export default async function UbuntuPage() {
           Restorative justice is not one of the five principles. It is a modern American framework
           developed in juvenile justice and therapeutic discourse, not an African one. Ubuntu
           addresses harm through the continuous practice of the virtues above, not through a
-          separate remedial process. The community does not define itself by how it handles
+          separate remedial process. The research community does not define itself by how it handles
           wrongdoing — it defines itself by how it lives.
         </blockquote>
       </section>

--- a/components/landing/ai-native-section.tsx
+++ b/components/landing/ai-native-section.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import { Section, SectionHeader } from "@/components/landing/section"
-import { Check, Copy, Bot, Zap, BarChart2, Terminal } from "lucide-react"
+import { Check, Copy, Bot, Zap, BarChart2, FlaskConical } from "lucide-react"
 import { LiveMcpStats } from "@/components/live-mcp-stats"
 
 function CopySnippet({ code, label }: { code: string; label: string }) {
@@ -40,23 +40,23 @@ const mcpConfig = `{
   }
 }`
 
-const skillUsage = `# In any Claude Code session:
-/nyuchi-design
-/bundu-design
-/mukoko-design
+const benchmarkProtocol = `# Phase 0 — same agent, same corpus, three languages
+subjects:  Mzizi syntax · raw Dioxus · Leptos
+corpus:    this registry, reauthored end to end
+metrics:   tokens consumed
+           iterations to a clean compile
+           defect rate*
 
-# Or ask Claude directly:
-@mzizi get_component button
-@mzizi scaffold_component data-table`
+* defect = compiles cleanly, behaviorally wrong`
 
 export function AiNativeSection() {
   return (
     <Section>
       <SectionHeader
         align="center"
-        eyebrow="AI-native"
-        title="Your design system, inside your AI assistant"
-        sub="Mzizi ships with a Model Context Protocol server and a Claude Code skill. Your AI assistant can browse components, generate scaffolds, and fetch source code — without leaving the conversation."
+        eyebrow="Machine authorship"
+        title="Designed for the author that never sleeps"
+        sub="The framework's thesis is that agents are the primary authors of the next web — so the project itself is run that way. The corpus is exposed to agents over MCP, the benchmark is defined in the open, and the telemetry is public."
       />
 
       <div className="mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
@@ -74,8 +74,9 @@ export function AiNativeSection() {
             </div>
           </div>
           <p className="text-xs leading-relaxed text-muted-foreground">
-            Connect Claude Code, Cursor, or any MCP-compatible assistant to the full component
-            registry. Browse, search, scaffold, and fetch source — live from the database.
+            Connect Claude Code, Cursor, or any MCP-compatible assistant to the benchmark corpus.
+            Browse, search, and fetch component source — the same fixed component set the framework
+            is measured against, live from the database.
           </p>
           <CopySnippet code={mcpConfig} label=".claude/settings.json" />
           <div className="mt-auto grid grid-cols-2 gap-1.5">
@@ -97,39 +98,30 @@ export function AiNativeSection() {
           </div>
         </div>
 
-        {/* Claude Code Skill */}
+        {/* The benchmark */}
         <div className="flex flex-col gap-4 rounded-[var(--radius-xl)] border border-border bg-card p-6">
           <div className="flex items-center gap-3">
             <div className="flex size-10 items-center justify-center rounded-[var(--radius-md)] bg-[var(--color-tanzanite)]/10">
-              <Terminal className="size-5 text-[var(--color-tanzanite)]" />
+              <FlaskConical className="size-5 text-[var(--color-tanzanite)]" />
             </div>
             <div>
-              <h3 className="text-sm font-semibold text-foreground">Claude Code Skill</h3>
-              <p className="text-xs text-muted-foreground">Slash command · Design system aware</p>
+              <h3 className="text-sm font-semibold text-foreground">The Benchmark</h3>
+              <p className="text-xs text-muted-foreground">Phase 0 · Defined before the results</p>
             </div>
           </div>
           <p className="text-xs leading-relaxed text-muted-foreground">
-            Three design skills —{" "}
-            <code className="rounded bg-muted px-1 py-0.5 font-mono text-[10px]">
-              nyuchi-design
-            </code>
-            ,{" "}
-            <code className="rounded bg-muted px-1 py-0.5 font-mono text-[10px]">bundu-design</code>
-            ,{" "}
-            <code className="rounded bg-muted px-1 py-0.5 font-mono text-[10px]">
-              mukoko-design
-            </code>{" "}
-            — teach Claude Code the Seven African Minerals palette, component patterns, Ubuntu
-            design principles, and APCA accessibility standards.
+            One experiment scores the whole thesis: an LLM agent authors Mzizi&apos;s own component
+            corpus in Mzizi syntax versus raw Dioxus and Leptos. The protocol is fixed up front, so
+            the numbers — good or bad — mean something.
           </p>
-          <CopySnippet code={skillUsage} label="Usage" />
+          <CopySnippet code={benchmarkProtocol} label="Benchmark protocol" />
           <ul className="mt-auto space-y-1.5 text-xs text-muted-foreground">
             {[
-              "Seven African Minerals palette",
-              "CVA + Radix + cn() patterns",
-              "Ubuntu design checklist",
-              "APCA Lc 90+ contrast guide",
-              "56px touch target enforcement",
+              "Fixed corpus — no cherry-picked tasks",
+              "Same agent and harness for every language",
+              "Tokens, iterations, and defects all reported",
+              "Contract tests define “behaviorally wrong”",
+              "Results published raw, not as marketing",
             ].map((f) => (
               <li key={f} className="flex items-center gap-2">
                 <span className="size-1 shrink-0 rounded-full bg-[var(--color-tanzanite)]" />
@@ -151,9 +143,9 @@ export function AiNativeSection() {
             </div>
           </div>
           <p className="text-xs leading-relaxed text-muted-foreground">
-            Usage metrics are public — aligned with the bundu open data philosophy. See which
-            components are most installed, API latency, error rates, and MCP tool usage in real
-            time.
+            Research telemetry is public — aligned with the Bundu open data philosophy. Corpus
+            usage, API latency, error rates, and MCP tool traffic are live today; Phase 0 benchmark
+            results land here when they exist.
           </p>
           <div className="space-y-2">
             <a
@@ -173,11 +165,11 @@ export function AiNativeSection() {
           </div>
           <ul className="mt-auto space-y-1.5 text-xs text-muted-foreground">
             {[
-              "Most installed components",
+              "Corpus usage and install counts",
               "API call volumes + latency",
               "MCP tool usage breakdown",
               "Error rates by endpoint",
-              "30-day traffic trends",
+              "Benchmark results, when they land",
             ].map((f) => (
               <li key={f} className="flex items-center gap-2">
                 <span className="size-1 shrink-0 rounded-full bg-[var(--color-malachite)]" />

--- a/components/landing/build-with-section.tsx
+++ b/components/landing/build-with-section.tsx
@@ -1,141 +1,123 @@
 import Link from "next/link"
 import { Button } from "@/components/registry/n2-primitives/button"
 import { ArrowRight } from "lucide-react"
-import { CopyCommand } from "@/components/landing/copy-command"
-import { LiveMcpStats } from "@/components/live-mcp-stats"
 import { Section, SectionHeader } from "@/components/landing/section"
 
 /**
- * "Build with the design portal" — five-step orientation for any developer
- * landing here. Each step is concrete and links to the canonical doc/page,
- * so a new visitor can go from zero to shipping a Five-African-Minerals
- * page without leaving the portal.
- *
- * Sits on the landing between InstallSteps (which only covers the shadcn
- * CLI install) and AiNativeSection (which covers the MCP + skills layer).
- * InstallSteps says "how to install one component"; this section says
- * "what does building a whole app look like".
+ * The research program — the five phases of the charter, in order. Each card
+ * states what the phase produces and links to where progress can be followed.
+ * Phase 0 is the current phase; nothing beyond it is presented as shipped.
  */
 export function BuildWithSection() {
   return (
     <Section bordered muted>
       <SectionHeader
-        eyebrow="Build with the portal"
-        title="Five steps from new repo to shipped page"
-        sub="The portal is a registry, a token system, an MCP server, and a set of installable Claude Code skills. You don't pull a package — you pull exactly the pieces you need and own the source. Here's the full authoring loop."
+        eyebrow="The research program"
+        title="Five phases, benchmark first"
+        sub="Mzizi ships as evidence before it ships as software. The compiler is proven against a fixed corpus before rendering, edge deployment, ML, and distribution are layered on — each phase gated by the one before it."
       />
 
       <ol className="mt-12 grid gap-4 sm:gap-6 md:grid-cols-2 lg:grid-cols-3">
         <li className="flex flex-col gap-3 rounded-2xl border border-border bg-background p-6">
-          <span className="font-mono text-xs text-muted-foreground">01</span>
-          <h3 className="font-serif text-xl font-semibold">Install a component</h3>
+          <span className="font-mono text-xs text-muted-foreground">PHASE 0 · NOW</span>
+          <h3 className="font-serif text-xl font-semibold">Compiler prototype + benchmark</h3>
           <p className="text-sm leading-relaxed text-muted-foreground">
-            Every registry item is installable through the shadcn CLI. The CLI copies the source
-            into your repo — you own and modify it freely.
+            The syntax and compiler prototype, scored by one experiment: an LLM agent reauthors the
+            corpus in Mzizi syntax vs. raw Dioxus and Leptos — measured on tokens consumed,
+            iterations to a clean compile, and defect rate (a defect compiles cleanly but is
+            behaviorally wrong).
           </p>
-          <CopyCommand command="npx shadcn@latest add https://mzizi.dev/api/v1/ui/button" />
           <Link
             href="/components"
-            className="mt-1 inline-flex items-center gap-1 text-xs font-medium text-foreground hover:underline"
-          >
-            Browse the live registry <ArrowRight className="size-3" />
-          </Link>
-        </li>
-
-        <li className="flex flex-col gap-3 rounded-2xl border border-border bg-background p-6">
-          <span className="font-mono text-xs text-muted-foreground">02</span>
-          <h3 className="font-serif text-xl font-semibold">Adopt the tokens</h3>
-          <p className="text-sm leading-relaxed text-muted-foreground">
-            Copy the <code className="font-mono text-xs">:root</code> and{" "}
-            <code className="font-mono text-xs">.dark</code> blocks from{" "}
-            <code className="font-mono text-xs">app/globals.css</code> — Seven African Minerals,
-            semantic colors, typography, radius scale. Every component reads from these CSS
-            variables.
-          </p>
-          <Link
-            href="https://docs.bundu.org/mzizi/brand"
-            target="_blank"
-            rel="noopener noreferrer"
             className="mt-auto inline-flex items-center gap-1 text-xs font-medium text-foreground hover:underline"
           >
-            Brand &amp; tokens reference <ArrowRight className="size-3" />
+            The benchmark corpus <ArrowRight className="size-3" />
           </Link>
         </li>
 
         <li className="flex flex-col gap-3 rounded-2xl border border-border bg-background p-6">
-          <span className="font-mono text-xs text-muted-foreground">03</span>
-          <h3 className="font-serif text-xl font-semibold">Wire the MCP server</h3>
+          <span className="font-mono text-xs text-muted-foreground">PHASE 1</span>
+          <h3 className="font-serif text-xl font-semibold">Dioxus rendering interop</h3>
           <p className="text-sm leading-relaxed text-muted-foreground">
-            Add <code className="font-mono text-xs">https://mzizi.dev/mcp</code> to your Claude Code
-            settings. <LiveMcpStats /> let your AI assistant install components, scaffold new ones,
-            look up tokens, and read live docs without round-tripping to the browser.
-          </p>
-          <Link
-            href="https://docs.bundu.org/mzizi/mcp"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-auto inline-flex items-center gap-1 text-xs font-medium text-foreground hover:underline"
-          >
-            MCP server reference <ArrowRight className="size-3" />
-          </Link>
-        </li>
-
-        <li className="flex flex-col gap-3 rounded-2xl border border-border bg-background p-6">
-          <span className="font-mono text-xs text-muted-foreground">04</span>
-          <h3 className="font-serif text-xl font-semibold">Install the skills</h3>
-          <p className="text-sm leading-relaxed text-muted-foreground">
-            Three design skills ship in the{" "}
-            <code className="font-mono text-xs">@nyuchi/mzizi-skills</code> bundle:{" "}
-            <code className="font-mono text-xs">nyuchi-design</code>,{" "}
-            <code className="font-mono text-xs">bundu-design</code>,{" "}
-            <code className="font-mono text-xs">mukoko-design</code>. Run{" "}
-            <code className="font-mono text-xs">npx skills add @nyuchi/mzizi-skills</code> and the
-            router activates them automatically.
-          </p>
-          <Link
-            href="https://docs.bundu.org/mzizi/skills"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-auto inline-flex items-center gap-1 text-xs font-medium text-foreground hover:underline"
-          >
-            Skill install guide <ArrowRight className="size-3" />
-          </Link>
-        </li>
-
-        <li className="flex flex-col gap-3 rounded-2xl border border-border bg-background p-6">
-          <span className="font-mono text-xs text-muted-foreground">05</span>
-          <h3 className="font-serif text-xl font-semibold">Ship and observe</h3>
-          <p className="text-sm leading-relaxed text-muted-foreground">
-            The N8 assurance node surfaces runtime failures across the ecosystem. Run{" "}
-            <code className="font-mono text-xs">pnpm check</code> before every push to mirror the
-            full CI gate locally.
+            Rendering interops with <code className="font-mono text-xs">Dioxus</code> — Mzizi does
+            not rebuild a renderer. The output is a standalone compiled artifact: WASM for the web,
+            native for desktop, embeddable anywhere with no host framework required.
           </p>
           <Link
             href="/architecture"
             className="mt-auto inline-flex items-center gap-1 text-xs font-medium text-foreground hover:underline"
           >
-            The DNA double helix <ArrowRight className="size-3" />
+            Integration posture <ArrowRight className="size-3" />
+          </Link>
+        </li>
+
+        <li className="flex flex-col gap-3 rounded-2xl border border-border bg-background p-6">
+          <span className="font-mono text-xs text-muted-foreground">PHASE 2</span>
+          <h3 className="font-serif text-xl font-semibold">Edge deployment</h3>
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            Edge-first on Cloudflare Workers via{" "}
+            <code className="font-mono text-xs">workers-rs</code>. The same WASM artifact that runs
+            in a browser deploys to the edge — the agentic web is served from where the agents are.
+          </p>
+          <Link
+            href="https://docs.bundu.org/mzizi"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-auto inline-flex items-center gap-1 text-xs font-medium text-foreground hover:underline"
+          >
+            Charter documentation <ArrowRight className="size-3" />
+          </Link>
+        </li>
+
+        <li className="flex flex-col gap-3 rounded-2xl border border-border bg-background p-6">
+          <span className="font-mono text-xs text-muted-foreground">PHASE 3</span>
+          <h3 className="font-serif text-xl font-semibold">ML via Candle</h3>
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            Machine learning runs through <code className="font-mono text-xs">Candle</code> — not a
+            competing tensor runtime. The language makes inference reachable; the runtime stays
+            someone else&apos;s well-solved problem.
+          </p>
+          <Link
+            href="https://docs.bundu.org/mzizi"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-auto inline-flex items-center gap-1 text-xs font-medium text-foreground hover:underline"
+          >
+            Charter documentation <ArrowRight className="size-3" />
+          </Link>
+        </li>
+
+        <li className="flex flex-col gap-3 rounded-2xl border border-border bg-background p-6">
+          <span className="font-mono text-xs text-muted-foreground">PHASE 4</span>
+          <h3 className="font-serif text-xl font-semibold">Distribution adapters</h3>
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            Astro and other frameworks become thin optional adapters around the standalone artifact
+            — distribution channels, not compile targets — published under the{" "}
+            <code className="font-mono text-xs">@bundu</code> npm scope.
+          </p>
+          <Link
+            href="https://docs.bundu.org/mzizi"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-auto inline-flex items-center gap-1 text-xs font-medium text-foreground hover:underline"
+          >
+            Charter documentation <ArrowRight className="size-3" />
           </Link>
         </li>
 
         <li className="flex flex-col items-start justify-between gap-4 rounded-2xl border border-foreground/10 bg-foreground/5 p-6">
           <div>
-            <span className="font-mono text-xs text-muted-foreground">NEXT</span>
-            <h3 className="mt-3 font-serif text-xl font-semibold">Bootstrap a whole new app</h3>
+            <span className="font-mono text-xs text-muted-foreground">STATUS</span>
+            <h3 className="mt-3 font-serif text-xl font-semibold">Where the project stands</h3>
             <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-              Going from <code className="font-mono text-xs">create-next-app</code> to a
-              portal-consuming production build? The{" "}
-              <code className="font-mono text-xs">ecosystem-app-setup</code> skill walks Claude Code
-              through the eight setup steps end-to-end.
+              This is a research charter in Phase 0. The language and compiler are being designed
+              now — there is no toolchain to install yet, and no benchmark numbers to quote. What
+              exists today is the corpus, the charter, and the telemetry on this site.
             </p>
           </div>
           <Button asChild className="rounded-full">
-            <Link
-              href="https://docs.bundu.org/mzizi/installation"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Read the installation guide
+            <Link href="/architecture">
+              Read the research charter
               <ArrowRight className="size-4" />
             </Link>
           </Button>

--- a/components/landing/component-showcase.tsx
+++ b/components/landing/component-showcase.tsx
@@ -5,10 +5,11 @@ import { readComponent } from "@/lib/registry"
 import { Section, SectionHeader } from "@/components/landing/section"
 
 /**
- * Live component band — show, don't tell. A curated grid of *actual* rendered
- * components, so a first-time visitor sees the quality on the landing rather than
- * reading about it. Only self-contained, non-modal components are featured so nothing
- * opens an overlay from the grid.
+ * Live corpus band — show, don't tell. A curated grid of *actual* rendered
+ * components from the benchmark corpus, so a first-time visitor sees that the
+ * proving ground is real, running software — not a synthetic task list. Only
+ * self-contained, non-modal components are featured so nothing opens an
+ * overlay from the grid.
  *
  * A server component: it resolves each featured item to the file that implements it,
  * then hands that to AutoPreview (a client component) to render. Previously it pulled
@@ -34,9 +35,9 @@ export function ComponentShowcase() {
   return (
     <Section bordered>
       <SectionHeader
-        eyebrow="The library"
-        title="Components that look shipped, out of the box"
-        sub="Real components, rendered live — theme-adaptive, accessible, and installed straight into your repo with the shadcn CLI. This is the same registry your AI assistant reads."
+        eyebrow="The proving ground"
+        title="The benchmark corpus, rendered live"
+        sub="Mzizi is measured against a fixed component set: this registry. In Phase 0, an LLM agent reauthors these exact components — in Mzizi syntax, in raw Dioxus, in Leptos — and the results are compared. Real, running components make an honest benchmark; here is a sample of the corpus."
       />
 
       <div className="mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -70,7 +71,7 @@ export function ComponentShowcase() {
           href="/components"
           className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground hover:underline"
         >
-          Browse all components
+          Browse the full corpus
           <ArrowRight className="size-4" />
         </Link>
       </div>

--- a/components/landing/explore-section.tsx
+++ b/components/landing/explore-section.tsx
@@ -13,11 +13,11 @@ export async function ExploreSection() {
 
   const sections = [
     {
-      title: "Components",
+      title: "Benchmark corpus",
       description:
         counts.ui > 0
-          ? `${counts.ui} production-ready UI components. Browse, preview, and install.`
-          : "Production-ready UI components. Browse, preview, and install.",
+          ? `${counts.ui} live UI components — the fixed proving ground the framework is measured against.`
+          : "Live UI components — the fixed proving ground the framework is measured against.",
       href: "/components",
       icon: Layers,
       mineral: "bg-[var(--color-cobalt)]",
@@ -25,8 +25,8 @@ export async function ExploreSection() {
       external: false,
     },
     {
-      title: "Architecture",
-      description: "The open Mzizi DNA double helix — nodes on strands, plus cross-cutting rungs.",
+      title: "Research charter",
+      description: "The full charter — the thesis, the four design goals, and the five phases.",
       href: "/architecture",
       icon: Box,
       mineral: "bg-[var(--color-tanzanite)]",
@@ -34,7 +34,8 @@ export async function ExploreSection() {
     },
     {
       title: "Observability",
-      description: "Live usage metrics for the registry, the API, and the MCP server.",
+      description:
+        "Live telemetry for the corpus, the API, and the MCP server — benchmark results land here.",
       href: "/observability",
       icon: Activity,
       mineral: "bg-[var(--color-malachite)]",
@@ -42,15 +43,15 @@ export async function ExploreSection() {
     },
     {
       title: "Documentation",
-      description: "Installation, theming, CLI, and contributing guides.",
+      description: "The charter in long form — goals, phasing, and integration posture.",
       href: "https://docs.bundu.org/mzizi",
       icon: BookOpen,
       mineral: "bg-[var(--color-gold)]",
       external: true,
     },
     {
-      title: "API & Registry",
-      description: "REST API, MCP server, and the OpenAPI contract.",
+      title: "API & MCP",
+      description: "REST API, MCP server, and the OpenAPI contract — the corpus, machine-readable.",
       href: "/api/v1",
       icon: Code,
       mineral: "bg-[var(--color-terracotta)]",
@@ -63,8 +64,8 @@ export async function ExploreSection() {
       <SectionHeader
         align="center"
         eyebrow="Explore"
-        title="Everything you need to build"
-        sub="Design system, component library, architecture reference, and developer docs — all in one place."
+        title="Follow the research"
+        sub="The corpus, the charter, the telemetry, and the agent surfaces — everything measurable about the project, in one place."
       />
 
       <div className="mt-12 grid gap-4 sm:grid-cols-2 md:grid-cols-3">

--- a/components/landing/footer.tsx
+++ b/components/landing/footer.tsx
@@ -24,7 +24,7 @@ const columns: FooterColumn[] = [
   {
     title: "Explore",
     links: [
-      { label: "Components", href: "/components" },
+      { label: "Benchmark corpus", href: "/components" },
       { label: "Colour tokens", href: "/tokens" },
       { label: "Playground", href: "/playground" },
       { label: "Tools", href: "/tools" },
@@ -156,7 +156,8 @@ export function Footer() {
           <div className="flex flex-col gap-4">
             <NyuchiLogo size={28} showWordmark suffix="mzizi" />
             <p className="max-w-sm text-sm leading-relaxed text-muted-foreground">
-              Mzizi — an open-architecture project of the Bundu Foundation, operated and developed
+              Mzizi — a Rust framework for the agentic web. A research project of the Bundu
+              Foundation (the framework is Foundation IP); the Fundi console is owned and operated
               by Nyuchi. Built on the Seven African Minerals palette.
             </p>
             <div className="flex items-center gap-2 pt-1" aria-label="Seven African Minerals">

--- a/components/landing/harness-section.tsx
+++ b/components/landing/harness-section.tsx
@@ -1,55 +1,54 @@
-import { Activity, Accessibility, Sparkles, Shield, HeartPulse, Languages } from "lucide-react"
+import { Layers, Cpu, Zap, Box, Monitor, Puzzle } from "lucide-react"
 import { Section, SectionHeader } from "@/components/landing/section"
 
 /**
- * The Harness spotlight — Mzizi's differentiator. Component libraries ship
- * components; Mzizi ships the *spine* that wires every component to
- * infrastructure with zero config. The harness IS the `spine` strand on the
- * engineering backbone: it pre-wires N3 brand, N4 safety and N5 resilience
- * to observability, a11y, motion and resilience.
+ * Integration posture — Mzizi is a language and compiler, not a parallel
+ * universe. Rendering, ML, and deployment are borrowed from the best of the
+ * Rust ecosystem so the research budget goes where the thesis lives: syntax,
+ * type system, and the compiler feedback loop.
  */
 
-const capabilities: Array<{
-  icon: typeof Activity
+const integrations: Array<{
+  icon: typeof Layers
   name: string
   mineral: string
   desc: string
 }> = [
   {
-    icon: Activity,
-    name: "Observability",
+    icon: Layers,
+    name: "Rendering — Dioxus",
     mineral: "cobalt",
-    desc: "A scoped logger per component and render timing, reported to the health monitor.",
+    desc: "Mzizi compiles to Dioxus's component model. No rebuilt renderer — that problem is already solved.",
   },
   {
-    icon: Accessibility,
-    name: "Accessibility",
+    icon: Box,
+    name: "Artifact — WASM",
     mineral: "malachite",
-    desc: "Auto-mounted aria-live region, announce(), and focus-ring tokens — for free.",
+    desc: "The compiled output is standalone WASM — embeddable in any host page, framework or none.",
   },
   {
-    icon: Sparkles,
-    name: "Motion",
-    mineral: "tanzanite",
-    desc: "Entry animation from the motion tokens, automatically honouring reduced-motion.",
-  },
-  {
-    icon: Shield,
-    name: "Error boundary",
-    mineral: "copper",
-    desc: "A branded fallback with retry and structured error tracking around every section.",
-  },
-  {
-    icon: HeartPulse,
-    name: "Health",
-    mineral: "gold",
-    desc: "Reports healthy / degraded / error / loading to the global health monitor.",
-  },
-  {
-    icon: Languages,
-    name: "Locale",
+    icon: Monitor,
+    name: "Native — desktop",
     mineral: "sodalite",
-    desc: "Text direction (RTL/LTR) and a string-token accessor via useLocale.",
+    desc: "The same program also compiles native for desktop. One corpus, two artifacts, zero rewrites.",
+  },
+  {
+    icon: Zap,
+    name: "Edge — Workers",
+    mineral: "gold",
+    desc: "Edge-first on Cloudflare Workers via workers-rs — the default deployment target, not an afterthought.",
+  },
+  {
+    icon: Cpu,
+    name: "ML — Candle",
+    mineral: "copper",
+    desc: "Inference runs through Candle. Mzizi makes tensors reachable from the language; it doesn't compete with the runtime.",
+  },
+  {
+    icon: Puzzle,
+    name: "Adapters — Astro & co.",
+    mineral: "tanzanite",
+    desc: "Astro and other frameworks are thin optional adapters around the artifact — distribution, never compile targets.",
   },
 ]
 
@@ -57,36 +56,39 @@ export function HarnessSection() {
   return (
     <Section bordered muted>
       <SectionHeader
-        eyebrow="The helix"
-        title="One harness wires every component"
-        sub="Other libraries hand you components. Mzizi ships the spine that connects them to infrastructure — observability, accessibility, motion, resilience and health — with zero config. Wrap a section or call the hook; everything else is wired."
+        eyebrow="Integration posture"
+        title="Interop, not reinvention"
+        sub="Mzizi is a language and a compiler — not a renderer, a tensor runtime, or a hosting platform. Everything below the language is borrowed from the Rust ecosystem, so the research budget stays on the thesis: syntax, types, and the feedback loop."
       />
 
       <div className="mt-10 grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)] lg:items-start">
-        {/* Usage — show, don't tell */}
+        {/* The contract — show what the corpus is held to, honestly */}
         <div className="flex flex-col gap-3">
           <span className="font-mono text-xs tracking-widest text-muted-foreground uppercase">
-            Drop-in
+            The contract
           </span>
           <pre className="overflow-x-auto rounded-xl border border-border bg-background p-4 font-mono text-xs leading-relaxed">
-            <code>{`// Declarative — wrap any section
-<NyuchiHarness name="events-feed" skeleton={<FeedSkeleton />}>
-  <EventsFeed />
-</NyuchiHarness>
-
-// Imperative — inside a component
-const { log, motion, announce } = useNyuchiHarness("listing-card")`}</code>
+            <code>{`// The oracle behind the Phase 0 defect metric: every corpus
+// component carries a behavioral contract test (Rust/Dioxus).
+#[test]
+fn button_outline_contract() {
+    let dom = render(rsx! {
+        Button { variant: Variant::Outline, "Ship it" }
+    });
+    assert_eq!(dom.roles("button").count(), 1);
+    assert!(dom.meets_contrast(Apca::Lc90));
+}`}</code>
           </pre>
           <p className="text-sm leading-relaxed text-muted-foreground">
-            Tokens (N1) and primitives (N2) stay pure. Brand (N3), safety (N4) and resilience (N5)
-            components plug into the same harness — so behaviour is consistent across the whole
-            system, not re-implemented per component.
+            &quot;Compiles cleanly but behaviorally wrong&quot; is only measurable if behavior is
+            pinned down. Contract tests like this one define correctness per component — the same
+            oracle scores the agent&apos;s output in Mzizi syntax, raw Dioxus, and Leptos.
           </p>
         </div>
 
-        {/* Capabilities */}
+        {/* Integration surface */}
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-          {capabilities.map((c) => {
+          {integrations.map((c) => {
             const Icon = c.icon
             return (
               <div

--- a/components/landing/hero.tsx
+++ b/components/landing/hero.tsx
@@ -1,7 +1,6 @@
 import { Button } from "@/components/registry/n2-primitives/button"
 import { Badge } from "@/components/registry/n2-primitives/badge"
 import { ArrowRight } from "lucide-react"
-import { CopyCommand } from "@/components/landing/copy-command"
 import { getRegistryCounts } from "@/lib/db"
 
 const minerals = [
@@ -35,7 +34,7 @@ export async function Hero() {
     lib: 0,
   }))
 
-  const totalLabel = counts.total > 0 ? `${counts.total}` : "production-ready"
+  const corpusLabel = counts.total > 0 ? `${counts.total}-component` : "fixed"
 
   return (
     <section className="relative flex flex-col items-center gap-8 px-4 pt-12 pb-16 text-center sm:gap-10 sm:px-6 md:pt-20 md:pb-32">
@@ -54,7 +53,7 @@ export async function Hero() {
             ))}
           </span>
           <span className="truncate text-muted-foreground sm:whitespace-normal">
-            Ndiri nekuti tiri — I am because we are
+            A Bundu Foundation research project · Phase 0
           </span>
         </Badge>
 
@@ -75,40 +74,39 @@ export async function Hero() {
 
       <div className="flex max-w-3xl flex-col items-center gap-4 sm:gap-6">
         <h1 className="font-serif text-[clamp(1.75rem,6vw,2rem)] leading-[1.1] font-bold tracking-tight text-balance text-foreground sm:text-4xl md:text-6xl lg:text-7xl">
-          The design system
+          A Rust framework
           <br />
-          for the bundu ecosystem
+          for the agentic web
         </h1>
         <p className="max-w-xl text-sm leading-relaxed text-pretty text-muted-foreground sm:text-base md:text-lg">
-          {totalLabel} components, blocks, and charts rooted in the Seven African Minerals palette.
-          One design system powering mukoko, nyuchi, and every app in the bundu family. Install with
-          the shadcn CLI — no packages, no lock-in.
+          Every existing framework was designed assuming a human is typing. Mzizi&apos;s syntax,
+          type system, and compiler feedback loop are designed for machine authorship — an agent
+          iterating against a compiler in a tight loop, thousands of times — and measured against a{" "}
+          {corpusLabel} benchmark corpus.
         </p>
       </div>
 
       <div className="flex w-full flex-col items-center gap-4 sm:gap-5">
-        <CopyCommand />
         <div className="flex w-full flex-col items-center gap-2 sm:w-auto sm:flex-row sm:gap-3">
           <Button size="lg" className="w-full gap-2 sm:w-auto" asChild>
-            <a href="/components">
-              Browse components
+            <a href="/architecture">
+              Read the research charter
               <ArrowRight className="size-4" />
             </a>
           </Button>
           <Button variant="outline" size="lg" className="w-full sm:w-auto" asChild>
-            <a href="https://docs.bundu.org/mzizi" target="_blank" rel="noopener noreferrer">
-              Documentation
-            </a>
+            <a href="/components">The benchmark corpus</a>
           </Button>
         </div>
       </div>
 
-      {/* Registry stats — live counts from the DB (Palette is a brand constant). */}
+      {/* Charter stats — the corpus count is live from the DB; the rest are
+          fixed properties of the research program. */}
       <div className="flex flex-wrap items-center justify-center gap-6 pt-4 sm:gap-8">
         {[
-          { label: "Registry Items", value: counts.total > 0 ? `${counts.total}` : "—" },
-          { label: "UI Components", value: counts.ui > 0 ? `${counts.ui}` : "—" },
-          { label: "Blocks", value: counts.blocks > 0 ? `${counts.blocks}` : "—" },
+          { label: "Corpus Components", value: counts.total > 0 ? `${counts.total}` : "—" },
+          { label: "Design Goals", value: "4" },
+          { label: "Current Phase", value: "0" },
           { label: "Palette", value: "7 minerals" },
         ].map((stat) => (
           <div key={stat.label} className="flex flex-col items-center gap-0.5">

--- a/components/landing/install-steps.tsx
+++ b/components/landing/install-steps.tsx
@@ -1,50 +1,68 @@
-import { Terminal, FolderOpen, Palette } from "lucide-react"
+import { Braces, Terminal, Timer, Coins } from "lucide-react"
 import { Section, SectionHeader } from "@/components/landing/section"
 
-const steps = [
+/**
+ * The four measurable design goals from the research charter. Each card
+ * carries the metric the goal is judged by — goals here are commitments to
+ * measure, not shipped features (the compiler is being designed in Phase 0).
+ */
+const goals = [
   {
-    icon: Terminal,
-    title: "Install from the registry",
+    icon: Braces,
+    title: "Low syntactic ambiguity",
     description:
-      "Use the shadcn CLI to add any component. Dependencies and tokens resolve automatically.",
-    code: "npx shadcn@latest add https://mzizi.dev/api/v1/ui/button",
+      "Fewer distinct-but-equivalent ways to express the same intent. When there is one canonical spelling, an agent stops burning iterations choosing between synonyms.",
+    code: "measure: equivalent spellings per intent → 1",
     mineralColor: "bg-[var(--color-tanzanite)]",
   },
   {
-    icon: FolderOpen,
-    title: "Own your code",
+    icon: Terminal,
+    title: "Dense compiler errors",
     description:
-      "Components land in your project as source files. Full ownership, zero hidden dependencies.",
-    code: "components/ui/button.tsx",
+      "Maximum actionable information per character, aimed at a machine reader. For an agent, the error message is the prompt for the next attempt.",
+    code: "measure: actionable signal per error char ↑",
     mineralColor: "bg-[var(--color-malachite)]",
   },
   {
-    icon: Palette,
-    title: "Inherit the brand",
+    icon: Timer,
+    title: "Fast incremental compilation",
     description:
-      "Seven African Minerals built in. Swap tokens to match your product, or ship as-is.",
-    code: '<Button variant="outline">Ship it</Button>',
+      "Compile latency is the dominant cost of an agent's workflow — author, compile, correct, thousands of times. Every millisecond compounds across the loop.",
+    code: "measure: incremental recompile latency ↓",
     mineralColor: "bg-[var(--color-gold)]",
+  },
+  {
+    icon: Coins,
+    title: "Token-efficient representation",
+    description:
+      "More real logic per token of context window. A denser language means the agent holds more of the program in view on every iteration.",
+    code: "measure: logic per token of context ↑",
+    mineralColor: "bg-[var(--color-cobalt)]",
   },
 ]
 
 export function InstallSteps() {
   return (
     <Section>
-      <SectionHeader align="center" eyebrow="How it works" title="Three steps. Zero friction." />
+      <SectionHeader
+        align="center"
+        eyebrow="The charter"
+        title="Four measurable design goals"
+        sub="Not aesthetics, not vibes — each goal is a metric the Phase 0 benchmark can score."
+      />
 
-      <div className="mt-12 grid gap-4 sm:gap-6 md:grid-cols-3">
-        {steps.map((step, i) => (
+      <div className="mt-12 grid gap-4 sm:gap-6 md:grid-cols-2 lg:grid-cols-4">
+        {goals.map((goal, i) => (
           <div
-            key={step.title}
+            key={goal.title}
             className="group relative flex flex-col gap-4 rounded-2xl border border-border bg-card p-6 transition-all hover:border-foreground/12"
           >
             <div className="flex items-center justify-between">
               <div className="flex size-10 items-center justify-center rounded-xl bg-secondary text-foreground">
-                <step.icon className="size-5" />
+                <goal.icon className="size-5" />
               </div>
               <div className="flex items-center gap-2">
-                <span className={`size-2 rounded-full ${step.mineralColor}`} />
+                <span className={`size-2 rounded-full ${goal.mineralColor}`} />
                 <span className="font-mono text-xs text-muted-foreground">
                   {String(i + 1).padStart(2, "0")}
                 </span>
@@ -52,13 +70,13 @@ export function InstallSteps() {
             </div>
 
             <div className="flex flex-col gap-1.5">
-              <h3 className="text-base font-semibold text-foreground">{step.title}</h3>
-              <p className="text-sm leading-relaxed text-muted-foreground">{step.description}</p>
+              <h3 className="text-base font-semibold text-foreground">{goal.title}</h3>
+              <p className="text-sm leading-relaxed text-muted-foreground">{goal.description}</p>
             </div>
 
             <div className="mt-auto overflow-hidden rounded-xl bg-secondary px-3 py-2.5">
               <code className="block font-mono text-[11px] leading-relaxed break-all text-muted-foreground sm:text-xs">
-                {step.code}
+                {goal.code}
               </code>
             </div>
           </div>

--- a/components/landing/resilient-by-design-section.tsx
+++ b/components/landing/resilient-by-design-section.tsx
@@ -6,35 +6,32 @@ import { Skeleton } from "@/components/registry/n2-primitives/skeleton"
 import { Section, SectionHeader } from "@/components/landing/section"
 
 /**
- * "Resilient by design" — explains two of the Mzizi DNA helix's cross-cutting
- * rungs (N9 fundi and N10 documentation) and why they exist.
+ * "The wrong author" — the argument behind the charter. Two premises:
  *
- * Most design systems ship as a snapshot — frozen at release time, drift
- * sets in, security findings pile up, docs go stale. The Mzizi helix has two
- * rungs — cross-cutting base pairs that bridge both backbones — whose entire
- * job is to prevent that:
+ *   1. Every existing framework optimizes for a human typist — forgiving
+ *      syntax, expressive redundancy, errors written for eyes. An agent
+ *      pays for each of those affordances on every one of thousands of
+ *      iterations.
+ *   2. For a machine author, the compiler IS the IDE. The error channel and
+ *      incremental compile speed are the interface, so Mzizi treats them as
+ *      first-class design surfaces.
  *
- *   - N9 fundi: the self-healing rung. It consumes N8 assurance signals and
- *     remediates the root cause.
- *   - N10 documentation: the system documents itself — every component and
- *     every version is in Supabase, served live, never copy-pasted.
- *
- * Together they're why the system stays current and secure without
- * manual maintenance pressure.
+ * The embedded ArchitectureExplorer renders the corpus architecture live
+ * from the database — the proving ground the claim is tested against.
  */
 // `ResilientBySection` is async because it embeds the server-rendered
-// `ArchitectureExplorer` (which fetches the helix — nodes, rungs and
-// strands — from Supabase).
+// `ArchitectureExplorer` (which fetches the corpus architecture — nodes,
+// rungs and strands — from Supabase).
 export async function ResilientBySection() {
   return (
     <Section bordered>
       <SectionHeader
-        eyebrow="Resilient by design"
-        title="Two rungs keep the system current and secure"
-        sub="The Mzizi DNA helix has two backbones that build the product; two cross-cutting rungs — fundi and documentation — exist so the system never goes stale or insecure."
+        eyebrow="Why a new language"
+        title="Every framework assumes a human is typing"
+        sub="Forgiving syntax, many ways to say the same thing, errors written for human eyes, compile times a person can tolerate — all of it optimizes for the wrong author. Below: the live corpus architecture the claim gets tested against, and the two premises behind the charter."
       />
 
-      {/* Interactive model explorer */}
+      {/* Interactive corpus-architecture explorer */}
       <div className="mt-12 mb-10 overflow-hidden">
         <Suspense
           fallback={
@@ -48,106 +45,100 @@ export async function ResilientBySection() {
       <div className="grid gap-4 sm:gap-6 lg:grid-cols-2">
         <article className="flex flex-col gap-4 rounded-2xl border border-border bg-background p-6 sm:p-8">
           <div className="flex items-center justify-between">
-            <span className="font-mono text-xs text-muted-foreground">N9 · RUNG</span>
+            <span className="font-mono text-xs text-muted-foreground">PREMISE · 01</span>
             <span className="rounded-full bg-[var(--color-cobalt)]/10 px-2.5 py-0.5 font-mono text-[10px] font-medium text-[var(--color-cobalt)]">
-              fundi
+              the author
             </span>
           </div>
-          <h3 className="font-serif text-2xl font-semibold">
-            Self-healing — failure becomes a learning event
-          </h3>
+          <h3 className="font-serif text-2xl font-semibold">Human affordances are machine costs</h3>
           <p className="text-sm leading-relaxed text-muted-foreground">
-            Fundi (Shona for &quot;artisan&quot;) is a <strong>rung</strong> — a cross-cutting base
-            pair that bridges both backbones of the helix rather than sitting on a single strand. It
-            consumes the N8 assurance node&apos;s runtime signals and remediates the root cause, so
-            a failure becomes a learning event rather than a user-facing incident.
+            Humans benefit from redundancy: several spellings of the same intent, gentle free-prose
+            errors, an IDE filling the gaps. An agent iterating against a compiler in a tight loop —
+            thousands of times — pays for every one of those affordances: each synonym is a
+            decision, each vague error is another round trip, and every token of ceremony is context
+            window that can&apos;t hold logic.
           </p>
           <ul className="space-y-1.5 text-sm leading-relaxed text-muted-foreground">
             <li className="flex gap-2">
               <span aria-hidden="true">→</span>
-              <span>A cross-cutting rung — bridges both backbones, sits on neither strand</span>
+              <span>Expressive redundancy becomes wasted iterations</span>
             </li>
             <li className="flex gap-2">
               <span aria-hidden="true">→</span>
-              <span>Consumes N8 assurance signals; never sits inside a component</span>
+              <span>Prose-shaped errors are low-signal for a machine reader</span>
             </li>
             <li className="flex gap-2">
               <span aria-hidden="true">→</span>
-              <span>Failure is treated as a learning event, not an incident</span>
+              <span>Compile latency multiplies by thousands of attempts</span>
             </li>
             <li className="flex gap-2">
               <span aria-hidden="true">→</span>
-              <span>Open architecture — consumers wire their own healing actor</span>
+              <span>Verbose syntax spends the context window token by token</span>
             </li>
           </ul>
           <Link
             href="/architecture"
             className="mt-auto inline-flex items-center gap-1.5 text-sm font-medium text-foreground hover:underline"
           >
-            The DNA helix model <ArrowRight className="size-4" />
+            The full research charter <ArrowRight className="size-4" />
           </Link>
         </article>
 
         <article className="flex flex-col gap-4 rounded-2xl border border-border bg-background p-6 sm:p-8">
           <div className="flex items-center justify-between">
-            <span className="font-mono text-xs text-muted-foreground">N10 · RUNG</span>
+            <span className="font-mono text-xs text-muted-foreground">PREMISE · 02</span>
             <span className="rounded-full bg-[var(--color-tanzanite)]/10 px-2.5 py-0.5 font-mono text-[10px] font-medium text-[var(--color-tanzanite)]">
-              documentation
+              the loop
             </span>
           </div>
           <h3 className="font-serif text-2xl font-semibold">
-            The system documents itself — no stale truth
+            The compiler is the agent&apos;s whole IDE
           </h3>
           <p className="text-sm leading-relaxed text-muted-foreground">
-            Every component, brand spec, and changelog entry lives in Supabase; long-form guides
-            live in standalone Mintlify docs sites. The Next.js app and the MCP server read live;
-            nothing is copy-pasted between them. When a component changes in the database, the
-            portal, the API, and the AI tools all pick it up on the next request. Drift becomes
-            structurally impossible.
+            An agent doesn&apos;t hover for tooltips or skim docs mid-keystroke. It writes,
+            compiles, reads the error, and writes again — so the compiler&apos;s output channel is
+            the entire developer experience. Mzizi treats that channel as a first-class API: dense,
+            structured, maximally actionable errors, and incremental compilation fast enough that
+            the loop is bounded by thinking, not waiting.
           </p>
           <ul className="space-y-1.5 text-sm leading-relaxed text-muted-foreground">
             <li className="flex gap-2">
               <span aria-hidden="true">→</span>
-              <span>Long-form guides ship as standalone Mintlify documentation sites</span>
+              <span>Errors designed as data — max actionable signal per character</span>
             </li>
             <li className="flex gap-2">
               <span aria-hidden="true">→</span>
-              <span>
-                <code className="font-mono text-xs">/api/v1/*</code> endpoints serve component +
-                brand + changelog data live from the database
-              </span>
+              <span>One canonical spelling per intent, by construction</span>
             </li>
             <li className="flex gap-2">
               <span aria-hidden="true">→</span>
-              <span>
-                <code className="font-mono text-xs">registry.json</code> is a CI-verified snapshot,
-                never hand-edited
-              </span>
+              <span>Incremental compile latency as a headline benchmark metric</span>
             </li>
             <li className="flex gap-2">
               <span aria-hidden="true">→</span>
-              <span>MCP tools surface live counts; AI never quotes a stale number</span>
+              <span>Behavioral contracts catch &quot;compiles cleanly but wrong&quot;</span>
             </li>
           </ul>
           <Link
             href="/architecture"
             className="mt-auto inline-flex items-center gap-1.5 text-sm font-medium text-foreground hover:underline"
           >
-            The DNA helix model <ArrowRight className="size-4" />
+            The full research charter <ArrowRight className="size-4" />
           </Link>
         </article>
       </div>
 
       <div className="mt-10 rounded-2xl border border-foreground/10 bg-foreground/5 px-6 py-5 sm:px-8 sm:py-6">
         <p className="text-sm leading-relaxed text-muted-foreground">
-          <span className="font-medium text-foreground">Net effect.</span> Five CVEs cleared in this
-          PR alone — caught by <code className="font-mono text-xs">pnpm audit</code>, fixed inside
-          the same PR per the no-deferral rule. CodeQL workflow-permissions findings, Dependabot
-          advisories, and security-review notes never wait for a follow-up PR. See{" "}
+          <span className="font-medium text-foreground">Where this stands.</span> Mzizi is a Bundu
+          Foundation research charter in Phase 0 — the language and compiler are being designed now.
+          There are no benchmark numbers yet and no toolchain to install, and this page won&apos;t
+          pretend otherwise. What is real today: the corpus, the MCP server, and the telemetry on
+          this site. See{" "}
           <Link href="/architecture" className="underline hover:no-underline">
             the architecture page
           </Link>{" "}
-          for the full helix model and{" "}
+          for the full charter and{" "}
           <a
             href="https://github.com/nyuchi/mzizi/blob/main/SECURITY.md"
             target="_blank"

--- a/lib/nav.ts
+++ b/lib/nav.ts
@@ -17,11 +17,13 @@ import {
 // surfaces only; long-form guides live in the standalone Mintlify
 // docs site at docs.bundu.org/mzizi.
 //
-//   Explore       — the component gallery, tools, skills, the CLI, and the architecture explorer
-//   Playground    — interactive registry browser (live preview + API tester)
-//   Doctrine      — Ubuntu Five Pillars + Five Principles (issue #45)
-//   Releases      — the node-aware changelog (issue #85)
-//   Observability — live registry / API / MCP usage metrics
+//   Framework     — the research architecture (charter layers, phases) and
+//                   the benchmark's measurement discipline
+//   Corpus        — the benchmark corpus: the fixed component set the
+//                   framework is measured against, its tokens, its playground
+//   Agent tooling — the agent-facing surface: tools, skills, the CLI
+//   Doctrine      — Ubuntu, the Bundu Foundation research ethos
+//   Releases      — the node-aware corpus changelog
 //   Documentation — external link to the Mintlify docs site
 //
 // Header nav (top-right) and sidebar (left) share this file so the two
@@ -45,20 +47,27 @@ export interface NavGroup {
 
 export const SIDEBAR_NAV: NavGroup[] = [
   {
-    label: "Explore",
+    label: "Framework",
     items: [
-      { label: "Components", href: "/components", icon: Layers },
-      { label: "Colour tokens", href: "/tokens", icon: Palette },
-      { label: "Tools", href: "/tools", icon: Wrench },
-      { label: "Skills", href: "/skills", icon: BookOpen },
-      { label: "CLI", href: "/cli", icon: Terminal },
       { label: "Architecture", href: "/architecture", icon: Box },
       { label: "Observability", href: "/observability", icon: Activity },
     ],
   },
   {
-    label: "Playground",
-    items: [{ label: "Playground", href: "/playground", icon: Sparkles }],
+    label: "Corpus",
+    items: [
+      { label: "Components", href: "/components", icon: Layers },
+      { label: "Colour tokens", href: "/tokens", icon: Palette },
+      { label: "Playground", href: "/playground", icon: Sparkles },
+    ],
+  },
+  {
+    label: "Agent tooling",
+    items: [
+      { label: "Tools", href: "/tools", icon: Wrench },
+      { label: "Skills", href: "/skills", icon: BookOpen },
+      { label: "CLI", href: "/cli", icon: Terminal },
+    ],
   },
   {
     label: "Doctrine",
@@ -79,10 +88,10 @@ export const SIDEBAR_NAV: NavGroup[] = [
 // Header top-level nav (desktop-only). Mirrors the sidebar so the header
 // and sidebar tell the same story.
 export const HEADER_NAV: NavItem[] = [
-  { label: "Components", href: "/components" },
-  { label: "Tokens", href: "/tokens" },
   { label: "Architecture", href: "/architecture" },
+  { label: "Corpus", href: "/components" },
   { label: "Playground", href: "/playground" },
+  { label: "CLI", href: "/cli" },
   { label: "Docs", href: "https://docs.bundu.org/mzizi", external: true },
 ]
 


### PR DESCRIPTION
## Summary

Complete content rebuild of mzizi.dev around the new framing, built with a worktree and four parallel agents on disjoint file sets. Every content surface now tells one story: **Mzizi is a Rust framework for the agentic web** — a Bundu Foundation research project whose syntax, type system, and compiler feedback loop are designed for machine authorship. The old design-system-as-the-product identity is gone from the copy; the 571-component registry is reframed as the **Phase 0 benchmark corpus**, the fixed ground truth the framework is measured against.

## What changed, by surface

- **Shared chrome** (my slice): site metadata/description/keywords, JSON-LD, web manifest, OG alt text; nav regrouped as Framework / Corpus / Agent tooling / Doctrine / Releases — all routes unchanged.
- **Landing** (agent 1): new hero ("A Rust framework for the agentic web", live corpus count kept); the npm-install section became the four measurable design goals; build-with became the Phase 0–4 roadmap with a status-honesty card; AI-native became machine authorship (MCP card kept — it's real infra); harness became interop-not-reinvention (Dioxus, WASM, native, Workers, Candle, Astro-as-adapter) with an honest Rust contract-test snippet as the code block; footer states Foundation IP + Nyuchi-owned Fundi console.
- **Architecture/doctrine** (agent 2): charter layer table, goals G1–G4, and roadmap up top; N1–N12 helix retained as the corpus taxonomy with node pages describing their corpus slice; Ubuntu recast as the Foundation's research ethos; Observability trimmed to "Measurement" — the three benchmark metrics and the contract-test defect oracle, plus honest live corpus telemetry.
- **Corpus surfaces** (agent 3): components/tokens/playground/changelog intros recast to benchmark-corpus framing; all live data plumbing, `ComponentGallery`, and `npx shadcn add` install affordances untouched.
- **Agent tooling** (agent 4): cli/skills/tools presented as the agent-facing surface of the research program; every real command, package name, and route unchanged; compiler toolchain consistently framed as upcoming, never shipped.

## Deliberate guardrails

- **The registry API is untouched** — `/api/v1/**`, MCP, and shadcn installs keep working byte-for-byte; only the story changed.
- **No fabricated anything**: no fake Mzizi-lang syntax, no invented benchmark numbers, no install commands for a compiler that doesn't exist. Phase 0 is presented as research in progress, explicitly.

## Test plan

- [x] `tsc --noEmit` clean (verified after each agent and after integration)
- [x] `pnpm test` — 211 tests pass (22 files)
- [x] `pnpm build` — production build succeeds (26 pages indexed)
- [x] Prettier applied across all changed files
- [x] No route, API, or dependency changes


---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_