### PR TITLE
ci: add the Cloudflare Workers deploy workflow

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,135 @@
+# Deploy mzizi.dev to Cloudflare Workers.
+#
+# The app half of leaving Vercel is done: nothing under lib/ or app/ reads the
+# filesystem at request time, and `@opennextjs/cloudflare` builds the Next app
+# into a Worker. This is the deploy half — modelled on
+# nyuchi/mzizi-tools/.github/workflows/deploy-mzizi-mcp.yml so both Workers ship
+# the same way.
+#
+# ONE-TIME SETUP — repository secrets, Settings → Secrets and variables → Actions:
+#
+#   CLOUDFLARE_API_TOKEN            Workers Scripts:Edit (plus Workers Routes:Edit
+#                                   and DNS:Edit once the domain is attached)
+#   CLOUDFLARE_ACCOUNT_ID           the account hosting the Worker
+#   NEXT_PUBLIC_SUPABASE_URL        the project URL
+#   NEXT_PUBLIC_SUPABASE_ANON_KEY   the project's anon key
+#
+# The two Supabase values are build-time, not runtime: Next inlines every
+# NEXT_PUBLIC_* variable into the bundle when it compiles. Setting them as
+# Worker secrets instead would do nothing — the built code would carry empty
+# strings and every database-backed route would answer 503 "Database not
+# configured". Both are already shipped to browsers today, so this is not a new
+# exposure.
+#
+# WHY MANUAL, NOT ON PUSH. Turning this into `on: push` is the cutover: it makes
+# Cloudflare the thing that serves what lands on main. That should be a
+# deliberate act by someone who can also point DNS and retire the Vercel
+# project, not a side effect of merging this file. Run it by hand, confirm the
+# workers.dev URL serves correctly, then add the push trigger and the route.
+
+name: Deploy Worker (mzizi.dev)
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "deploy" to confirm publishing to Cloudflare'
+        required: true
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Guard the confirmation input
+        env:
+          CONFIRM: ${{ inputs.confirm }}
+        run: |
+          set -euo pipefail
+          if [ "$CONFIRM" != "deploy" ]; then
+            echo "::error::Publishing is gated. Re-run and type 'deploy' to confirm."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # The same gates a pull request has to clear. A deploy path that skips
+      # them is how a broken build reaches production faster than a reviewed one.
+      - run: pnpm typecheck
+      - run: pnpm lint
+      - run: pnpm test
+
+      # Every generated artifact must match its source, or the Worker ships
+      # skills, doctrine or component source that disagree with the repo.
+      - name: Verify generated artifacts are current
+        run: |
+          set -euo pipefail
+          pnpm skills:generate:check
+          pnpm doctrine:generate:check
+          pnpm registry:index:check
+          pnpm registry:source:check
+
+      - name: Build the Worker
+        run: pnpm exec opennextjs-cloudflare build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+
+      - name: Publish to Cloudflare Workers
+        id: publish
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+
+      # Verified against what is live, not against the build log. A deploy that
+      # reports success and then serves 500s is the failure this catches.
+      #
+      # The base URL comes from the deploy output rather than a hardcoded
+      # workers.dev hostname: guessing the account's subdomain would turn a
+      # healthy deploy into a wall of connection failures.
+      - name: Smoke-test the deployed Worker
+        env:
+          BASE: ${{ steps.publish.outputs.deployment-url }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BASE:-}" ]; then
+            echo "::error::wrangler reported no deployment URL; cannot verify the deploy."
+            exit 1
+          fi
+          echo "Verifying $BASE"
+          fail=0
+          check() {
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "$BASE$1" || echo 000)
+            if [ "$code" != "$2" ]; then
+              echo "::error::$1 returned $code, expected $2"
+              fail=1
+            else
+              echo "  ok  $1 -> $code"
+            fi
+          }
+          check / 200
+          check /api/v1/skills 200
+          check /api/v1/ecosystem 200
+          check /api/v1/ui/button 200
+          # A TypeScript-only component. A 200 from /rs here would mean the Rust
+          # registry is serving the wrong language, which is worse than a 404.
+          check /api/v1/rs/data-table 404
+          # The retired second MCP must stay a redirect, not become a page.
+          check /mcp 308
+          exit "$fail"

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ CLAUDE.md
 # OpenNext build output (Cloudflare Workers)
 .open-next/
 .wrangler/
