### PR TITLE
feat(api): serve all 21 colour families from /api/v1/brand

### DIFF
--- a/__tests__/api/brand-route.test.ts
+++ b/__tests__/api/brand-route.test.ts
@@ -63,3 +63,102 @@ describe("GET /api/v1/brand", () => {
     expect(response.headers["Access-Control-Allow-Origin"]).toBe("*")
   })
 })
+
+/**
+ * All 21 colour families must be served.
+ *
+ * `/api/v1/brand` shipped 7 of them. `getBrandSystem()` fetches minerals,
+ * semantic colours, backgrounds, typography, spacing, ecosystem and meta —
+ * heritage and experimental were never in the query, and there is no
+ * `brand_heritage` or `brand_experimental` view to read (19 `brand_*` views
+ * exist; those two are not among them).
+ *
+ * The consequence was not local. This route is what the MCP server reads, so
+ * `mzizi_get_tokens(family: "heritage")` errored for every agent — while the
+ * tool advertised `heritage` in its own schema. Fourteen of twenty-one families
+ * were unreachable from outside the repo, and no gate noticed, because nothing
+ * asserted a family count on the response.
+ *
+ * These specs mock the DB deliberately THIN: heritage and experimental come from
+ * the committed `palette.generated.ts` snapshot, not from the mocked query, so a
+ * regression that drops the import fails here even though the DB mock is
+ * unchanged.
+ */
+describe("GET /api/v1/brand colour families", () => {
+  beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://stub.supabase.co")
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "stub-anon-key")
+    vi.resetModules()
+  })
+
+  async function serve() {
+    vi.doMock("@/lib/db", () => ({
+      isSupabaseConfigured: () => true,
+      getBrandSystem: async () => ({
+        minerals: [
+          {
+            name: "cobalt",
+            hex: "#0047AB",
+            light_hex: "#0047AB",
+            dark_hex: "#00B0FF",
+            container_light: "#E3F2FD",
+            container_dark: "#001F3F",
+            css_var: "--color-cobalt",
+            origin: "Katanga",
+            symbolism: "trust",
+            usage: "links",
+          },
+        ],
+        semanticColors: [],
+        backgrounds: [],
+        typography: [],
+        spacing: [],
+        ecosystem: [],
+        meta: {
+          version: "4.0.0",
+          name: "Mzizi",
+          last_updated: "2026-08-24",
+          homepage: "https://mzizi.dev",
+          radii: {},
+          component_specs: {},
+          accessibility: {},
+          voice_and_tone: {},
+          philosophy: {},
+        },
+      }),
+    }))
+    const { GET } = await import("@/app/api/v1/brand/route")
+    return (await GET()) as unknown as {
+      data: Record<string, Array<Record<string, unknown>>>
+      status: number
+    }
+  }
+
+  it("serves heritage and experimental, not just minerals", async () => {
+    const res = await serve()
+    expect(res.status).toBe(200)
+    expect(res.data.heritage, "heritage family absent from /api/v1/brand").toBeDefined()
+    expect(res.data.experimental, "experimental family absent from /api/v1/brand").toBeDefined()
+    expect(res.data.heritage).toHaveLength(7)
+    expect(res.data.experimental).toHaveLength(7)
+  })
+
+  it("names the four families that were unreachable, and gives them real hexes", async () => {
+    const res = await serve()
+    const heritage = res.data.heritage.map((h) => h.name)
+    expect(heritage).toContain("hematite")
+    expect(heritage).toContain("kalahari")
+    // A family present but hexless would satisfy a count assertion and still be
+    // useless to the agent reading it.
+    for (const row of [...res.data.heritage, ...res.data.experimental]) {
+      expect(String(row.darkHex), `${row.name} darkHex`).toMatch(/^#[0-9a-fA-F]{6}$/)
+      expect(String(row.lightHex), `${row.name} lightHex`).toMatch(/^#[0-9a-fA-F]{6}$/)
+    }
+  })
+
+  it("carries the heptagon index on experimental tones", async () => {
+    const res = await serve()
+    const idx = res.data.experimental.map((e) => e.heptagonIndex).sort()
+    expect(idx).toEqual([0, 1, 2, 3, 4, 5, 6])
+  })
+})

--- a/app/api/v1/brand/route.ts
+++ b/app/api/v1/brand/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { createLogger } from "@/lib/observability"
 import { isSupabaseConfigured, getBrandSystem } from "@/lib/db"
