### PR TITLE
fix(lint): stop the palette lint reporting correct code, so its 9 real hits can be seen

### DIFF
--- a/scripts/lint-colors.ts
+++ b/scripts/lint-colors.ts
@@ -23,8 +23,113 @@ import { minerals, heritageColors } from "../lib/tokens/palette.generated"
 
 const ROOT = process.cwd()
 const SCAN_DIRS = ["app", "components", "lib", "hooks"]
-// Canonical token files may legitimately hold raw palette hexes.
-const ALLOW = ["lib/tokens/", "app/globals.css", "packages/design-cli/templates/", "scripts/"]
+
+/**
+ * Paths whose raw palette hexes are correct, each with the reason it is correct.
+ *
+ * An entry here is a claim that the hex CANNOT be a token reference at this
+ * path — not that the violation is inconvenient. Widening this list to quieten
+ * a component that could reference a token turns the gate off silently, so the
+ * reason is part of the data and has to survive review alongside the path.
+ */
+const ALLOW: { prefix: string; why: string }[] = [
+  {
+    prefix: "lib/tokens/",
+    why: "The generated palette itself — the vocabulary this lint is checked against.",
+  },
+  {
+    prefix: "app/globals.css",
+    why: "The canonical `:root` / `.dark` declarations. N1's web emitter output.",
+  },
+  {
+    prefix: "packages/design-cli/templates/",
+    why: "Scaffolding emitted into a consumer's repo, where our tokens do not exist yet.",
+  },
+  { prefix: "scripts/", why: "Generators and this lint, which must name hexes to check them." },
+  {
+    prefix: "components/registry/n1-tokens/",
+    why:
+      "N1 is the only layer allowed to DEFINE a design value — docs/pulling-in-primitives.md §3, " +
+      "invariant 1 " +
+      '("If you find yourself typing a hex, stop." — everything else consumes), and ' +
+      "content/doctrine/documentation-architecture-nodes/design-tokens.mdx, whose `role` is " +
+      '"N1 — the only node allowed to define CSS values". This is the same reason `lib/tokens/` ' +
+      "is above; the boundary is the LAYER, not the file, so the directory is listed rather " +
+      "than the three files that happen to trip today. Most of it is generated anyway: " +
+      "scripts/sync-tokens.ts writes nyuchi-tokens-{react-native,swift,kotlin,arkts,python,rust} " +
+      "from the Supabase store and `pnpm tokens:verify` is their drift gate — so the hexes here " +
+      "are already checked, by a stricter check than this one.",
+  },
+  {
+    prefix: "app/manifest.ts",
+    why:
+      "A web app manifest is JSON served to the browser. It cannot resolve a CSS custom " +
+      "property, so `theme_color` / `background_color` have nowhere to reference a token " +
+      "from — the same reason `next/og` routes are exempt (§7.4). The file already says so " +
+      "in its docblock; this is the lint agreeing with it.",
+  },
+  /**
+   * `color-picker` and `caption-editor` present colours for a user to CHOOSE.
+   *
+   * This is not a new exemption — it is this lint catching up with a decision
+   * the repo already made and wrote down. `scripts/validate-registry.mjs`
+   * enforces the same §7.4 rule over registry component source and exempts
+   * exactly these two by name (`LITERAL_COLOUR_DATA`), because "the hex is the
+   * value the component returns, so it has to be a literal: a swatch rendered
+   * as `var(--color-cobalt)` cannot report which colour was picked."
+   *
+   * `color-picker` proves it mechanically: the value round-trips through a
+   * `maxLength={7}` text input and is validated with /^#[0-9A-Fa-f]{6}$/, which
+   * `var(--color-cobalt)` fails. `caption-editor` hands the same string back
+   * through `onColorChange` for the consumer to store.
+   *
+   * Two gates enforcing one rule and disagreeing about which files break it is
+   * itself a blind spot: `pnpm check` failed on files `pnpm registry:validate`
+   * had already cleared, and the two lists had no way to notice each other.
+   * These are listed per file, not as an `n2-primitives/` directory, because
+   * the exemption belongs to those two components and to nothing else in that
+   * layer. The residual — both files RETYPE N1's palette
+   * instead of sourcing it, and `color-picker`'s "Terracotta" swatch (#D4A574)
+   * is not the terracotta token (#A0522D / #E1B07E) — is recorded in
+   * `validate-registry.mjs` and needs the §15.6 self-containment rule relaxed
+   * before it can be fixed. Neither gate can see that drift; a hex that is not
+   * a palette value is invisible to this one by design.
+   */
+  {
+    prefix: "components/registry/n2-primitives/color-picker.tsx",
+    why: "Colour DATA, not styling — see the block comment above.",
+  },
+  {
+    prefix: "components/registry/n2-primitives/caption-editor.tsx",
+    why: "Colour DATA, not styling — see the block comment above.",
+  },
+]
+
+/**
+ * Generated artifacts are skipped entirely.
+ *
+ * This rule exists to stop a hex being hardcoded in code that should reference
+ * a token. A generated file is not code anybody writes — its content is
+ * governed by its source, and pointing at the projection tells the wrong
+ * person to edit a file whose first line says "do not edit".
+ *
+ * It is not hypothetical. Inlining the skills bundle put
+ * `lib/skills.generated.ts` in `lib/`, and one skill body TEACHES the canonical
+ * token block:
+ *
+ *     --color-terracotta: #a0522d; \/* Community *\/
+ *
+ * That is the same content as `app/globals.css`, which is on the allow-list
+ * above, arriving by a different route — so the linter reported nine
+ * violations for documentation doing exactly what the rule wants. `pnpm
+ * lint:colors` has been red on `main` ever since, and nothing noticed because
+ * it runs only via `pnpm check`, never in CI.
+ *
+ * The gate is not weakened. A hex hardcoded in a generated file means a hex
+ * hardcoded in its SOURCE, and that is where it has to be caught — for skills,
+ * in `nyuchi/mzizi-tools`, where the SKILL.md is authored.
+ */
+const GENERATED = /\.generated\.(ts|tsx|json)$/
 
 // hex (lowercase) -> token name, for a helpful message.
 const paletteHex = new Map<string, string>()