+.env.production.local

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -26,6 +26,7 @@
   "ignores": [
     "node_modules/**",
     ".next/**",
+    ".open-next/**",
     "public/_pagefind/**",
     "CHANGELOG.md",
     ".github/ISSUE_TEMPLATE/**",

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,7 @@
 # Build outputs
 .next/
+.open-next/
+.wrangler/
 out/
 dist/
 build/

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -9,6 +9,8 @@ extends: default
 
 ignore: |
   .next/
+  .open-next/
+  .wrangler/
   node_modules/
   public/_pagefind/
   pnpm-lock.yaml

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,10 @@ export default tseslint.config(
   {
     ignores: [
       ".next/**",
+      // OpenNext build output, and wrangler's local state. Both are
+      // generated (and gitignored) — same reasoning as `.next/**` above.
+      ".open-next/**",
+      ".wrangler/**",
       "node_modules/**",
       "packages/*/node_modules/**",
       "packages/*/dist/**",


### PR DESCRIPTION
## Summary

The app half of leaving Vercel landed across #275–#279: no module reads the filesystem at request time any more, `open-next.config.ts` and `wrangler.jsonc` are committed, and the built Worker runs in workerd (`wrangler dev --local` serves `/`, all the `/api/v1/*` routes and the `/mcp` redirect correctly; upload is 6,889 KiB gzipped against the 10 MB limit).

What was missing was a way to publish it that isn't someone's laptop. This adds that, plus a fix for four lint gates the Worker build breaks.

This does **not** cut over. The workflow is `workflow_dispatch`-only behind a typed confirmation, so merging it changes nothing about what serves `mzizi.dev`.

## Changes

- **`.github/workflows/deploy-worker.yml`** — build and publish the Worker, modelled on `nyuchi/mzizi-tools` `deploy-mzizi-mcp.yml` so both Workers ship the same way, with three differences the portal needs:
  - Runs the full PR gate first (`typecheck`, `lint`, `test`) plus all four `--check` generators. A deploy path that skips the gates is how a broken build reaches production faster than a reviewed one.
  - Passes `NEXT_PUBLIC_SUPABASE_*` to the **build**, not as Worker secrets. Next inlines every `NEXT_PUBLIC_*` variable when it compiles; set as Worker secrets they'd be read by nothing and every database-backed route would answer 503 "Database not configured".
  - Smoke-tests the deployed Worker over HTTP afterwards, against the URL `wrangler` reports (`steps.publish.outputs.deployment-url`) rather than a guessed `workers.dev` hostname. A deploy that reports success and then serves 500s is the failure that catches.
- **`eslint.config.mjs`, `.prettierignore`, `.markdownlint-cli2.jsonc`, `.yamllint.yml`** — ignore `.open-next/` (and `.wrangler/`) alongside the `.next/` entry each already carries.
- **`.gitignore`** — `.env.production.local`, which is how the build gets those two variables locally.

### Why the lint change is here and not separate

Running `opennextjs-cloudflare build` leaves `.open-next/` in the tree. It's gitignored, but these four configs walk the working tree, not the index:

| gate | with `.open-next/` present |
|---|---|
| `pnpm lint` | 2212 parsing errors — `.open-next/server-functions/default` carries its own tsconfig, so typescript-eslint finds two candidate roots and refuses to parse anything |
| `pnpm lint:md` | MD037 against a copy of `accessibility-audit.md`, a registry component already ignored at its real path |
| `pnpm format:check` | did not finish — prettier walks the whole bundle |
| `pnpm lint:yaml` | clean today; excluded for the same reason |

No rule changes and nothing newly exempted from review — the added paths are generated build output that was never meant to be linted, exactly as `.next/` already is.

## Type

- [x] CI/infrastructure

## Pre-commit Gate (must pass locally before pushing)

- [x] `pnpm lint` — zero warnings
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm test` — 251 passed (28 files)
- [x] `pnpm audit --audit-level=moderate` — zero vulnerabilities
- [x] `pnpm exec prettier --check` — all files formatted

All four re-run **with `.open-next/` present**, which is the state that motivated the ignore change.

## Quality Checklist

- [x] No new tests: the change is a workflow definition and four ignore lists. What would be tested is the workflow run itself, which is why it smoke-tests the deployed Worker rather than trusting the build log.
- [x] `yamllint 1.35.1` (the version CI pins) clean on the new workflow
- [x] `cloudflare/wrangler-action@v3` really does declare a `deployment-url` output — checked against `action.yml` on the `v3` branch, not from memory
- [x] Action versions match `ci.yml` (`checkout@v7`, `setup-node@v7` with `node-version: 22`, `pnpm/action-setup@v6`). An earlier draft used `node-version-file: .nvmrc`; this repo has no `.nvmrc`, so that step would have failed on first run.

Not applicable: registry/design-system, architecture/docs, screenshots.

## Before this can actually deploy

Four repository secrets (Settings → Secrets and variables → Actions), documented in the workflow header:

| secret | value |
|---|---|
| `CLOUDFLARE_API_TOKEN` | Workers Scripts:Edit — plus Workers Routes:Edit and DNS:Edit once the domain is attached |
| `CLOUDFLARE_ACCOUNT_ID` | the account hosting the Worker |
| `NEXT_PUBLIC_SUPABASE_URL` | the project URL |
| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | the project's anon key |

Both Supabase values are already shipped to browsers today, so this is not a new exposure.

## The remaining cutover, which this PR deliberately does not do

1. Set the four secrets.
2. Run the workflow by hand, typing `deploy`.
3. Confirm the `workers.dev` URL serves correctly (the smoke test does this, but look at it).
4. Attach `mzizi.dev` to the Worker and point DNS.
5. Retire the Vercel project, then add `on: push` to `main` here.

Steps 2–5 are a deliberate act by someone who can also point DNS, not a side effect of merging a file.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_