+import { experimentalColors, heritageColors } from "@/lib/tokens/palette.generated"
 
 const logger = createLogger("brand")
 
@@ -104,6 +105,43 @@ export async function GET() {
         dark: c.dark_value,
         usage: c.usage,
       })),
+      // Heritage and experimental come from the committed palette snapshot, not
+      // from a DB read, because there is no `brand_heritage` or
+      // `brand_experimental` view to read — `getBrandSystem()` only ever fetched
+      // minerals. That is why /api/v1/brand served 7 of the 21 colour families
+      // and `mzizi_get_tokens(family: "heritage")` errored despite the MCP tool
+      // advertising `heritage` in its own schema.
+      //
+      // The snapshot is the right source rather than a stopgap: it is generated
+      // from the same Supabase collections by `scripts/sync-tokens.ts` and CI
+      // fails via `pnpm tokens:verify` if it drifts, so this is DB-derived data
+      // with a build-time guarantee and no request-time round trip. Minerals are
+      // deliberately left on their existing DB read — changing that would alter
+      // a payload 571 components and the MCP already depend on.
+      heritage: heritageColors.map((h) => ({
+        name: h.name,
+        hex: h.darkHex,
+        lightHex: h.lightHex,
+        darkHex: h.darkHex,
+        cssVar: h.cssVar,
+        origin: h.origin,
+        symbolism: h.symbolism,
+        usage: h.usage,
+      })),
+      experimental: experimentalColors.map((e) => ({
+        name: e.name,
+        hex: e.darkHex,
+        lightHex: e.lightHex,
+        darkHex: e.darkHex,
+        containerLight: e.containerLight,
+        containerDark: e.containerDark,
+        onContainerLight: e.onContainerLight,
+        onContainerDark: e.onContainerDark,
+        uiLight: e.uiLight,
+        uiDark: e.uiDark,
+        cssVar: `--color-${e.name}`,
+        heptagonIndex: e.heptagonIndex,
+      })),
       componentSpecs: dbBrand.meta.component_specs,
       accessibility: dbBrand.meta.accessibility,
       voiceAndTone: dbBrand.meta.voice_and_tone,
@@ -111,7 +149,13 @@ export async function GET() {
     }
 
     logger.info("Brand system served", {
-      data: { version: brandSystem.version },
+      data: {
+        version: brandSystem.version,
+        colourFamilies:
+          brandSystem.minerals.length +
+          brandSystem.heritage.length +
+          brandSystem.experimental.length,
+      },
     })
 
     return NextResponse.json(brandSystem, { headers: CORS_CACHE })


### PR DESCRIPTION
`/api/v1/brand` served **7 of the 21 colour families.**

`getBrandSystem()` fetches minerals, semantic colours, backgrounds, typography, spacing, ecosystem and meta. **Heritage and experimental were never in the query** — and there's no view to read them from either: 19 `brand_*` views exist over `brand_store`, and `brand_heritage` / `brand_experimental` are not among them.

So the seven heritage tones and seven experimental tones were unreachable through the public API, and therefore through MCP. `mzizi_get_tokens(family: "heritage")` errored *even though the tool advertises `heritage` in its own schema*. That's the "somewhere we lost tokens" instinct being right — at the serving layer, not in the repo.

## Where the data comes from

`lib/tokens/palette.generated.ts`, not a new DB read and not two new views.

That's the right source rather than a stopgap: the snapshot is generated from the same Supabase collections by `scripts/sync-tokens.ts`, and CI fails via `pnpm tokens:verify` if it drifts. So it's DB-derived data with a **build-time** guarantee and **no request-time round trip** — strictly better than adding views that would need their own grants and carry their own drift risk. PR #260 is what made this possible; before it, the snapshot didn't carry the experimental seven.

## Deliberately not changed

**Minerals stay on their existing DB read.** Repointing them would alter a payload that 571 components, the registry and the MCP already depend on, for no gain — the defect was the missing families, not the present one. The two new keys are purely additive, so every existing consumer is untouched.

## Verification

| Gate | Result |
| --- | --- |
| `tsc --noEmit` | clean |
| `pnpm test` | 219/219 |
| `prettier --check` | clean |
| pre-commit (eslint, prettier, typecheck, audit) | all passed |

Pairs with **nyuchi/mzizi-tools#72**, which fixes the MCP-side resolver. This PR is the half that makes the data exist; that one is the half that makes it addressable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_