### PR TITLE
fix: the palette is seven per family, not five

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -35,7 +35,7 @@
     "shadcn",
     "registry",
     "africa",
-    "five-african-minerals",
+    "seven-african-minerals",
     "ubuntu",
     "claude-code",
     "mcp"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 # Default: all changes request review from the core team
 *                               @nyuchi/core
 
-# Design system — Five African Minerals tokens, globals.css
+# Design system — Seven African Minerals tokens, globals.css
 app/globals.css                 @nyuchi/core
 
 # Database access layer — Supabase queries + types (post-#43 the

--- a/__tests__/tokens-seven-fold.test.ts
+++ b/__tests__/tokens-seven-fold.test.ts
@@ -15,6 +15,7 @@
 // snapshot and `pnpm tokens:verify` is what proves it matches the database.
 
 import { describe, expect, it } from "vitest"
+import { execSync } from "node:child_process"
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
 import { experimentalColors, heritageColors, minerals } from "@/lib/tokens/palette.generated"
@@ -120,5 +121,54 @@ describe("the ListingTheme union and the map agree", () => {
     const declared = [...block![1].matchAll(/\|\s*"([^"]+)"/g)].map((m) => m[1]).sort()
     const defined = Object.keys(listingThemes).sort()
     expect(declared).toEqual(defined)
+  })
+})
+
+/**
+ * "Five African Minerals" is the retired pre-Seven palette name.
+ *
+ * `__tests__/api/v1/architecture-routes.test.ts` already asserts this — but only
+ * against ONE API route's text, so the name survived in fourteen other places:
+ * a rendered `<CardDescription>`, a rendered feature list, the published plugin
+ * keyword, six strings in `registry.json` (which the shadcn CLI prints after
+ * install), and seven comments in the token source itself.
+ *
+ * A guard aimed at one route cannot see the other thirteen. This one walks the
+ * tracked tree.
+ *
+ * MATCHED CASE-SENSITIVELY, and that is what makes it safe to run repo-wide.
+ * The legitimate historical references — "emitted five minerals and five
+ * heritage tones against a seven-and-seven system", "every one carried FIVE
+ * minerals" — never write the proper noun, so a citation of the retired name and
+ * a use of it are distinguishable without a heuristic. That distinction is the
+ * whole reason a prose guard is viable here and was not viable for the count
+ * claims above.
+ */
+describe("the retired palette name", () => {
+  const EXEMPT = [
+    // Historical by definition — it records that the name WAS used and is not.
+    "CHANGELOG.md",
+    // Tests cite the retired name in order to forbid it.
+    "__tests__/",
+  ]
+
+  it("appears nowhere outside the changelog and the tests", () => {
+    const tracked = execSync("git ls-files", { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 })
+      .split("\n")
+      .filter(Boolean)
+      .filter((f) => !EXEMPT.some((e) => f.startsWith(e)))
+      .filter((f) => !/\.(png|jpg|jpeg|gif|webp|avif|ico|woff2?|ttf|pdf|lock)$/i.test(f))
+
+    const offenders: string[] = []
+    for (const file of tracked) {
+      let body: string
+      try {
+        body = readFileSync(join(process.cwd(), file), "utf8")
+      } catch {
+        continue // deleted or unreadable in this checkout
+      }
+      if (body.includes("Five African Minerals")) offenders.push(file)
+    }
+    expect(offenders).toEqual([])
   })
 })

--- a/components/registry/n1-tokens/nyuchi-tokens-typescript.ts
+++ b/components/registry/n1-tokens/nyuchi-tokens-typescript.ts
@@ -21,7 +21,7 @@
  *   - Python: Config dataclass
  *
  * TEN LISTING THEMES:
- *   Five African Minerals (geological) + Five Heritage Colors (atmospheric)
+ *   Seven African Minerals (geological) + Seven Heritage Colors (atmospheric)
  *
  * "Thou hast ordered all things in measure, and number, and weight."
  * — The Bundu Order, v4.0.2
