### PR TITLE
fix: let `next build` typecheck — drop `typescript.ignoreBuildErrors`

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -30,9 +30,20 @@ const withMDX = createMDX({
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ["ts", "tsx", "md", "mdx"],
-  typescript: {
-    ignoreBuildErrors: true,
-  },
+
+  // There is deliberately no `typescript: { ignoreBuildErrors: true }` here.
+  // It stood in this file until #274 and meant `next build` — the step that
+  // produces what users actually get — compiled and shipped regardless of type
+  // errors. `pnpm typecheck` was the only real gate, and it is a convention
+  // (pre-commit hook) plus a CI job the deploy does not depend on.
+  //
+  // Without the flag Next runs `tsc` itself as part of the build, over a
+  // tsconfig that includes `.next/types/**` — the generated route types. CI's
+  // `Type Check` job runs `pnpm typecheck` on a bare checkout, where that
+  // directory does not exist yet, so those generated types are only ever
+  // checked here. Do not put the flag back: it removes the last gate the
+  // deploy path has of its own.
+
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
## Summary

`next.config.mjs` carried `typescript: { ignoreBuildErrors: true }`, so `next build` — the step that produces what users actually get — compiled and shipped regardless of type errors. Everything protecting the codebase sat elsewhere: the pre-commit hook (skippable with `--no-verify`, bypassed by a merge commit or a web-UI edit) and the `Type Check` required status check on `main` (blocks a merge, but is not what the deploy depends on). That is the inverse of where a gate belongs.

It stopped being theoretical when mzizi.dev moved to Cloudflare Workers (#279, #280): `deploy-worker.yml` runs `opennextjs-cloudflare build`, which runs `next build`, so the untypechecked build is literally what ships to production.

**What removing it surfaced: nothing. Zero errors.** The flag was pure legacy — a batch of errors long since fixed, with the flag outliving the batch. No `@ts-expect-error` and no `any` was added anywhere, because nothing needed fixing.

One thing #274 anticipated turns out to be real. `next build` typechecks against a tsconfig whose `include` covers `.next/types/**/*.ts` — Next's generated route types. CI's `Type Check` job is a bare checkout plus `pnpm typecheck`, with no build before it, so `.next/types/` does not exist when it runs and those generated types are never reached there. They are only ever checked by the build. So this is not a redundant second copy of `pnpm typecheck`: with the flag on, one category of type error had no gate at all.

Closes #274

## Changes

- Deleted the `typescript: { ignoreBuildErrors: true }` block from `next.config.mjs`.
- Left a comment in its place explaining why the flag is deliberately absent, what the build now checks that `pnpm typecheck` in CI does not, and not to restore it. The absence is the point, and it is invisible without a note.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Component addition
- [ ] Block addition
- [ ] Portal page
- [ ] Brand/design system update
- [ ] Documentation
- [x] CI/infrastructure
- [ ] Security / dependency update

## Pre-commit Gate (must pass locally before pushing)

- [x] `pnpm lint` — zero warnings
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm test` — 251 tests across 28 files pass (the template's "123" is stale)
- [x] `pnpm audit --audit-level=moderate` — zero vulnerabilities
- [x] `pnpm exec prettier --check` — formatted

Also run beyond the gate:

- [x] `pnpm build` from a removed `.next` — `Running TypeScript ... Finished TypeScript in 22.9s`, then a clean 1,225-page static generation.
- [x] `pnpm exec opennextjs-cloudflare build` — completes, `Worker saved in .open-next/worker.js`. Run with `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` present at build time, since Next inlines `NEXT_PUBLIC_*` at compile time.

### Verifying the gate is actually live

"It builds green" is not on its own evidence, since a build that ignores type errors also builds green. Checked directly instead — a deliberate `const n: number = "definitely not a number"` dropped into `app/` fails the build:

```text
app/probe-typecheck-canary.tsx(2,9): error TS2322: Type 'string' is not assignable to type 'number'.
Failed to type check.
```

with a non-zero exit. The canary was removed; nothing from it is in the diff.

## Quality Checklist

- [x] New tests added for new functionality — n/a, this removes a config flag; the behaviour is verified by the build itself and by the canary above.
- [x] No hardcoded colors — n/a
- [x] Brand wordmarks are lowercase — n/a
- [x] Accessibility — n/a, no UI change
- [x] Ubuntu design checklist — n/a
- [x] AI output safety checks — n/a, no AI features touched

## Registry / Design System

Not applicable — no registry, Supabase, or component surface touched.

## Architecture / Docs

- [x] `CLAUDE.md` — no architecture, command or convention change; the reasoning lives in the config comment where someone about to re-add the flag will actually read it.
- [ ] `CHANGELOG.md` — not updated, matching the rest of this series (#277–#281 each left it alone). Happy to add an `[Unreleased]` entry if preferred.
- [x] `openapi.yaml` — no API surface change
- [x] Version bump — not a release

## Screenshots

None — no user-visible change. The change is that a red build is now a failed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_