@@ -47,6 +152,33 @@ for (const h of heritageColors) {
 
 const HEX = /#[0-9a-fA-F]{6}\b/g
 
+/**
+ * Is the position at the end of `before` inside an unclosed `var(`?
+ *
+ * This walks the parentheses with a stack instead of counting them, because
+ * counting got it wrong. The previous form subtracted every `)` on the line
+ * from the number of `var(`s, so ANY earlier parenthesis — one that had
+ * nothing to do with a var() — cancelled the var out and the fallback hex was
+ * reported as a hardcoded colour:
+ *
+ *     rainfall: { label: "Rainfall (mm)", color: "var(--color-tanzanite, #B388FF)" }
+ *                                ^^^^ this `)` closed the `var(`
+ *
+ * That is textbook-correct token usage — a var() reference with a fallback,
+ * exactly what the rule asks for — and it was two of the violations standing
+ * between `pnpm lint:colors` and green. A stack keeps unrelated parens
+ * balanced against their own openers and nests properly, so
+ * `var(--a, var(--b, #hex))` is inside a var() at both depths.
+ */
+function insideVar(before: string): boolean {
+  const stack: boolean[] = []
+  for (let i = 0; i < before.length; i++) {
+    if (before[i] === "(") stack.push(before.slice(Math.max(0, i - 3), i) === "var")
+    else if (before[i] === ")") stack.pop()
+  }
+  return stack.includes(true)
+}
+
 async function* walk(dir: string): AsyncGenerator<string> {
   let entries
   try {
@@ -59,7 +191,7 @@ async function* walk(dir: string): AsyncGenerator<string> {
     if (e.isDirectory()) {
       if (e.name === "node_modules" || e.name === ".next") continue
       yield* walk(full)
-    } else if (/\.(ts|tsx)$/.test(e.name)) {
+    } else if (/\.(ts|tsx)$/.test(e.name) && !GENERATED.test(e.name)) {
       yield full
     }
   }
@@ -70,7 +202,7 @@ async function main() {
   for (const base of SCAN_DIRS) {
     for await (const file of walk(join(ROOT, base))) {
       const rel = relative(ROOT, file)
-      if (ALLOW.some((a) => rel.startsWith(a))) continue
+      if (ALLOW.some((a) => rel.startsWith(a.prefix))) continue
       // Blank out block + line comments so documented hexes aren't flagged,
       // preserving newlines so reported line numbers stay accurate.
       const text = (await readFile(file, "utf8")).replace(/\/\*[\s\S]*?\*\//g, (m) =>
@@ -83,12 +215,8 @@ async function main() {
           const hex = match[0].toLowerCase()
           const token = paletteHex.get(hex)
           // A hex used as a `var(--color-x, #fallback)` fallback is correct
-          // token usage — skip it. We're inside a var() if more `var(` than `)`
-          // precede the match on this line.
-          const before = code.slice(0, match.index ?? 0)
-          const openVars =
-            (before.match(/var\(/g)?.length ?? 0) - (before.match(/\)/g)?.length ?? 0)
-          if (token && openVars <= 0) {
+          // token usage — skip it.
+          if (token && !insideVar(code.slice(0, match.index ?? 0))) {
             const k = `${rel}:${i + 1}:${hex}`
             if (!seen.has(k)) {
               seen.add(k)


### PR DESCRIPTION
## Summary

`pnpm lint:colors` has been red on `main` with **139 violations**, and had been for a while. **130 of them were the lint being wrong.** It runs only inside `pnpm check`, never in CI, so nothing ever objected — and 139 lines of output nobody trusts is the same as no gate at all.

This fixes the lint. It does **not** fix the 9 real violations that were hiding underneath, and it does not force the command green.

**`pnpm lint:colors` is still RED, with 9 violations. That is the intended outcome** — a linter reporting a real violation is working. All 9 have one root cause and need a design decision, filed as **#288**.

## Changes

Three defects in `scripts/lint-colors.ts`, one file, no component source touched.

**1. A `)` anywhere earlier on the line cancelled a `var(`.** The fallback-detection counted `var(` occurrences and subtracted every `)` on the line, so an unrelated parenthesis swallowed the opener:

```ts
rainfall: { label: "Rainfall (mm)", color: "var(--color-tanzanite, #B388FF)" }
                           //  ^^^^ this `)` "closed" the var(
```

That is exactly the token usage the rule asks for, reported as a hardcoded colour — `chart-area-axes` and `chart-radar-label-custom`. Counting is replaced with a paren stack, which also makes nested `var(--a, var(--b, #hex))` read correctly at both depths.

**2. Generated artifacts were scanned.** Inlining the skills bundle put `lib/skills.generated.ts` under `lib/`, and one skill body *teaches* the canonical token block — `--color-terracotta: #a0522d;`, the same content as `app/globals.css`, which is already allowed, arriving by a different route. Nine violations for documentation doing precisely what the rule wants. `*.generated.*` is now skipped. The gate is not weakened: a hex in a generated file means a hex in its **source**, which for skills is the SKILL.md in `nyuchi/mzizi-tools`.

**3. The allow-list did not describe the layer the doctrine describes.** ~110 hits were `components/registry/n1-tokens/`. N1 is the only layer permitted to *define* a design value — `docs/pulling-in-primitives.md` §3 invariant 1 ("If you find yourself typing a hex, stop"), and `design-tokens.mdx` `role: "N1 — the only node allowed to define CSS values"`. Same reason `lib/tokens/` was already listed; the boundary is the **layer**, so the directory is listed rather than the three files that happen to trip today. Most of it is generated by `scripts/sync-tokens.ts` and gated by `pnpm tokens:verify` anyway — already checked by something stricter.

Three files join it, each with a stated reason:

- **`app/manifest.ts`** — a web app manifest is JSON served to the browser and cannot resolve a custom property. The file's own docblock already says so, citing the same §7.4 exemption `next/og` routes get.
- **`color-picker` + `caption-editor`** — not a new judgement. `scripts/validate-registry.mjs` already made this one and wrote it down in `LITERAL_COLOUR_DATA`: the hex is the value the component returns, and a swatch rendered as `var(--color-cobalt)` cannot report which colour was picked. `pnpm check` was failing on files `pnpm registry:validate` had already cleared.

`ALLOW` entries now carry the reason they exist, **as data**. An entry there is a claim that a hex *cannot* be a token reference at that path; that claim should have to survive review next to the path it exempts.

## What is deliberately NOT in this PR

- **The 9 remaining violations** — `wallet-card.tsx:17-20` (8) and `nyuchi-create-listing.tsx:36` (1). Every one is a gradient needing a mineral's light *and* dark value simultaneously, and N1 publishes neither: `var(--color-tanzanite)` resolves to one or the other per theme, so substituting it collapses both stops and flattens the gradient. Four files already reach for a `--color-<mineral>-light`/`-dark` that has **never existed** in `app/globals.css`; all 26 of those references silently render their fallback. Full per-hex analysis, including the swapped comments and mismatched fallback in `nyuchi-create-listing`, is in **#288**.
- **Wiring `lint:colors` into CI.** It belongs in the existing **Lint** job in `ci.yml` and is the reason this went unnoticed — but adding it now would land a red required check. It is the last step, once #288 is settled. The exact patch is in that issue.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Component addition
- [ ] Block addition
- [ ] Portal page
- [ ] Brand/design system update
- [ ] Documentation
- [ ] CI/infrastructure
- [ ] Security / dependency update

## Pre-commit Gate (must pass locally before pushing)

- [x] `pnpm lint` — zero warnings
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm test` — 251 tests across 28 files pass
- [ ] `pnpm audit --audit-level=moderate` — not run (no dependency change)
- [x] `pnpm exec prettier --check` — all files formatted

`pnpm lint:colors` — **red, 9 violations, intentionally.** See above and #288.

## Quality Checklist

- [ ] New tests added for new functionality — none; there is no test harness for `scripts/*` and this PR does not add one. Behaviour was verified against a throwaway probe covering a bare hex, a `var()` with an unrelated earlier `)`, a nested `var()`, and a hex following a closed `calc()`: the first and last are caught, the middle two are not.
- [ ] All packages at latest — untouched
- [x] No hardcoded colors — no colour value added, changed, or removed anywhere
- [x] Brand wordmarks are lowercase
- [ ] Accessibility — no rendered output changed
- [ ] Ubuntu design checklist — no rendered output changed
- [ ] AI output safety — not touched

## Registry / Design System

- [x] No component source changed, so the registry payload is byte-identical. `pnpm registry:validate` and `pnpm registry:verify` both run clean regardless (575 items canonical).
- [ ] Supabase rows — not applicable
- [ ] `registry.json` — not applicable

## Architecture / Docs

- [ ] `CLAUDE.md` — **there is no `CLAUDE.md` in this repository**, though `ci.yml` cites "§14" and `app/manifest.ts` / `app/globals.css` cite "§7.4". Noted in #288. The in-repo statements of the N1 rule cited by this change are `docs/pulling-in-primitives.md` §3 and `content/doctrine/documentation-architecture-nodes/design-tokens.mdx`.
- [ ] `CHANGELOG.md` — not updated; no user-visible change
- [ ] `openapi.yaml` — no API surface change
- [ ] Version bump — not a release

## Screenshots

None — nothing rendered changes. The observable difference is the lint's own output:

```
before:  ✗ hardcoded palette colours found (139)
after:   ✗ hardcoded palette colours found (9)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED


---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPxAPY7KvsN9WLbdLSQED)_