### PR TITLE
refactor: drop the Vercel file-tracing hint and the docblock it belonged to

### DIFF
--- a/lib/registry-source.ts
+++ b/lib/registry-source.ts
@@ -19,12 +19,6 @@
 import SOURCES from "./registry-source.generated.json"
 import { basename, extname } from "node:path"
 
-/**
- * Resolved against `process.cwd()` so it works in `next dev`, in a Vercel
- * lambda, and in a script. The directory has to be traced into the deployed
- * bundle explicitly — see `outputFileTracingIncludes` in `next.config.mjs`,
- * without which these reads succeed locally and 404 in production.
- */
 // `REGISTRY_ROOT` is gone with the filesystem reads. The index is built from
 // the keys of the generated artifact, and the "path" a component resolves to is
 // now that artifact's key — `<node-dir>/<file>` — rather than an absolute path.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -38,21 +38,24 @@ const nextConfig = {
   },
   transpilePackages: ["radix-ui"],
 
-  // Component source lives on disk under `components/registry/**` and is read
-  // at request time by `@/lib/registry-source`. Those reads are dynamic
-  // (readdir + readFileSync), so Next's static trace cannot see them and the
-  // files would be absent from the deployed lambdas — the reads succeed in
-  // `next dev` and 404 in production, which is the worst-shaped failure
-  // available here. Tracing them in explicitly is what makes the registry
-  // route serve real source on Vercel.
-  outputFileTracingIncludes: {
-    "/api/v1/ui/[name]": ["./components/registry/**/*"],
-    "/api/v1/stats": ["./components/registry/**/*"],
-    "/mcp": ["./components/registry/**/*"],
-    "/source/[name]": ["./components/registry/**/*"],
-    "/components/[name]": ["./components/registry/**/*"],
-    "/playground/[name]": ["./components/registry/**/*"],
-  },
+  // `outputFileTracingIncludes` stood here, naming `components/registry/**` for
+  // six routes. It existed because `@/lib/registry-source` read those files at
+  // request time with `readdir` + `readFileSync` — dynamic reads Next's static
+  // trace cannot see, so without the hint the reads succeeded in `next dev` and
+  // 404'd in a Vercel lambda.
+  //
+  // Nothing reads them at request time any more. The source is inlined into
+  // `lib/registry-source.generated.json` at build time, and every remaining
+  // `components/registry/...` reference is a static import the bundler resolves.
+  // The hint now describes a mechanism this app no longer has, which is the
+  // reason to delete it: a comment asserting request-time filesystem reads is
+  // how the next person concludes the Vercel coupling is still real.
+  //
+  // It buys no size back, and that was checked rather than assumed. All 609
+  // files are still traced into `.open-next/server-functions/default/` without
+  // it — Next reaches them through the static imports — and the Worker upload
+  // is unchanged at ~6.9 MB gzipped either way. This is a correctness cleanup,
+  // not an optimisation.
 
   turbopack: {
     resolveAlias: {


### PR DESCRIPTION
## Summary

`outputFileTracingIncludes` in `next.config.mjs` named `components/registry/**` for six routes. It was there because `lib/registry-source.ts` opened those files at request time with `readdir` + `readFileSync` — dynamic reads Next's static trace cannot follow, so without the hint they succeeded in `next dev` and 404'd in a Vercel lambda.

Those reads are gone (#278). The source is inlined into `lib/registry-source.generated.json` at build time, and every remaining `components/registry/...` reference in `app/` and `lib/` is a static import the bundler resolves. Nothing in either directory imports `node:fs` any more outside the three OG-image routes, which read their own font files.

What's left is config describing a mechanism the app no longer has — and, above the deleted `REGISTRY_ROOT`, an orphaned docblock still explaining that these paths resolve against `process.cwd()` *"so it works in a Vercel lambda"*. A comment asserting request-time filesystem reads is how the next person concludes the Vercel coupling is still real.

## Changes

- `next.config.mjs` — remove `outputFileTracingIncludes`; replace it with a note on why it existed and why it no longer applies.
- `lib/registry-source.ts` — remove the docblock that documented `REGISTRY_ROOT`, which was deleted in #278. The `// REGISTRY_ROOT is gone with the filesystem reads` comment immediately below it already says what happened.

## This is a correctness cleanup, not an optimisation

Worth stating plainly, because I expected otherwise and measured instead of assuming.

The guess was that the hint forced a second raw copy of source into the bundle — 3.8 MB of files the deployment already carries as a 2.8 MB JSON artifact. **That is wrong.** Rebuilt without the hint:

| | with the hint | without it |
|---|---|---|
| files under `.open-next/server-functions/default/components/registry` | 609 (3.8 MB) | 609 (3.8 MB) |
| Worker upload, gzipped | 6,889 KiB | 6,945 KiB |

Next reaches those files through the static imports regardless, so the hint was already redundant for inclusion. **Nothing is reclaimed** — the ~56 KiB difference is build noise against unrelated commits on `main`, not a regression this introduces. If you were hoping for headroom against the 10 MB limit, this is not where it is.

## Verification

In workerd (`wrangler dev --local`), not from the build log. All six formerly-traced routes serve:

```
/                        200   212,274 B
/api/v1/skills           200     3,985 B
/api/v1/ecosystem        200     7,226 B
/api/v1/stats            200     4,217 B
/api/v1/ui/button        200     5,287 B
/source/button           200    94,295 B
/components/button       200   138,824 B
/playground/button       200   122,267 B
```

Content checked as well as status, because a 200 with an empty body is how this codebase's past defects hid: `/api/v1/ui/button` returns the same **3,643 bytes of real React** as the pre-migration baseline (`import * as React from "react"` … `cva` … `radix-ui`), and `/api/v1/stats` returns live counts (5,626 API calls, 1.1% error rate).

The correct non-200s still hold: `/api/v1/rs/data-table` 404 (TypeScript-only component — a 200 there would mean the Rust registry is serving the wrong language), `/mcp` 308 to `mcp.mzizi.dev`.

## Type

- [x] CI/infrastructure

## Pre-commit Gate (must pass locally before pushing)

- [x] `pnpm lint` — zero warnings
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm test` — 251 passed (28 files)
- [x] `pnpm audit --audit-level=moderate` — zero vulnerabilities
- [x] `pnpm exec prettier --check` — all files formatted

## Quality Checklist

- [x] No new tests. The behaviour under change is what the *bundler* includes, which a unit test cannot observe — it is checked by building and serving, which is what the verification above does.
- [x] Safe while Vercel still serves production: the removal changes no code path. Both targets resolve the source through the same generated JSON.
- [x] No hardcoded colors, no wordmark or accessibility surface touched.

Not applicable: registry/design-system rows, architecture docs, screenshots.

## Still outstanding after this

`app/privacy/page.tsx` names Vercel as a data processor. That is **true today** and must not be changed until the Worker actually serves `mzizi.dev` — it is a live legal statement, and editing it early would make the page false in the other direction. Flagging it so it is not missed at cutover.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_