### PR TITLE
ci: add workflow_dispatch to ci.yml and lint.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Manual trigger. Added because on 2026-08-26 neither this workflow nor its
+  # sibling produced ANY run for PR #265 — zero runs created, both workflows
+  # `active`, valid, correctly triggered on `pull_request: [main]`, while the
+  # GitHub-managed CodeQL and Dependabot workflows kept running. With no
+  # dispatch trigger anywhere in the repo there was no way to run the checks
+  # at all, or to tell an environmental block from a trigger misfire.
+  workflow_dispatch:
 
 # Top-level default keeps the entire workflow read-only. Each job
 # re-declares its own permissions so CodeQL

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Manual trigger. Added because on 2026-08-26 neither this workflow nor its
+  # sibling produced ANY run for PR #265 — zero runs created, both workflows
+  # `active`, valid, correctly triggered on `pull_request: [main]`, while the
+  # GitHub-managed CodeQL and Dependabot workflows kept running. With no
+  # dispatch trigger anywhere in the repo there was no way to run the checks
+  # at all, or to tell an environmental block from a trigger misfire.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
**No workflow in this repository can be triggered manually.** On 2026-08-26 that turned a CI outage into an unfalsifiable one.

PR #265 produced **zero runs** of either workflow — not queued, not `waiting`, not `action_required`. No run was ever created. Meanwhile:

| | |
| --- | --- |
| Both workflows | `state: active` |
| Both files | parse, `actionlint` clean |
| Both triggers | `pull_request: branches: [main]`, no `paths` filter |
| PR #265 base | `main` |
| CodeQL + Dependabot Updates (**GitHub-managed**) | running normally |

That last asymmetry — repository-defined workflows silent while GitHub-managed ones are healthy — is what says this is an account or policy condition rather than anything wrong with these files.

## What this buys

Two things, and the second matters as much as the first:

1. **A route to run the required checks** when the automatic trigger doesn't fire.
2. **A decisive diagnostic.** If a manual dispatch *also* refuses to start, the cause is environmental — billing, or org/repo Actions policy — and not these workflows. Right now that question can't be answered at all.

## Scope

Trigger-only. No job, step, permission or condition is touched. All seven `ci.yml` jobs (Security Audit, Registry Snapshot, Rust, Lint, Type Check, Test, Build) and all five `lint.yml` jobs (actionlint, JSON validity, prettier, markdownlint, yamllint) are unchanged. Adding a trigger cannot disable an existing one.

## Why this is a separate PR, and not part of #265

`workflow_dispatch` **requires the workflow to carry the trigger on the default branch**. A branch that has it is not dispatchable until it merges. So this has to reach `main` before it can be used for anything — including diagnosing #265.

It is deliberately minimal for that reason: 14 added lines, all comment and trigger.

## Verification

| Gate | Result |
| --- | --- |
| `actionlint` (both files) | clean |
| `yamllint` | clean |
| YAML parse | both, with triggers `push`, `pull_request`, `workflow_dispatch` |
| Job sets | unchanged — 7 in `ci.yml`, 5 in `lint.yml` |
| pre-commit hook | passed |

**This PR will not get CI either** — it is subject to the same block it exists to diagnose. Its own checks were run locally.

## One thing I could not verify

Reading branch protection returns `403: Resource not accessible by integration` for this token, so I cannot confirm that the **required check names** in branch protection still match the job names these workflows produce. If a required context names a job that was since renamed, a PR would sit `blocked` forever waiting on a check that can never report — worth someone with Settings access confirming while they are looking at Actions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_