### PR TITLE
fix: have sync-tokens ask prettier instead of imitating it

### DIFF
--- a/scripts/sync-tokens.ts
+++ b/scripts/sync-tokens.ts
@@ -45,6 +45,10 @@
  * against; an experimental set can change, and widening a published surface is
  * a separate decision from ending a drift hole.
  *
+ * Every artifact prettier has a parser for is passed through prettier before it
+ * is written or compared (see `prettified()`), so `pnpm tokens:sync` leaves the
+ * tree formatted rather than needing a format pass afterwards.
+ *
  * Modes:
  *   pnpm tokens:sync     regenerate the artifacts from the DB
  *   pnpm tokens:verify   non-mutating CI gate; exits non-zero if an artifact
@@ -58,6 +62,7 @@
 import { readFile, writeFile } from "fs/promises"
 import { join } from "path"
 import { createClient } from "@supabase/supabase-js"
+import { format, getFileInfo, resolveConfig } from "prettier"
 
 const CHECK = process.argv.includes("--check")
 
@@ -693,6 +698,39 @@ function spliceRegion(css: string, region: string, body: string): string {
   return css.slice(0, s + start.length) + "\n" + body + "\n  " + css.slice(e)
 }
 
+/**
+ * Run an emitted artifact through prettier before it is written or compared.
+ *
+ * The renderers above hand-indent their templates, which is a guess at what
+ * prettier does — and it was wrong: they emitted four-space object bodies while
+ * prettier's config says two, so every `tokens:sync` left
+ * `nyuchi-tokens-react-native.ts` 88 lines dirty and `pnpm format:check`
+ * failing. `tokens:verify` could not see it, by design: it compares with
+ * `norm()` so that a reformat never trips the value-drift gate. That gate is
+ * right and stays; the defect was upstream, in a generator imitating a
+ * formatter instead of asking it.
+ *
+ * So this asks. `.prettierrc` is the single source of truth for formatting, and
+ * resolving it per file (rather than baking options in here) means the
+ * generator keeps agreeing with `format:check` when that config changes.
+ *
+ * Content is returned untouched when prettier has nothing to say about the
+ * file: the Swift, Kotlin, ArkTS, Python and Rust targets have no prettier
+ * parser, and a path listed in `.prettierignore` is one whose generator owns
+ * its formatting on purpose (`registry.json`, `components/ui/` — see the
+ * comments there). In both cases the renderer's own indentation is the
+ * committed shape, and reformatting it would be the drift, not the fix.
+ */
+async function prettified(filePath: string, source: string): Promise<string> {
+  const { ignored, inferredParser } = await getFileInfo(filePath, {
+    ignorePath: join(process.cwd(), ".prettierignore"),
+    resolveConfig: true,
+  })
+  if (ignored || !inferredParser) return source
+  const options = await resolveConfig(filePath)
+  return format(source, { ...options, filepath: filePath })
+}
+
 /** Strip whitespace so value drift is caught but formatting differences are not. */
 const norm = (s: string) => s.replace(/\s+/g, "")
 
