### PR TITLE
chore: retire the "Nyuchi Design Portal" naming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# CODEOWNERS — nyuchi design portal
+# CODEOWNERS — Mzizi
 #
 # These owners are automatically requested for review on every pull request
 # that touches the corresponding paths.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Report a bug in the Nyuchi Design Portal
+about: Report a bug in Mzizi
 title: "[Bug] "
 labels: bug
 assignees: ""

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# Nyuchi Design Portal — Pre-commit hook
+# Mzizi — Pre-commit hook
 # All checks must pass before a commit is allowed.
 # This is the canonical quality gate for the ecosystem's design system registry.
 

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,5 +1,5 @@
 {
-  // Markdownlint configuration for the Nyuchi Design Portal docs.
+  // Markdownlint configuration for the Mzizi docs.
   // Goals: catch real formatting mistakes (broken headings, stray blanks)
   // without fighting long URLs, tables, inline HTML, or in-code examples.
   "config": {

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,4 +1,4 @@
-# yamllint config for the Nyuchi Design Portal.
+# yamllint config for Mzizi.
 #
 # Goals: catch real YAML mistakes (indentation drift, duplicate keys,
 # invalid syntax) while not fighting the conventions GitHub Actions

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,7 +4,7 @@
 
 **Umuntu ngumuntu ngabantu** — A person is a person through other persons.
 
-The nyuchi design portal is built on the Ubuntu philosophy: we are who we are through our relationships with others. This community exists because people share, build, and grow together. Every contribution — a bug report, a component, a translation, a question — makes this system stronger for everyone.
+Mzizi is built on the Ubuntu philosophy: we are who we are through our relationships with others. This community exists because people share, build, and grow together. Every contribution — a bug report, a component, a translation, a question — makes this system stronger for everyone.
 
 We are building technology for Africa, rooted in African values. That means community first, dignity always, and shared prosperity as the measure of success.
 
@@ -12,7 +12,7 @@ We are building technology for Africa, rooted in African values. That means comm
 
 ## Our Pledge
 
-We as contributors and maintainers pledge to make participation in the nyuchi design portal community a welcoming, respectful, and empowering experience for everyone — regardless of age, body, disability, ethnicity, sex characteristics, gender identity, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+We as contributors and maintainers pledge to make participation in the Mzizi community a welcoming, respectful, and empowering experience for everyone — regardless of age, body, disability, ethnicity, sex characteristics, gender identity, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 

--- a/__tests__/metadata-titles.test.ts
+++ b/__tests__/metadata-titles.test.ts
@@ -13,6 +13,11 @@
 //
 // Two pages also carried names that no longer exist: "mzizi design portal" and
 // "nyuchi design portal" both predate the rename to Mzizi.
+//
+// The retired-name check originally read only double-quoted titles, and three
+// dynamic routes — /components/[name], /source/[name], /changelog/[name] — wrote
+// theirs as template literals. All three shipped "— nyuchi design portal" while
+// this file was green. Both quoting styles are now read.
 
 import { describe, expect, it } from "vitest"
 import { readdirSync, readFileSync, statSync } from "node:fs"
@@ -34,6 +39,12 @@ function pageFiles(dir: string): string[] {
 function titlesIn(source: string): string[] {
   const out: string[] = []
   for (const m of source.matchAll(/\btitle:\s*"([^"]+)"/g)) out.push(m[1])
+  // Template literals too. Three live routes carried a retired name for exactly
+  // this reason: `title: \`${item.name} — nyuchi design portal\`` is a backtick
+  // string, so a double-quote-only pattern walked straight past it. A guard that
+  // only inspects one of the two ways to write a title is a guard with a hole in
+  // the shape of the bug it exists to catch.
+  for (const m of source.matchAll(/\btitle:\s*`([^`]+)`/g)) out.push(m[1])
   return out
 }
 

--- a/app/api/openapi/route.ts
+++ b/app/api/openapi/route.ts
@@ -5,7 +5,7 @@ import { NextResponse } from "next/server"
 /**
  * GET /api/openapi
  *
- * Serves the OpenAPI 3.1 specification for the Nyuchi Design Portal API.
+ * Serves the OpenAPI 3.1 specification for the Mzizi registry API.
  * Returns the raw YAML by default, or JSON if ?format=json is requested.
  */
 export async function GET(request: Request) {

--- a/app/api/v1/stats/route.ts
+++ b/app/api/v1/stats/route.ts
@@ -63,9 +63,9 @@ export async function GET(request: Request) {
       {
         "@context": "https://schema.org",
         "@type": "Dataset",
-        name: "Nyuchi Design Portal — Usage Statistics",
+        name: "Mzizi — Usage Statistics",
         description:
-          "Public API and MCP usage metrics for the Nyuchi Design Portal. Open data aligned with the bundu ecosystem philosophy.",
+          "Public API and MCP usage metrics for the Mzizi component registry. Open data aligned with the bundu ecosystem philosophy.",
         license: "https://creativecommons.org/licenses/by/4.0/",
         ...stats,
         layers,

--- a/app/architecture/nodes/[n]/page.tsx
+++ b/app/architecture/nodes/[n]/page.tsx
@@ -40,12 +40,12 @@ export async function generateMetadata({ params }: { params: Promise<{ n: string
   const { n } = await params
   const parsed = parseNode(n)
   if (parsed === null) return { title: "Node not found" }
-  if (!isSupabaseConfigured()) return { title: `N${parsed} — Mzizi` }
+  if (!isSupabaseConfigured()) return { title: `N${parsed}` }
 
   const element = await getHelixNode(parsed).catch(() => null)
-  if (!element) return { title: `N${parsed} — Mzizi` }
+  if (!element) return { title: `N${parsed}` }
   return {
-    title: `N${element.node_number} ${element.title} — Mzizi`,
+    title: `N${element.node_number} ${element.title}`,
     description: element.description,
   }
 }

--- a/app/changelog/[name]/page.tsx
+++ b/app/changelog/[name]/page.tsx
@@ -34,7 +34,7 @@ export async function generateMetadata({ params }: { params: Promise<{ name: str
     return { title: "Component not found" }
   }
   return {
-    title: `Changelog: ${name} — nyuchi design portal`,
+    title: `Changelog: ${name}`,
     description: `Per-version release notes for the \`${name}\` registry component, newest first.`,
   }
 }

--- a/app/components/[name]/page.tsx
+++ b/app/components/[name]/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata({ params }: { params: Promise<{ name: str
   const item = await getComponent(name).catch(() => null)
   if (!item) return { title: "Not Found" }
   return {
-    title: `${item.name} — nyuchi design portal`,
+    title: item.name,
     description: item.description,
   }
 }

--- a/app/skills/[name]/page.tsx
+++ b/app/skills/[name]/page.tsx
@@ -32,9 +32,9 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { name } = await params
   const skill = isSupabaseConfigured() ? await getSkill(name).catch(() => null) : null
-  if (!skill) return { title: `${name} — Mzizi skills` }
+  if (!skill) return { title: `Skill: ${name}` }
   return {
-    title: `${skill.name} — Mzizi skills`,
+    title: `Skill: ${skill.name}`,
     description: skill.description ?? undefined,
   }
 }

--- a/app/source/[name]/page.tsx
+++ b/app/source/[name]/page.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata({ params }: { params: Promise<{ name: str
     return { title: "Component not found" }
   }
   return {
-    title: `Source: ${name} — nyuchi design portal`,
+    title: `Source: ${name}`,
     description: `Read the full TypeScript source for the \`${name}\` registry component.`,
   }
 }

--- a/app/tools/[name]/page.tsx
+++ b/app/tools/[name]/page.tsx
@@ -100,7 +100,7 @@ export async function generateMetadata({
   }
   const tool = KNOWN_TOOLS[name]
   return {
-    title: `${tool.name} — Mzizi tools`,
+    title: `Tool: ${tool.name}`,
     description: tool.description,
   }
 }

--- a/components/registry/n1-tokens/nyuchi-harness-prewire.tsx
+++ b/components/registry/n1-tokens/nyuchi-harness-prewire.tsx
@@ -290,7 +290,7 @@ export interface ComponentHarnessResult {
 }
 
 // ─── OBSERVABILITY (domain-gated) ────────────────────────────
-// Design portal backlinks and observability only render on allowed domains.
+// Registry backlinks and observability only render on allowed domains.
 // This protects privacy: no tracking on unauthorized domains.
 // Domains are controlled via the observability_domains table.
 

--- a/components/registry/n2-primitives/sidebar-01.tsx
+++ b/components/registry/n2-primitives/sidebar-01.tsx
@@ -40,7 +40,7 @@ function Sidebar01() {
       </nav>
       <Separator />
       <div className="p-3">
-        <p className="px-3 text-xs text-muted-foreground">nyuchi design portal v4.0.1</p>
+        <p className="px-3 text-xs text-muted-foreground">mzizi v4.0.1</p>
       </div>
     </aside>
   )

--- a/components/registry/n8-assurance/mzizi-api-probe.ts
+++ b/components/registry/n8-assurance/mzizi-api-probe.ts
@@ -19,7 +19,7 @@ export interface EndpointCheck {
 }
 
 export interface ApiProbeConfig {
-  /** Base URL of the design portal */
+  /** Base URL of the registry */
   baseUrl?: string
   /** Timeout per request in ms */
   timeout?: number

--- a/components/registry/n8-assurance/mzizi-chaos.tsx
+++ b/components/registry/n8-assurance/mzizi-chaos.tsx
@@ -13,7 +13,7 @@ import * as React from "react"
 
 // BACKLINKS: Uses data-portal and data-slot attributes to identify components
 // during chaos injection. When injecting an error, Fundi reads the data-portal
-// attribute to link the failure back to the design portal documentation.
+// attribute to link the failure back to the registry documentation.
 
 export interface ChaosConfig {
   /** Enable chaos injection (default: false in dev, configurable in prod) */

--- a/components/registry/n8-assurance/mzizi-conformity-check.ts
+++ b/components/registry/n8-assurance/mzizi-conformity-check.ts
@@ -34,7 +34,7 @@ export interface ConformityReport {
 }
 
 export interface ConformityCheckConfig {
-  /** Known registered components from the design portal */
+  /** Known registered components from the registry */
   registry?: Set<string>
   /** Deprecated component names */
   deprecated?: Set<string>

--- a/components/registry/n8-assurance/mzizi-rum.ts
+++ b/components/registry/n8-assurance/mzizi-rum.ts
@@ -52,7 +52,7 @@ export interface RumConfig {
 }
 
 // BACKLINKS: RUM events are enriched with data-portal attributes
-// to link performance metrics back to specific components in the design portal.
+// to link performance metrics back to specific components in the registry.
 
 class RumCollector {
   private events: RumEvent[] = []

--- a/content/doctrine/documentation/api-reference.mdx
+++ b/content/doctrine/documentation/api-reference.mdx
@@ -5,7 +5,7 @@ author: "nyuchi-team"
 category: "api-reference"
 createdAt: "2026-04-14T04:34:29.591833+00:00"
 currentVersion: 2
-description: "REST API and MCP server reference for the Nyuchi Design Portal."
+description: "REST API and MCP server reference for the Mzizi component registry."
 dnaRole: "documentation"
 doctrineVersion: "4.1.7"
 keywords:
@@ -28,14 +28,14 @@ sortOrder: 30
 status: "published"
 strand: "transcription"
 subcategory: "rest"
-title: "Design Portal API Reference"
+title: "Registry API Reference"
 updatedAt: "2026-04-24T10:57:17.273063+00:00"
 version: "4.0.34"
 ---
 
 # API Reference
 
-The Nyuchi Design Portal exposes a REST API and MCP server for accessing the component registry.
+Mzizi exposes a REST API and MCP server for accessing the component registry.
 
 ## Base URL
 

--- a/content/doctrine/documentation/component-backlinks.mdx
+++ b/content/doctrine/documentation/component-backlinks.mdx
@@ -29,7 +29,7 @@ sortOrder: 12
 status: "published"
 strand: "transcription"
 subcategory: "backlinks"
-title: "Component Backlinks & Design Portal Integration"
+title: "Component Backlinks & Registry Integration"
 updatedAt: "2026-04-24T10:56:44.877196+00:00"
 version: "4.0.34-reviewed"
 ---

--- a/content/doctrine/documentation/contributing.mdx
+++ b/content/doctrine/documentation/contributing.mdx
@@ -47,7 +47,7 @@ The Nyuchi Design System is open source and built by the community. Ubuntu — I
 
 ## Repository
 
-github.com/nyuchi/design-portal
+github.com/nyuchi/mzizi
 
 ## Source code lives in the database
 
@@ -133,4 +133,4 @@ Change types: created, fix, enhancement, tokens_wired, node_moved, breaking, dep
 
 When N8 detects an issue with your component, Fundi creates a GitHub issue with structured labels. You can find issues related to your component at:
 
-github.com/nyuchi/design-portal/issues?q=label:fundi:node/{your-node}
+github.com/nyuchi/mzizi/issues?q=label:fundi:node/{your-node}

--- a/lib/db/client.ts
+++ b/lib/db/client.ts
@@ -38,7 +38,7 @@ interface RegistryCache {
   ttl: number
 }
 
-const CACHE_KEY = "design-portal-cache"
+const CACHE_KEY = "mzizi-registry-cache"
 const CACHE_TTL = 1000 * 60 * 60 // 1 hour
 
 /**

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -1,5 +1,5 @@
 /**
- * Database types for the Nyuchi Design Portal Supabase document store.
+ * Database types for the Mzizi Supabase document store.
  *
  * These types mirror the Supabase tables defined in supabase/schema.sql.
  * Components, docs, and demos are stored as rows in Postgres — queryable,

--- a/lib/tokens/index.ts
+++ b/lib/tokens/index.ts
@@ -95,7 +95,7 @@ export const primitives = {
     info: { value: "#00B0FF" },
   },
 
-  // ─── SPACING SCALE (design portal canonical) ───────────────
+  // ─── SPACING SCALE (canonical) ───────────────
   spacing: {
     "0": { value: "0px" },
     xs: { value: "4px", description: "Tight gaps, icon padding" },
@@ -108,7 +108,7 @@ export const primitives = {
     "3xl": { value: "64px", description: "Page section spacing" },
   },
 
-  // ─── BORDER RADIUS (design portal canonical) ──────────────
+  // ─── BORDER RADIUS (canonical) ──────────────
   // Base unit: 7px (--radius-unit). Ecosystem numbers: 7, 12, 14, 17.
   // Buttons are ALWAYS pill (rounded-full, 9999px).
   radius: {
@@ -121,7 +121,7 @@ export const primitives = {
     circle: { value: "50%", description: "Perfect circles" },
   },
 
-  // ─── TYPOGRAPHY (design portal canonical) ─────────────────
+  // ─── TYPOGRAPHY (canonical) ─────────────────
   // Noto Sans/Serif chosen for cross-language compatibility
   // (800+ languages including African languages and diacritics)
   fontFamily: {
@@ -139,7 +139,7 @@ export const primitives = {
     },
   },
 
-  // Type scale (design portal canonical)
+  // Type scale (canonical)
   fontSize: {
     caption: { value: "12px", description: "0.75rem — Labels, metadata, timestamps" },
     bodySmall: { value: "14px", description: "0.875rem — Secondary text, descriptions" },
@@ -161,14 +161,14 @@ export const primitives = {
     bold: { value: "700" },
   },
 
-  // ─── TOUCH TARGETS (design portal canonical) ──────────────
+  // ─── TOUCH TARGETS (canonical) ──────────────
   // APCA 3.0 AAA accessibility standard
   touchTarget: {
     default: { value: "56px", description: "Default interactive element height" },
     sm: { value: "48px", description: "Minimum — NEVER below this" },
   },
 
-  // ─── MOTION (design portal canonical) ─────────────────────
+  // ─── MOTION (canonical) ─────────────────────
   motion: {
     duration: {
       quick: { value: "100ms", description: "Micro-interactions, toggles" },
@@ -222,7 +222,7 @@ export const primitives = {
 
 // ═══════════════════════════════════════════════════════════════
 // TIER 2 — SEMANTIC TOKENS
-// These change per theme. Values from design portal canonical.
+// These change per theme. Values from the canonical token set.
 // ═══════════════════════════════════════════════════════════════
 
 export type ThemeMode = "dark" | "light" | "high-contrast"

--- a/registry.json
+++ b/registry.json
@@ -1034,7 +1034,7 @@
       ],
       "dependencies": [],
       "description": "Nyuchi ecosystem architecture specification — local-first data strategy and sovereignty assessment.",
-      "docs": "Use it for: Architecture specification display in design portal, Sovereignty assessment documentation, Data-layer strategy visualization, System design reference for AI assistants, Architecture review and audit tooling.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/architecture",
+      "docs": "Use it for: Architecture specification display in the registry, Sovereignty assessment documentation, Data-layer strategy visualization, System design reference for AI assistants, Architecture review and audit tooling.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: Semantic HTML.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/architecture",
       "files": [
         {
           "path": "components/registry/n2-primitives/architecture.ts",
@@ -1054,7 +1054,7 @@
         "hasDemo": true,
         "owner": "mzizi",
         "useCases": [
-          "Architecture specification display in design portal",
+          "Architecture specification display in the registry",
           "Sovereignty assessment documentation",
           "Data-layer strategy visualization",
           "System design reference for AI assistants",
@@ -10233,7 +10233,7 @@
         "primitives"
       ],
       "dependencies": [],
-      "description": "TikTok-style progressive lazy section with sequential mount queue and bidirectional visibility. Only ONE section mounts at a time via a global FIFO queue, preventing DOM/Canvas surges that OOM mobile browsers. Sections unmount when scrolled far off-screen (1500px margin) to cap peak memory. Adaptive timing: 150ms settle on mobile, 50ms on desktop. Production-proven in mukoko-weather with 7 Chart.js sections. The design portal's most critical performance primitive.",
+      "description": "TikTok-style progressive lazy section with sequential mount queue and bidirectional visibility. Only ONE section mounts at a time via a global FIFO queue, preventing DOM/Canvas surges that OOM mobile browsers. Sections unmount when scrolled far off-screen (1500px margin) to cap peak memory. Adaptive timing: 150ms settle on mobile, 50ms on desktop. Production-proven in mukoko-weather with 7 Chart.js sections. The registry's most critical performance primitive.",
       "docs": "Use it for: Chart-heavy dashboards on mobile (mukoko-weather pattern), Feed pages with multiple heavy sections, Long-form content with embedded media, Image-heavy galleries with staggered loading, Any mobile surface with multiple Canvas/WebGL contexts.\nVariants: default.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/lazy-section",
       "files": [
         {
@@ -11932,7 +11932,7 @@
         "assurance"
       ],
       "dependencies": [],
-      "description": "API endpoint health checker. Pings all design portal API endpoints (from component_backlinks) and reports status codes, latency, and error rates. Feeds into nyuchi-platform-health. Uses the backlinks system built in v4.8.0.",
+      "description": "API endpoint health checker. Pings all Mzizi registry API endpoints (from component_backlinks) and reports status codes, latency, and error rates. Feeds into nyuchi-platform-health. Uses the backlinks system built in v4.8.0.",
       "docs": "Use it for: Platform monitoring, L8 assurance observability.\nVariants: default.\nIncludes: Z-axis depth observability, Cross-layer blast radius analysis via data-portal backlinks, L9 Fundi integration for auto-healing.\nAccessibility: Non-visual infrastructure — no direct a11y requirements.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/mzizi-api-probe",
       "files": [
         {
@@ -22874,7 +22874,7 @@
         "radix-ui"
       ],
       "description": "A composable, themeable and customizable sidebar component.",
-      "docs": "Use it for: Customizable sidebar shell for any app, Design-portal sidebar foundation, Base for all sidebar variants, Composable sidebar parts (header, content, footer), Theme-aware sidebar with collapse support.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar",
+      "docs": "Use it for: Customizable sidebar shell for any app, Registry sidebar foundation, Base for all sidebar variants, Composable sidebar parts (header, content, footer), Theme-aware sidebar with collapse support.\nVariants: default, outline, ghost, destructive.\nIncludes: cn() for className composition, data-slot attribute, Radix UI primitive.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/sidebar",
       "files": [
         {
           "path": "components/registry/n2-primitives/sidebar.tsx",
@@ -22897,7 +22897,7 @@
         "owner": "framework",
         "useCases": [
           "Customizable sidebar shell for any app",
-          "Design-portal sidebar foundation",
+          "Registry sidebar foundation",
           "Base for all sidebar variants",
           "Composable sidebar parts (header, content, footer)",
           "Theme-aware sidebar with collapse support"

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # setup-github-labels.sh
 #
-# Creates the canonical label set for nyuchitech/design-portal.
+# Creates the canonical label set for nyuchi/mzizi.
 # Requires the GitHub CLI (gh) and repo write access.
 #
 # Usage:
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 
-REPO="${1:-nyuchitech/design-portal}"
+REPO="${1:-nyuchi/mzizi}"
 echo "Setting up labels for: $REPO"
 
 create_label() {

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,6 +1,6 @@
-# Supabase — Nyuchi Design Portal
+# Supabase — Mzizi
 
-This directory captures the Supabase side of the design portal. The
+This directory captures the Supabase side of the Mzizi registry. The
 database itself is the source of truth; the files here document and
 reproduce its structure.
 

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,4 +1,4 @@
-// Shared CORS helpers for every Nyuchi Design Portal edge function.
+// Shared CORS helpers for every Mzizi edge function.
 //
 // The portal is public by design — all endpoints serve `Access-Control-Allow-Origin: *`.
 // Only the methods differ per function, which is why this file exports a small

--- a/supabase/functions/analytics/index.ts
+++ b/supabase/functions/analytics/index.ts
@@ -1,4 +1,4 @@
-// Nyuchi Design Portal — analytics edge function.
+// Mzizi — analytics edge function.
 //
 // Fire-and-forget ingest endpoint. Accepts usage events from the portal itself,
 // from downstream ecosystem apps (mukoko-*, nhimbe, shamwari), and from the

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,4 +1,4 @@
--- Nyuchi Design Portal — canonical Supabase `public` schema
+-- Mzizi — canonical Supabase `public` schema
 --
 -- This file is the single source of truth for the database structure:
 -- 41 tables, 2 views, 14 functions, ~31 triggers, ~50 RLS policies.


### PR DESCRIPTION
`design.nyuchi.com` has been a 308 to `mzizi.dev` for some time, and this repo already carried a guard declaring the name retired — `__tests__/metadata-titles.test.ts` has a `RETIRED` list containing `/nyuchi design portal/i`. Sixty-odd occurrences outlived it. **Two reached users:**

- `app/api/v1/stats/route.ts` returned `"Nyuchi Design Portal — Usage Statistics"` in a **public API response**
- `components/registry/n2-primitives/sidebar-01.tsx` **rendered** `nyuchi design portal v4.0.1`

Two more were broken links, not just stale names:

- `content/doctrine/documentation/contributing.mdx` pointed contributors at `github.com/nyuchi/design-portal`, which **403s** — the same broken-URL class `__tests__/api/security-txt.test.ts` already guards against for `security.txt`
- `scripts/setup-github-labels.sh` pointed at `nyuchitech/design-portal` — a third spelling of a repo that doesn't exist

## Why the guard didn't catch any of it

`titlesIn()` matched `/\btitle:\s*"([^"]+)"/` — **double-quoted strings only**. Three dynamic routes (`/components/[name]`, `/source/[name]`, `/changelog/[name]`) wrote theirs as backtick template literals, so the pattern walked straight past them.

A guard that reads one of the two ways to write a title has a hole in the exact shape of the bug it exists to catch. It now reads both.

## Widening it surfaced six pre-existing defects

These are **not** caused by this change — the widened guard could simply see them for the first time. Template-literal titles duplicating the brand that `app/layout.tsx` already appends via `template: "%s | Mzizi"`:

| Route | Was shipping |
| --- | --- |
| `architecture/nodes/[n]` | `N3 — Mzizi \| Mzizi` |
| `skills/[name]` | `button — Mzizi skills \| Mzizi` |
| `tools/[name]` | `mzizi-mcp — Mzizi tools \| Mzizi` |

Fixed to `Skill:` / `Tool:` / bare-node forms, matching the `Source:` / `Changelog:` convention. This is precisely the defect the test file's own header describes as its reason for existing — it just couldn't see these six.

## Deliberately kept

CHANGELOG entries, both test guards, the Rust assertions in `nyuchi-ai-context.rs` and `mzizi-fundi/tests/contract.rs`, the seed SQL, the two Mukoko amendment docs, and the comments in `app/mcp/route.ts` and `security.txt/route.ts` documenting the 308 and the old 403.

Those record **why** the name is retired, which is what stops it coming back. Deleting them would remove the institutional memory and leave only the rule.

## One behavioural change

`lib/db/client.ts`'s localStorage `CACHE_KEY` moves from `design-portal-cache` to `mzizi-registry-cache`. Returning visitors take one cache miss and refetch; the old key lingers in their localStorage as dead data. Judged worth it — the alternative is a user-visible storage key carrying a retired brand indefinitely.

## Verification

| Gate | Result |
| --- | --- |
| `tsc --noEmit` | clean |
| `pnpm test` | **211/211 pass** (22 files) |
| `registry:verify` | canonical, 575 items |
| `registry:validate` | ✓ every item resolves; only pre-existing raw-hex warnings on components I didn't touch |
| `lint:json` / `lint:md` / `lint:yaml` | clean |
| `prettier --check` on all changed files | clean |
| pre-commit hook (eslint `--max-warnings=0`, prettier, typecheck, audit) | all passed |

The 41 `format:check` warnings are **pre-existing** `mzizi-rs/target/` build artifacts — I verified they're identical on `main`.

## Not in this PR

The **GitHub repo description and homepage** still read "The Nyuchi Design Portal" / `design.nyuchi.com`. That's the most-seen surface of all, and it points at a retired domain — but the API write is blocked by this session's permission classifier. It needs doing by hand or in a session that permits it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_