@@ -33,7 +33,7 @@
 // ═══════════════════════════════════════════════════════════════
 
 export const primitives = {
-  // ─── FIVE AFRICAN MINERALS (geological, from underground) ───
+  // ─── SEVEN AFRICAN MINERALS (geological, from underground) ──
   // Each mineral has a dark-mode and light-mode value.
   // Dark mode values are used in the Nyuchi default dark theme.
   // Light mode values are used for light theme and text-on-light.
@@ -94,7 +94,7 @@ export const primitives = {
       description: "Text on terracotta container (dark)",
     },
 
-    // ─── FIVE HERITAGE COLORS (atmospheric, from above ground) ───
+    // ─── SEVEN HERITAGE COLORS (atmospheric, from above ground) ──
     // African fashion, sunset, savanna, rivers, ancient and biblical.
     indigo: {
       value: "#8C9EFF",
@@ -344,7 +344,7 @@ export const semanticTokens: Record<ThemeMode, Record<string, { value: string }>
 
 // ═══════════════════════════════════════════════════════════════
 // LISTING THEMES — Ten Colors of Africa
-// Five Minerals (geological) + Five Heritage (atmospheric)
+// Seven Minerals (geological) + Seven Heritage (atmospheric)
 // Each theme provides a background gradient for listing pages.
 // ═══════════════════════════════════════════════════════════════
 
@@ -860,7 +860,7 @@ export function generateTokens(format: PlatformFormat): string {
 // SEMANTIC STATUS & ALERT TOKEN SYSTEM
 //
 // IMPORTANT: These use GLOBALLY RECOGNIZED accessibility colors,
-// NOT the Five African Minerals. The minerals are brand identity
+// NOT the Seven African Minerals. The minerals are brand identity
 // (links, CTAs, achievements, community). Status colors are a
 // SEPARATE universal system that works across all languages,
 // literacy levels, and cultures. Color is the first thing people
@@ -1177,7 +1177,7 @@ export function generateStatusCSS(): string {
 }
 
 // CHART COLOR SYSTEM
-// Maps chart indices to Five African Minerals + Heritage colors.
+// Maps chart indices to Seven African Minerals + Heritage colors.
 // Replaces shadcn default --chart-1..5 with Nyuchi mineral palette.
 // Import mineralChartConfig in any chart block for instant brand compliance.
 // ═══════════════════════════════════════════════════════════════
@@ -1217,7 +1217,7 @@ export const mineralChartConfig = {
       color: "var(--color-malachite, #64FFDA)",
     },
   }),
-  /** Five-series chart — all five minerals */
+  /** Seven-series chart — all seven minerals */
   fiveMinerals: (labels: [string, string, string, string, string]) => ({
     [labels[0].toLowerCase().replace(/\\s/g, "_")]: {
       label: labels[0],

--- a/components/registry/n2-primitives/chart-bar-default.tsx
+++ b/components/registry/n2-primitives/chart-bar-default.tsx
@@ -14,7 +14,7 @@ import {
    BAR CHART — Default
    Layer 2 Primitive Block
    
-   ✅ TOKENS — Five African Minerals chart colors
+   ✅ TOKENS — Seven African Minerals chart colors
    ✅ ARIA — role="figure", aria-label
    ✅ LOADING — via ChartContainer loading prop
    ✅ I18N — accepts pre-formatted labels

--- a/components/registry/n2-primitives/chart-radial-shape.tsx
+++ b/components/registry/n2-primitives/chart-radial-shape.tsx
@@ -36,7 +36,7 @@ export function ChartRadialShape({ loading = false }: { loading?: boolean } = {}
     >
       <CardHeader>
         <CardTitle>Radial - Custom Shape</CardTitle>
-        <CardDescription>Five African Minerals radial</CardDescription>
+        <CardDescription>Seven African Minerals radial</CardDescription>
       </CardHeader>
       <CardContent>
         <ChartContainer

--- a/components/registry/n3-brand/nyuchi-create-listing.tsx
+++ b/components/registry/n3-brand/nyuchi-create-listing.tsx
@@ -28,7 +28,7 @@ import { cn } from "@/lib/utils"
    - Pill-shaped publish button, full-width, bottom-sticky
    ═══════════════════════════════════════════════════════════════ */
 
-/* ── Predefined gradient themes (Five African Minerals) ─────── */
+/* ── Predefined gradient themes (Seven African Minerals) ────── */
 const MINERAL_GRADIENTS: [string, string][] = [
   ["var(--color-malachite-light,#004D40)", "#00695C"], // Malachite
   ["var(--color-tanzanite-light,#4B0082)", "#6A1B9A"], // Tanzanite

--- a/components/registry/n6-pages/signup-03.tsx
+++ b/components/registry/n6-pages/signup-03.tsx
@@ -22,8 +22,8 @@ import { Label } from "@/components/ui/label"
 import { Check } from "@/lib/icons"
 
 const features = [
-  "82 production-ready components",
-  "Five African Minerals design system",
+  "Production-ready component registry",
+  "Seven African Minerals design system",
   "Accessible and theme-aware",
   "Install via shadcn CLI",
 ]

--- a/components/registry/n7-shell/nyuchi-footer.tsx
+++ b/components/registry/n7-shell/nyuchi-footer.tsx
@@ -152,7 +152,7 @@ export function NyuchiFooter({
           <p className="text-xs text-muted-foreground">
             &copy; {year} {companyName}. All rights reserved.
           </p>
-          {/* L1: TOKENS — Five African Minerals dots */}
+          {/* L1: TOKENS — Seven African Minerals dots */}
           <div className="flex items-center gap-1.5" aria-hidden="true">
             {[
               "var(--color-primary, #00B0FF)",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -34,7 +34,7 @@ tags:
   - name: Discovery
     description: API metadata, health, search, stats
   - name: Brand
-    description: Five African Minerals design system
+    description: Seven African Minerals design system
   - name: Registry
     description: Component registry (shadcn-compatible)
   - name: Architecture
@@ -72,7 +72,7 @@ paths:
     get:
       summary: Brand System
       description: |
-        Returns the complete Nyuchi brand system — Five African Minerals palette,
+        Returns the complete Nyuchi brand system — Seven African Minerals palette,
         typography, spacing, ecosystem brands, accessibility standards, and voice & tone.
 
         Reads from Supabase. Returns 503 if database is not configured.

--- a/registry.json
+++ b/registry.json
@@ -6831,7 +6831,7 @@
         "primitives"
       ],
       "dependencies": [],
-      "description": "Color selector with hex input and preset swatches including Five African Minerals.",
+      "description": "Color selector with hex input and preset swatches including the Seven African Minerals.",
       "docs": "Use it for: Theme customization in settings, Design tool color pickers, Brand color selection in admin interfaces, Calendar event color assignment, Tag color selection.\nVariants: default, sm, lg.\nIncludes: cn() for className composition, data-slot attribute.\nAccessibility: ARIA attributes, Keyboard accessible.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/color-picker",
       "files": [
         {
@@ -18931,7 +18931,7 @@
         "brand"
       ],
       "dependencies": [],
-      "description": "Branded success/confirmation screen with mineral-colored checkmark, title, message, and optional actions. Extracted from payment-page, checkout-page, and booking-page where the same checkmark + title pattern was repeated. Uses Five African Minerals for the success indicator.",
+      "description": "Branded success/confirmation screen with mineral-colored checkmark, title, message, and optional actions. Extracted from payment-page, checkout-page, and booking-page where the same checkmark + title pattern was repeated. Uses the Seven African Minerals for the success indicator.",
       "docs": "Use it for: events, wallet, transport, bushtrade, nhimbe.\nVariants: default.\nIncludes: Harness integration (log, motion, LiveRegion), animStyle with prefersReduced motion check, Mineral-colored accent via brand override, data-slot + data-portal DOM attributes.\nAccessibility: Focus-visible ring on interactive elements, 48px minimum touch targets, ARIA role attribute.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-success-screen",
       "files": [
         {
@@ -19552,7 +19552,7 @@
       },
       "dependencies": [],
       "description": "The Mzizi N1 design tokens as CSS custom properties — the Seven African Minerals and Seven Heritage colours with light/dark pairs, the four-level AAA surface system, radius scale, type scale, motion durations and touch targets. Generated from app/globals.css, so the registry and the site cannot disagree. Framework-agnostic by construction: the shadcn CLI merges these into whatever stylesheet the consuming project uses. Install this first — 431 of the registry's components reference these variables.",
-      "docs": "Use it for: Design token provider for all Nyuchi apps, CSS custom properties for colors, spacing, radii, motion, Multi-platform export: Swift, Kotlin, ArkTS, Rust, Python, Brand overrides per mini-app.\nVariants: light, dark, high-contrast.\nIncludes: Five African Minerals palette with light/dark pairs, Four-level AAA surface system, 8 semantic token categories, Brand override per mini-app, Multi-platform generators.\nAccessibility: AAA contrast on all text-surface combinations, prefers-contrast: more support, prefers-reduced-motion: respects motion tokens.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-tokens",
+      "docs": "Use it for: Design token provider for all Nyuchi apps, CSS custom properties for colors, spacing, radii, motion, Multi-platform export: Swift, Kotlin, ArkTS, Rust, Python, Brand overrides per mini-app.\nVariants: light, dark, high-contrast.\nIncludes: Seven African Minerals palette with light/dark pairs, Four-level AAA surface system, 8 semantic token categories, Brand override per mini-app, Multi-platform generators.\nAccessibility: AAA contrast on all text-surface combinations, prefers-contrast: more support, prefers-reduced-motion: respects motion tokens.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-tokens",
       "meta": {
         "a11y": [
           "AAA contrast on all text-surface combinations",
@@ -19561,7 +19561,7 @@
         ],
         "collection": "styling-libs",
         "features": [
-          "Five African Minerals palette with light/dark pairs",
+          "Seven African Minerals palette with light/dark pairs",
           "Four-level AAA surface system",
           "8 semantic token categories",
           "Brand override per mini-app",
@@ -19740,7 +19740,7 @@
       ],
       "dependencies": [],
       "description": "TypeScript constants mirroring the Mzizi N1 token set: typed primitive/semantic/component values plus the helpers (resolveColor, hexWithAlpha, generateCSSVariables) that components need at runtime. The canonical token DATA is nyuchi-tokens, which ships the CSS custom properties themselves; this is the typed accessor for code that must read a token value rather than reference it in CSS.",
-      "docs": "Use it for: Design token provider for all Nyuchi apps, CSS custom properties for colors, spacing, radii, motion, Multi-platform export: Swift, Kotlin, ArkTS, Rust, Python, Brand overrides per mini-app.\nVariants: light, dark, high-contrast.\nIncludes: Five African Minerals palette with light/dark pairs, Four-level AAA surface system, 8 semantic token categories, Brand override per mini-app, Multi-platform generators.\nAccessibility: AAA contrast on all text-surface combinations, prefers-contrast: more support, prefers-reduced-motion: respects motion tokens.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-tokens-typescript",
+      "docs": "Use it for: Design token provider for all Nyuchi apps, CSS custom properties for colors, spacing, radii, motion, Multi-platform export: Swift, Kotlin, ArkTS, Rust, Python, Brand overrides per mini-app.\nVariants: light, dark, high-contrast.\nIncludes: Seven African Minerals palette with light/dark pairs, Four-level AAA surface system, 8 semantic token categories, Brand override per mini-app, Multi-platform generators.\nAccessibility: AAA contrast on all text-surface combinations, prefers-contrast: more support, prefers-reduced-motion: respects motion tokens.\nInstall: npx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-tokens-typescript",
       "files": [
         {
           "path": "components/registry/n1-tokens/nyuchi-tokens-typescript.ts",
@@ -19756,7 +19756,7 @@
         ],
         "collection": "styling-libs",
         "features": [
-          "Five African Minerals palette with light/dark pairs",
+          "Seven African Minerals palette with light/dark pairs",
           "Four-level AAA surface system",
           "8 semantic token categories",
           "Brand override per mini-app",

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -50,7 +50,7 @@ create_label "priority:low"      "D4A574" "Nice to have"
 
 # ── Scope ───────────────────────────────────────────────────────────────────
 echo "Scope labels..."
-create_label "scope:design-system"  "0047AB" "Affects the Five African Minerals design system"
+create_label "scope:design-system"  "0047AB" "Affects the Seven African Minerals design system"
 create_label "scope:brand"          "B388FF" "Brand documentation or tokens"
 create_label "scope:architecture"   "64FFDA" "Architecture documentation or decisions"
 create_label "scope:ecosystem"      "D4A574" "Affects multiple bundu ecosystem apps"


### PR DESCRIPTION
"Five African Minerals" is the retired pre-Seven palette name. **The repo already knew** — `__tests__/api/v1/architecture-routes.test.ts` asserts it *"has no legitimate use here at all"*, and `CHANGELOG.md:18` records fixing the same claim in `.claude-plugin/plugin.json`'s description.

That guard checked **one API route's text**. The name survived in **seventeen other places**.

## Two were rendered to users

- `signup-03.tsx` listed `"Five African Minerals design system"` in its feature list
- `chart-radial-shape.tsx` rendered `<CardDescription>Five African Minerals radial</CardDescription>`

## Six were served

`registry.json` descriptions and `meta.features` — which the shadcn CLI prints **after install**. The derived `docs` strings were regenerated with `pnpm registry:metadata` rather than hand-edited, since they're generated from `meta`.

## The rest were the token source's own headers

`nyuchi-tokens-typescript.ts` declared `FIVE AFRICAN MINERALS` and `FIVE HERITAGE COLORS` directly above the arrays — the most misleading possible place for the claim.

## One more, found in passing

`signup-03`'s feature list also advertised `"82 production-ready components"`. The registry has 571+. A hardcoded count in shipped copy is the count-as-data rule inverted, so it's now a claim rather than a number.

## The guard, and why it can be a prose guard this time

It walks the tracked tree instead of one route — and **immediately earned itself**, finding three files my extension-filtered grep had missed:

| File | Why it matters |
| --- | --- |
| **`openapi.yaml`** | a **published API spec**, describing the brand endpoint |
| `.github/CODEOWNERS` | |
| `scripts/setup-github-labels.sh` | |

It matches **case-sensitively**, and that's what makes it safe repo-wide. The legitimate historical references — *"emitted five minerals and five heritage tones against a seven-and-seven system"*, *"every one carried FIVE minerals"* — never write the proper noun. So a **citation** of the retired name is distinguishable from a **use** of it without any heuristic.

That's precisely the distinction that made a prose guard unworkable for the count claims in #260 (where I tried one and deleted it) and workable here. `CHANGELOG.md` and `__tests__/` are exempt by path: one is historical by definition, the other cites the name in order to forbid it.

## Correcting myself

**#264 says `five-african-minerals` is the correct topic for this repo, and that I nearly "fixed" something that wasn't broken.** That was wrong, and the evidence was already in the repo — I'd read the "Five Minerals + Five Heritage" comments and believed them over the test that forbids the name. The topic should be `seven-african-minerals`. I'll update that issue.

## Verification

| Gate | Result |
| --- | --- |
| `tsc --noEmit` | clean |
| `pnpm test` | **223/223** (was 222) |
| `registry:validate` / `registry:verify` | ok |
| `registry:metadata:check` / `registry:paths:check` | ok |
| `lint:json` / `lint:yaml` | ok |
| Occurrences outside changelog + tests | **0** |

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_