### PR TITLE
fix: the plugin manifest advertised an MCP server that does not exist

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -21,7 +21,7 @@
     "mzizi": {
       "type": "url",
       "url": "https://mzizi.dev/mcp",
-      "description": "Mzizi MCP — components, brand tokens, open 3D architecture, skills, changelog. Streamable HTTP transport."
+      "description": "Mzizi MCP — the component registry: list and read components, browse collections by node, and check registry status. Streamable HTTP transport."
     }
   },
   "permissions": {

--- a/__tests__/plugin-manifest.test.ts
+++ b/__tests__/plugin-manifest.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+// Reads the manifest and the MCP server source off disk — must run in Node.
+import { describe, it, expect } from "vitest"
+import fs from "node:fs"
+import path from "node:path"
+
+/**
+ * The plugin manifest is a PROMISE about a running endpoint, and nothing was
+ * checking it against the endpoint.
+ *
+ * It advertised "Mzizi MCP — components, brand tokens, open 3D architecture,
+ * skills, changelog". The server at mzizi.dev/mcp registers four tools:
+ * list_components, get_component, list_collections, get_database_status. Four
+ * of the five advertised capabilities did not exist, and the fifth named the
+ * RETIRED axis model — the same vocabulary architecture-routes.test.ts already
+ * forbids in public/llms.txt.
+ *
+ * A manifest is the first thing an agent reads and the last thing anyone
+ * re-reads, so it drifts silently and is believed anyway.
+ */
+
+const root = process.cwd()
+const manifest = () =>
+  JSON.parse(fs.readFileSync(path.join(root, ".claude-plugin/plugin.json"), "utf-8"))
+const serverSrc = () => fs.readFileSync(path.join(root, "lib/mcp-server.ts"), "utf-8")
+
+/** Tool names the server actually registers — the source of truth. */
+function registeredTools(): string[] {
+  return [...serverSrc().matchAll(/server\.tool\(\s*"([a-z_]+)"/g)].map((m) => m[1] as string)
+}
+
+describe("the plugin's MCP entry describes the server that exists", () => {
+  it("registers the tools this test reasons about", () => {
+    // Guards the regex itself: if the registration style changes, the
+    // capability check below would silently pass on an empty list.
+    expect(registeredTools().length).toBeGreaterThan(0)
+  })
+
+  /**
+   * Capability word → the tool that would have to exist for the claim to be
+   * true. Asserted from the WORD rather than by parsing the sentence: a
+   * description is prose and will be rewritten, but claiming "tokens" without a
+   * token tool is wrong however the sentence is phrased.
+   */
+  const CLAIMS: Record<string, RegExp> = {
+    token: /token/,
+    architecture: /architecture|helix|node/,
+    skill: /skill/,
+    changelog: /changelog|version/,
+    doctrine: /doctrine|ubuntu/,
+    accessibility: /accessib|contrast/,
+  }
+
+  it("claims no capability the server does not implement", () => {
+    const description: string = manifest().mcpServers.mzizi.description
+    const tools = registeredTools()
+    const unbacked = Object.entries(CLAIMS)
+      .filter(([word]) => new RegExp(word, "i").test(description))
+      .filter(([, toolPattern]) => !tools.some((t) => toolPattern.test(t)))
+      .map(([word]) => word)
+    expect(unbacked).toEqual([])
+  })
+
+  it("does not name the retired axis model", () => {
+    const description: string = manifest().mcpServers.mzizi.description
+    // "3D", "X/Y/Z-axis" and "layers across ... axes" are the retired
+    // vocabulary. Unlike llms.txt, this field has no legitimate reason to cite
+    // it in order to disown it — it is one sentence of advertising copy.
+    expect(description).not.toMatch(/\b3D\b/i)
+    expect(description).not.toMatch(/\baxes\b|\b[XYZ]-axis\b/i)
+  })
+
+  it("points at the endpoint the tools are served from", () => {
+    expect(manifest().mcpServers.mzizi.url).toBe("https://mzizi.dev/mcp")
+  })
+
+  it("allows the hosts it needs and no others", () => {
+    const net: string[] = manifest().permissions.network
+    expect(net).toContain("mzizi.dev")
+    // A manifest that quietly widens its network reach is worth failing on.
+    expect(net.sort()).toEqual(["assets.nyuchi.com", "mzizi.dev"])
+  })
+})


### PR DESCRIPTION
## What was wrong

`.claude-plugin/plugin.json` described the endpoint at `mzizi.dev/mcp` as:

> Mzizi MCP — components, brand tokens, open 3D architecture, skills, changelog.

`lib/mcp-server.ts` registers four tools. Verified against the live endpoint by
JSON-RPC `tools/list`:

```
list_components
get_component
list_collections
get_database_status
```

One of the five advertised capabilities is real. **Brand tokens, skills and
changelog have no tool at all** — and "open 3D architecture" names the retired
axis model on top of that, the same vocabulary
`__tests__/api/v1/architecture-routes.test.ts` already forbids in
`public/llms.txt`. The manifest was simply never checked against it.

This matters because a manifest is the first thing an agent reads to decide what
a server is *for*. An agent that believed this one would plan around a token
tool that does not exist, then describe the architecture in vocabulary the repo
retired.

## The fix

The description now names what the server does.

## The guard

Structural rather than textual. Prose gets rewritten; the defect is claiming a
capability nothing implements, however the sentence is phrased. So the test:

1. reads the registered tool names out of `lib/mcp-server.ts`
2. maps capability **words** (`token`, `architecture`, `skill`, `changelog`,
   `doctrine`, `accessibility`) to the tool that would have to exist
3. fails on any claim in the description with no backing tool

A first spec asserts the registration regex still matches something — an empty
tool list would make the capability check pass vacuously, which is how this kind
of guard usually rots.

**Mutation-tested.** Restoring the original description fails exactly two specs:

```
× claims no capability the server does not implement
    expected [ 'token', 'architecture', 'skill', 'changelog' ] to deeply equal []
× does not name the retired axis model
    expected 'Mzizi MCP — components, brand tokens,…' not to match /\b3D\b/i
```

and the corrected description passes all five. A guard that has never failed on
the real defect is unproven.

Also asserted: the `permissions.network` list, which should not widen quietly.

## Verification

- `tsc --noEmit` clean
- `vitest run` — **228/228** (was 223)
- `registry:validate` and `lint:json` green (the `wallet-card` raw-hex warning
  is pre-existing on `main` and exits 0)

## How this was found

Probing the live MCP surface end-to-end after a report that tools were failing.
Two other defects came out of the same sweep:

- `mzizi_fundi` 401 on the OAuth-gated worker — fixed in nyuchi/mzizi-tools#77
- the live MCP still serves a **stale `scaffold-component` skill description**
  telling agents to author into `component_documents`, retired by
  nyuchi/mzizi-tools#73. Needs a `skills:sync` run against production, not a
  code change — tracked as nyuchi/mzizi-tools#75.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_