@@ -750,17 +788,28 @@ function checkExperimentalCss(css: string, experimental: Experimental[]): string
 async function main() {
   const { minerals, heritage, experimental } = await fetchPalette()
 
-  const paletteModule = renderPaletteModule(minerals, heritage, experimental)
+  const paletteModule = await prettified(
+    PALETTE_TS,
+    renderPaletteModule(minerals, heritage, experimental)
+  )
   let css = await readFile(GLOBALS_CSS, "utf8")
   css = spliceRegion(css, "theme", renderThemeBlock(minerals, heritage))
   css = spliceRegion(css, "light", renderVars(minerals, heritage, "light"))
   css = spliceRegion(css, "dark", renderVars(minerals, heritage, "dark"))
+  css = await prettified(GLOBALS_CSS, css)
 
-  const platforms = PLATFORM_TARGETS.map((t) => ({
-    path: join(N1, t.file),
-    label: `components/registry/n1-tokens/${t.file}`,
-    body: t.render(minerals, heritage),
-  }))
+  // Formatting happens here, on the way to BOTH branches, so `--check` measures
+  // the bytes `tokens:sync` would actually write.
+  const platforms = await Promise.all(
+    PLATFORM_TARGETS.map(async (t) => {
+      const path = join(N1, t.file)
+      return {
+        path,
+        label: `components/registry/n1-tokens/${t.file}`,
+        body: await prettified(path, t.render(minerals, heritage)),
+      }
+    })
+  )
 
   if (CHECK) {
     const onDiskPalette = await readFile(PALETTE_TS, "utf8")


### PR DESCRIPTION
## Summary

`scripts/sync-tokens.ts` hand-indents its templates, and the guess was wrong: the ArkTS and React Native renderers emit four-space object bodies while `.prettierrc` says two. So every `pnpm tokens:sync` rewrote `components/registry/n1-tokens/nyuchi-tokens-react-native.ts` with 88 changed lines carrying identical values — pure re-indentation — and left `pnpm format:check` failing.

`pnpm tokens:verify` could not see it, and that is deliberate rather than an oversight. It compares through `norm()`, which strips whitespace, so a reformat never trips the value-drift gate. **That gate is about values and it stays exactly as it is — this PR does not touch `norm()`.** The defect was upstream, in a generator imitating a formatter instead of asking it. This is option (1) from #262.

## Changes

- Added `prettified(filePath, source)` to `scripts/sync-tokens.ts`. It resolves `.prettierrc` **per file** through prettier's own Node API (`getFileInfo` + `resolveConfig` + `format`) and formats the rendered content on the way out. Resolving the config rather than restating its options is the point: the generator keeps agreeing with `format:check` when someone changes `tabWidth` or adds a plugin, which option (2) — matching prettier's output in the templates — would silently stop doing.
- Content is returned **untouched** when prettier has nothing to say about the file. Prettier has no parser for the Swift, Kotlin, ArkTS, Python and Rust targets (`inferredParser` is `null` for all five), and a path listed in `.prettierignore` is one whose generator owns its formatting on purpose. In both cases the renderer's indentation *is* the committed shape, so reformatting would be the drift, not the fix.
- Formatting happens **before** the `--check` branch as well as the write branch, so `tokens:verify` measures the bytes `tokens:sync` would actually write rather than a different pipeline that happens to normalise to the same thing.
- Docblock updated to say the artifacts are prettier-formatted on the way out.

No artifact content changed: `lib/tokens/palette.generated.ts` and `app/globals.css` were already prettier-shaped, and the committed React Native file was already the prettier-formatted version a human had fixed up by hand. The diff is the script only.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Component addition
- [ ] Block addition
- [ ] Portal page
- [ ] Brand/design system update
- [ ] Documentation
- [ ] CI/infrastructure
- [ ] Security / dependency update

## Pre-commit Gate (must pass locally before pushing)

- [x] `pnpm lint` — zero warnings
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm test` — 251 tests pass (28 files)
- [x] `pnpm audit --audit-level=moderate` — zero vulnerabilities
- [x] `pnpm exec prettier --check` — all files formatted

Plus, against the live Supabase store:

- [x] `pnpm tokens:sync` → **zero** artifact changes (was 44 insertions / 44 deletions in the React Native target)
- [x] `pnpm tokens:sync && pnpm format:check` → *"All matched files use Prettier code style!"*
- [x] `pnpm tokens:verify` → passes
- [x] whitespace tolerance intact — re-indenting the entire React Native file to eight spaces by hand and running `pnpm tokens:verify` **still passes**, which is the property `norm()` exists to provide

## Quality Checklist

- [ ] New tests added for new functionality — **deliberately not.** The assertion this needs already exists as a CI job: `format:check` over the tracked tree *is* "the generator emits what prettier would". A second copy in `__tests__` would restate the check rather than strengthen it, and could not exercise the generator anyway without network access to Supabase.
- [x] No hardcoded colors — no colour values touched
- [x] Brand wordmarks lowercase
- [x] `CLAUDE.md` unchanged — no architecture, command or convention change

## Notes

`pnpm format:check` was clean in a fresh worktree. The 41 `mzizi-rs/target/` warnings noted at the bottom of #262 are build artifacts that only appear after a Rust build; excluding them is a separate change, as the issue says.

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED


---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_